### PR TITLE
manifest: add kubelet's resource endpoint

### DIFF
--- a/manifests/prometheus-serviceMonitorKubelet.yaml
+++ b/manifests/prometheus-serviceMonitorKubelet.yaml
@@ -18,6 +18,19 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
+ - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    honorLabels: true
+    interval: 30s
+    metricRelabelings:
+    - action: drop
+      regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+      sourceLabels:
+      - __name__
+    path: /metrics/resource/v1alpha1
+    port: https-metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     honorLabels: true
     interval: 30s


### PR DESCRIPTION
If you want to grab metrics for runtime's that use CRI based stats, /metrics/resource/v1alpha1 from Kubelet is helpful (ie, CAdvisor can't grab all of the stats).

This endpoint also provides pod-level statistics as well, which is useful for assessing overheads associated with running a sandbox. 

Signed-off-by: Eric Ernst <eric.ernst@intel.com>