### PR TITLE
Fix libsonnet file for kube-state-metrics image

### DIFF
--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -1,7 +1,7 @@
 {
   _config+:: {
     versions+:: {
-      kubeStateMetrics: '1.9.5',
+      kubeStateMetrics: 'v1.9.5',
     },
     imageRepos+:: {
       kubeStateMetrics: 'quay.io/coreos/kube-state-metrics',
@@ -17,7 +17,7 @@
                         name:: 'kube-state-metrics',
                         namespace:: $._config.namespace,
                         version:: $._config.versions.kubeStateMetrics,
-                        image:: $._config.imageRepos.kubeStateMetrics + ':v' + $._config.versions.kubeStateMetrics,
+                        image:: $._config.imageRepos.kubeStateMetrics + ':' + $._config.versions.kubeStateMetrics,
                         service+: {
                           spec+: {
                             ports: [

--- a/manifests/kube-state-metrics-clusterRole.yaml
+++ b/manifests/kube-state-metrics-clusterRole.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.5
+    app.kubernetes.io/version: v1.9.5
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/manifests/kube-state-metrics-clusterRoleBinding.yaml
+++ b/manifests/kube-state-metrics-clusterRoleBinding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.5
+    app.kubernetes.io/version: v1.9.5
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/kube-state-metrics-deployment.yaml
+++ b/manifests/kube-state-metrics-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.5
+    app.kubernetes.io/version: v1.9.5
   name: kube-state-metrics
   namespace: monitoring
 spec:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 1.9.5
+        app.kubernetes.io/version: v1.9.5
     spec:
       containers:
       - args:

--- a/manifests/kube-state-metrics-service.yaml
+++ b/manifests/kube-state-metrics-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.5
+    app.kubernetes.io/version: v1.9.5
   name: kube-state-metrics
   namespace: monitoring
 spec:

--- a/manifests/kube-state-metrics-serviceAccount.yaml
+++ b/manifests/kube-state-metrics-serviceAccount.yaml
@@ -3,6 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.5
+    app.kubernetes.io/version: v1.9.5
   name: kube-state-metrics
   namespace: monitoring

--- a/manifests/kube-state-metrics-serviceMonitor.yaml
+++ b/manifests/kube-state-metrics-serviceMonitor.yaml
@@ -3,7 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.5
+    app.kubernetes.io/version: v1.9.5
   name: kube-state-metrics
   namespace: monitoring
 spec:


### PR DESCRIPTION
Running Jsonnet command to fetch images for the [internal repository](https://github.com/coreos/kube-prometheus#internal-registry), fails for kube-state-metrics image tag, this PR fix the libsonnet resource to be in sync with [prometheus libsonnet](https://github.com/coreos/kube-prometheus/blob/master/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet#L181) and [`node-exporter`](https://github.com/coreos/kube-prometheus/blob/master/manifests/node-exporter-daemonset.yaml#L6)

Before:
docker pull quay.io/coreos/kube-state-metrics:1.9.5 <- This fails as invalid tag

After:
docker pull quay.io/coreos/kube-state-metrics:v1.9.5 <- Successful