### PR TITLE
Support utf8 in external file alertmanager config

### DIFF
--- a/examples/alertmanager-config.yaml
+++ b/examples/alertmanager-config.yaml
@@ -1,6 +1,7 @@
 # external alertmanager yaml
 global:
   resolve_timeout: 10m
+  slack_api_url: url
 route:
   group_by: ['job']
   group_wait: 30s
@@ -13,3 +14,17 @@ route:
     receiver: 'null'
 receivers:
 - name: 'null'
+- name: slack
+slack_configs:
+- channel: '#alertmanager-testing'
+  send_resolved: true
+  title: '[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] Monitoring Event Notification'
+  text: |-
+    {{ range .Alerts }}
+      *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`
+      *Description:* {{ .Annotations.description }}
+      *Graph:* <{{ .GeneratorURL }}|:chart_with_upwards_trend:> *Runbook:* <{{ .Annotations.runbook }}|:spiral_note_pad:>
+      *Details:*
+      {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
+      {{ end }}
+    {{ end }}

--- a/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
@@ -81,7 +81,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         .withStringData({ 'alertmanager.yaml': std.manifestYamlDoc($._config.alertmanager.config) }) +
         secret.mixin.metadata.withNamespace($._config.namespace)
       else
-        secret.new('alertmanager-' + $._config.alertmanager.name, { 'alertmanager.yaml': std.base64($._config.alertmanager.config) }) +
+        secret.new('alertmanager-' + $._config.alertmanager.name, {})
+        .withStringData({ 'alertmanager.yaml': $._config.alertmanager.config }) +
         secret.mixin.metadata.withNamespace($._config.namespace),
 
     serviceAccount:


### PR DESCRIPTION
This could have been achieved either by switching to `stringData`, or doing `std.base64(std.encodeUTF8($._config.alertmanager.config))` as per google/jsonnet#575

I went with the former, because it's:
1. Easier to read existing config
2. Consistent with the way jsonnet object-based config is written (just above in the modified file)

Let me know if you prefer the other way.

The modified test fails with
```
RUNTIME ERROR: base64 encountered invalid codepoint value in the array (must be 0 <= X <= 255), got 8226
	vendor/kube-prometheus/alertmanager/alertmanager.libsonnet:84:90-131	builtin function <base64>
	During manifestation	
```
without the change. The character is `•` in ``{{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}` ``.

Fixes #363