### PR TITLE
Wait for CRDs to be created

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Though for a quickstart a compiled version of the Kubernetes [manifests](manifes
 ```shell
 # Create the namespace and CRDs, and then wait for them to be availble before creating the remaining resources
 kubectl create -f manifests/setup
-until kubectl get servicemonitors --all-namespaces ; do date; sleep 1; echo ""; done
+until kubectl get crd alertmanagers.monitoring.coreos.com podmonitors.monitoring.coreos.com prometheuses.monitoring.coreos.com prometheusrules.monitoring.coreos.com servicemonitors.monitoring.coreos.com thanosrulers.monitoring.coreos.com ; do date; sleep 1; echo ""; done
 kubectl create -f manifests/
 ```
 


### PR DESCRIPTION
Command now waits for all CRDs to exist before trying to use them. See #640

This isn't the best solution because if a new CRD is added then these docs will break again until updated. 

You can test it works by adding a CRD that doesn't exist which will cause it to exit with `1`

```
until kubectl get crd THIS_DOESNT_EXIST.monitoring.coreos.com alertmanagers.monitoring.coreos.com podmonitors.monitoring.coreos.com prometheuses.monitoring.coreos.com prometheusrules.monitoring.coreos.com servicemonitors.monitoring.coreos.com thanosrulers.monitoring.coreos.com ; do date; sleep 1; echo ""; done
```