### PR TITLE
Test against 1.18 and 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The following versions are supported and work as we test against these versions 
 | `release-0.3`         | ✔               | ✔               | ✔               | ✔               | ✗               | ✗               |
 | `release-0.4`         | ✗               | ✗               | ✔ (v1.16.5+)    | ✔               | ✗               | ✗               |
 | `release-0.5`         | ✗               | ✗               | ✗               | ✗               | ✔               | ✗               |
-| `release-0.6`         | ✗               | ✗               | ✗               | ✗               | ✔               | ✗               |
+| `release-0.6`         | ✗               | ✗               | ✗               | ✗               | ✔               | ✔               |
 | `HEAD`                | ✗               | ✗               | ✗               | ✗               | ✔               | ✗               |
 
 Note: Due to [two](https://github.com/kubernetes/kubernetes/issues/83778) [bugs](https://github.com/kubernetes/kubernetes/issues/86359) in Kubernetes v1.16.1, and prior to Kubernetes v1.16.5 the kube-prometheus release-0.4 branch only supports v1.16.5 and higher.  The `extension-apiserver-authentication-reader` role in the kube-system namespace can be manually edited to include list and watch permissions in order to workaround the second issue with Kubernetes v1.16.2 through v1.16.4.

--- a/tests/e2e/travis-e2e.sh
+++ b/tests/e2e/travis-e2e.sh
@@ -13,17 +13,30 @@ chmod +x kubectl
 curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64
 chmod +x kind
 
-./kind create cluster --image=kindest/node:v1.18.0
-# the default kube config location used by kind
-export KUBECONFIG="${HOME}/.kube/config"
+run_e2e_tests() {
+    cluster_version=$1
 
-# create namespace, permissions, and CRDs
-./kubectl create -f manifests/setup
+    ./kind create cluster --image=kindest/node:$cluster_version
+    # the default kube config location used by kind
+    export KUBECONFIG="${HOME}/.kube/config"
+    
+    # create namespace, permissions, and CRDs
+    ./kubectl create -f manifests/setup
 
-# wait for CRD creation to complete
-until ./kubectl get servicemonitors --all-namespaces ; do date; sleep 1; echo ""; done
+    # wait for CRD creation to complete
+    until ./kubectl get servicemonitors --all-namespaces ; do date; sleep 1; echo ""; done
 
-# create monitoring components
-./kubectl create -f manifests/
+    # create monitoring components
+    ./kubectl create -f manifests/
 
-make test-e2e
+    make test-e2e
+
+    ./kind delete cluster
+}
+
+cluster_compatible_versions=("v1.18.8" "v1.19.0")
+
+for cluster_version in "${cluster_compatible_versions[@]}"
+do
+    run_e2e_tests $cluster_version
+done


### PR DESCRIPTION
We should be testing against 1.18 and 1.19, with 1.18 being dropped for testing in master. 
cc @prometheus-operator/kube-prometheus-reviewers 