### PR TITLE
Added podMonitor for kube-proxy

### DIFF
--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -488,7 +488,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           podMetricsEndpoints: [
             {
               honorLabels: true,
-              port: "metrics"
+              targetPort: 10249
             }
           ]
         }

--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -462,5 +462,36 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           ],
         },
       },
+    podMonitorKubeProxy:
+      {
+        apiVersion: "monitoring.coreos.com/v1",
+        kind: "PodMonitor",
+        metadata: {
+          labels: {
+            "k8s-app": "kube-proxy"
+          },
+          name: "kube-proxy",
+          namespace: "monitoring"
+        },
+        spec: {
+          jobLabel: "k8s-app",
+          namespaceSelector: {
+            matchNames: [
+              "kube-system"
+            ]
+          },
+          selector: {
+            matchLabels: {
+              "k8s-app": "kube-proxy"
+            }
+          },
+          podMetricsEndpoints: [
+            {
+              honorLabels: true,
+              port: "metrics"
+            }
+          ]
+        }
+      },
   },
 }

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -39,6 +39,7 @@ resources:
 - ./manifests/prometheus-clusterRole.yaml
 - ./manifests/prometheus-clusterRoleBinding.yaml
 - ./manifests/prometheus-operator-serviceMonitor.yaml
+- ./manifests/prometheus-podMonitorKubeProxy.yaml
 - ./manifests/prometheus-prometheus.yaml
 - ./manifests/prometheus-roleBindingConfig.yaml
 - ./manifests/prometheus-roleBindingSpecificNamespaces.yaml

--- a/manifests/prometheus-podMonitorKubeProxy.yaml
+++ b/manifests/prometheus-podMonitorKubeProxy.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    k8s-app: kube-proxy
+  name: kube-proxy
+  namespace: monitoring
+spec:
+  jobLabel: k8s-app
+  namespaceSelector:
+    matchNames:
+    - kube-system
+  podMetricsEndpoints:
+  - honorLabels: true
+    targetPort: 10249
+  selector:
+    matchLabels:
+      k8s-app: kube-proxy


### PR DESCRIPTION
**Why have I added the kube-proxy pod monitor inside jsonnet/kube-prometheus/prometheus/prometheus.libsonnet?**
CoreDNS and kube-proxy are addons that are installed by default when kubeadm is used to bootstrap a cluster. I've added pod monitor for kube-proxy in prometheus.jsonnet since the service monitor object for CoreDNS was present in prometheus.jsonnet. AFAIK since kube-proxy is installed by default, it would be ok for the pod monitor also to be present by default when someone uses kube-prometheus.

**Couple of caveats that I wanted to discuss before I added documentation:**
1. Metrics bind address needs to be set to 0.0.0.0:10249. kube-proxy configmap can be updated and the kube-proxy daemonset can be restarted for existing clusters. [KubeProxyConfiguration](https://pkg.go.dev/k8s.io/kubernetes/pkg/proxy/apis/config?tab=doc#KubeProxyConfiguration) can be used in kubeadm config file to set the value of MetricsBindAddress to 0.0.0.0:10249
2. ~~Another problem is that, I've set targetPort in the pod monitor spec. But targetPort is deprecated as per the [prometheus operator docs](https://github.com/coreos/prometheus-operator/blob/327f2666938eddfa5ab0adb15119edb8e1664d63/Documentation/api.md#podmetricsendpoint) and port field is advised to be used. But we can't use port since the [kube-proxy daemonset manifest](https://github.com/kubernetes/kubernetes/blob/cab89c7d08a5a9ae4091a1aaaa9b9c0ab0f307da/cmd/kubeadm/app/phases/addons/proxy/manifests.go#L54) doesn't have a named port in the pod spec. If we still need to use port instead of targetPort, then we might have to add it as a step in documentation to edit the kube-proxy daemonset and add the named port manually.~~
**Update**: Setting targetPort in `PodMonitor` doesn't fix the service discovery. Port has to be added to the kube-proxy manifest for service discovery to work. Refer to this [comment](#issuecomment-622584604).

Fixes #321 
There is already another PR #464 that does the same task via service monitor.