### PR TITLE
Update node-exporter dependency to be aligned with mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ These are the available fields with their respective default values:
 
     versions+:: {
         alertmanager: "v0.17.0",
-        nodeExporter: "v0.18.1",
+        nodeExporter: "v1.0.1",
         kubeStateMetrics: "v1.5.0",
         kubeRbacProxy: "v0.4.1",
         prometheusOperator: "v0.30.0",

--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -5,7 +5,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
     namespace: 'default',
 
     versions+:: {
-      nodeExporter: 'v0.18.1',
+      nodeExporter: 'v1.0.1',
       kubeRbacProxy: 'v0.4.1',
     },
 

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -3,7 +3,7 @@ kind: DaemonSet
 metadata:
   labels:
     app.kubernetes.io/name: node-exporter
-    app.kubernetes.io/version: v0.18.1
+    app.kubernetes.io/version: v1.0.1
   name: node-exporter
   namespace: monitoring
 spec:
@@ -14,7 +14,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: node-exporter
-        app.kubernetes.io/version: v0.18.1
+        app.kubernetes.io/version: v1.0.1
     spec:
       containers:
       - args:
@@ -25,7 +25,7 @@ spec:
         - --no-collector.wifi
         - --no-collector.hwmon
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
-        image: quay.io/prometheus/node-exporter:v0.18.1
+        image: quay.io/prometheus/node-exporter:v1.0.1
         name: node-exporter
         resources:
           limits:

--- a/manifests/node-exporter-service.yaml
+++ b/manifests/node-exporter-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: node-exporter
-    app.kubernetes.io/version: v0.18.1
+    app.kubernetes.io/version: v1.0.1
   name: node-exporter
   namespace: monitoring
 spec:

--- a/manifests/node-exporter-serviceMonitor.yaml
+++ b/manifests/node-exporter-serviceMonitor.yaml
@@ -3,7 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: node-exporter
-    app.kubernetes.io/version: v0.18.1
+    app.kubernetes.io/version: v1.0.1
   name: node-exporter
   namespace: monitoring
 spec:


### PR DESCRIPTION
Related issue : https://github.com/prometheus-operator/kube-prometheus/issues/666#issuecomment-689430046

Summary : 

kube-prometheus jsonnet dependency for node-mixins is [set to master](https://github.com/prometheus-operator/kube-prometheus/blob/release-0.4/jsonnet/kube-prometheus/jsonnetfile.json#L64-L71) whereas node-exporter version is [set to 1.18.1](https://github.com/prometheus-operator/kube-prometheus/blob/release-0.4/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet#L8)

So it can lead to some inconsistency when new alerts have been added in node-mixins but the corresponding metrics are missing in the 1.18.1 node-exporter release

Sorry but I am not quite sure what branch I must make this PR to...  I am using the release-0.4 release because of my k8s version but this PR aims to fix also other releases (master, etc.)
What is the process here please ?