### PR TITLE
Backport: node-exporter: set maxUnavailable to 10%

### DIFF
--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -137,6 +137,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       daemonset.mixin.metadata.withNamespace($._config.namespace) +
       daemonset.mixin.metadata.withLabels(podLabels) +
       daemonset.mixin.spec.selector.withMatchLabels(selectorLabels) +
+      daemonset.mixin.spec.updateStrategy.rollingUpdate.withMaxUnavailable('10%') +
       daemonset.mixin.spec.template.metadata.withLabels(podLabels) +
       daemonset.mixin.spec.template.spec.withTolerations([existsToleration]) +
       daemonset.mixin.spec.template.spec.withNodeSelector({ 'kubernetes.io/os': 'linux' }) +

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -88,3 +88,6 @@ spec:
       - hostPath:
           path: /
         name: root
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 10%


### PR DESCRIPTION
This daemonset doesn't affect workload availability so allow its rollout to
be parallelized.

/cc @sdodson @prometheus-operator/kube-prometheus-reviewers 