### PR TITLE
Fix probe with ingress 650

### DIFF
--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -145,12 +145,18 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
                          'pods',
                        ]) +
                        policyRule.withVerbs(['get', 'list', 'watch']);
+      local ingressRule = policyRule.new() +
+                          policyRule.withApiGroups(['extensions']) +
+                          policyRule.withResources([
+                            'ingresses',
+                          ]) +
+                          policyRule.withVerbs(['get', 'list', 'watch']);
 
       local newSpecificRole(namespace) =
         role.new() +
         role.mixin.metadata.withName('prometheus-' + p.name) +
         role.mixin.metadata.withNamespace(namespace) +
-        role.withRules(coreRule);
+        role.withRules([coreRule, ingressRule]);
 
       local roleList = k3.rbac.v1.roleList;
       roleList.new([newSpecificRole(x) for x in p.roleBindingNamespaces]),

--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -182,8 +182,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           serviceAccountName: 'prometheus-' + p.name,
           serviceMonitorSelector: {},
           podMonitorSelector: {},
+          probeSelector: {},
           serviceMonitorNamespaceSelector: {},
           podMonitorNamespaceSelector: {},
+          probeNamespaceSelector: {},
           nodeSelector: { 'kubernetes.io/os': 'linux' },
           ruleSelector: selector.withMatchLabels({
             role: 'alert-rules',

--- a/manifests/prometheus-prometheus.yaml
+++ b/manifests/prometheus-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
     kubernetes.io/os: linux
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
+  probeNamespaceSelector: {}
+  probeSelector: {}
   replicas: 2
   resources:
     requests:

--- a/manifests/prometheus-roleSpecificNamespaces.yaml
+++ b/manifests/prometheus-roleSpecificNamespaces.yaml
@@ -16,6 +16,14 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - ingresses
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
@@ -32,6 +40,14 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - ingresses
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
@@ -44,6 +60,14 @@ items:
     - services
     - endpoints
     - pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - ingresses
     verbs:
     - get
     - list


### PR DESCRIPTION
This PR implements the workarounds that I reported in #650 to get my `Probe` working.

2 commits :
 - the first one to apply the workaround from https://github.com/prometheus-operator/kube-prometheus/issues/644#issuecomment-673941152
 - the second one to allow prometheus to get/list/watch extensions.ingress objects