### PR TITLE
Bump to kubernetes 1.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This adapter is an Extension API Server and Kubernetes needs to be have this fea
 To try out this stack, start [minikube](https://github.com/kubernetes/minikube) with the following command:
 
 ```shell
-$ minikube delete && minikube start --kubernetes-version=v1.18.1 --memory=6g --bootstrapper=kubeadm --extra-config=kubelet.authentication-token-webhook=true --extra-config=kubelet.authorization-mode=Webhook --extra-config=scheduler.address=0.0.0.0 --extra-config=controller-manager.address=0.0.0.0
+$ minikube delete && minikube start --kubernetes-version=v1.19.0 --memory=6g --bootstrapper=kubeadm --extra-config=kubelet.authentication-token-webhook=true --extra-config=kubelet.authorization-mode=Webhook --extra-config=scheduler.address=0.0.0.0 --extra-config=controller-manager.address=0.0.0.0
 ```
 
 The kube-prometheus stack includes a resource metrics API server, so the metrics-server addon is not necessary. Ensure the metrics-server addon is disabled on minikube:
@@ -97,13 +97,13 @@ The following versions are supported and work as we test against these versions 
 | `release-0.4`         | ✗               | ✗               | ✔ (v1.16.5+)    | ✔               | ✗               | ✗               |
 | `release-0.5`         | ✗               | ✗               | ✗               | ✗               | ✔               | ✗               |
 | `release-0.6`         | ✗               | ✗               | ✗               | ✗               | ✔               | ✗               |
-| `HEAD`                | ✗               | ✗               | ✗               | ✗               | ✔               | ✗               |
+| `HEAD`                | ✗               | ✗               | ✗               | ✗               | x               | ✔               |
 
 Note: Due to [two](https://github.com/kubernetes/kubernetes/issues/83778) [bugs](https://github.com/kubernetes/kubernetes/issues/86359) in Kubernetes v1.16.1, and prior to Kubernetes v1.16.5 the kube-prometheus release-0.4 branch only supports v1.16.5 and higher.  The `extension-apiserver-authentication-reader` role in the kube-system namespace can be manually edited to include list and watch permissions in order to workaround the second issue with Kubernetes v1.16.2 through v1.16.4.
 
 ## Quickstart
 
->Note: For versions before Kubernetes v1.18.z refer to the [Kubernetes compatibility matrix](#kubernetes-compatibility-matrix) in order to choose a compatible branch.
+>Note: For versions before Kubernetes v1.19.z refer to the [Kubernetes compatibility matrix](#kubernetes-compatibility-matrix) in order to choose a compatible branch.
 
 This project is intended to be used as a library (i.e. the intent is not for you to create your own modified copy of this repository).
 

--- a/tests/e2e/travis-e2e.sh
+++ b/tests/e2e/travis-e2e.sh
@@ -13,7 +13,7 @@ chmod +x kubectl
 curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64
 chmod +x kind
 
-./kind create cluster --image=kindest/node:v1.18.0
+./kind create cluster --image=kindest/node:v1.19.0
 # the default kube config location used by kind
 export KUBECONFIG="${HOME}/.kube/config"
 


### PR DESCRIPTION
We always just leave the latest version to be tested if I remember correctly.

@prometheus-operator/kube-prometheus-reviewers 