### PR TITLE
Fixing issues with kube-rbac-proxy when importing kube-prometheus as a library

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -1,6 +1,7 @@
 local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local k3 = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.3/k.libsonnet';
 local configMapList = k3.core.v1.configMapList;
+local kubeRbacProxyContainer = import './kube-rbac-proxy/container.libsonnet';
 
 (import 'github.com/brancz/kubernetes-grafana/grafana/grafana.libsonnet') +
 (import './kube-state-metrics/kube-state-metrics.libsonnet') +
@@ -60,7 +61,7 @@ local configMapList = k3.core.v1.configMapList;
       ],
     },
   } +
-  ((import 'kube-prometheus/kube-rbac-proxy/container.libsonnet') {
+  (kubeRbacProxyContainer {
     config+:: {
       kubeRbacProxy: {
         local cfg = self,

--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -1,3 +1,6 @@
+local kubeRbacProxyContainer = import '../kube-rbac-proxy/container.libsonnet';
+local ksm = import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet';
+
 {
   _config+:: {
     versions+:: {
@@ -11,9 +14,9 @@
       scrapeTimeout: '30s',
     },
   },
-  kubeStateMetrics+:: (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-state-metrics/kube-state-metrics.libsonnet') +
-                      {
-                        local ksm = self,
+  kubeStateMetrics+::
+    ksm + {
+                        local version = self.version,
                         name:: 'kube-state-metrics',
                         namespace:: $._config.namespace,
                         version:: $._config.versions.kubeStateMetrics,
@@ -57,7 +60,7 @@
                               namespace: $._config.namespace,
                               labels: {
                                 'app.kubernetes.io/name': 'kube-state-metrics',
-                                'app.kubernetes.io/version': ksm.version,
+                                'app.kubernetes.io/version': version,
                               },
                             },
                             spec: {
@@ -98,7 +101,7 @@
                             },
                           },
                       } +
-                      ((import 'kube-prometheus/kube-rbac-proxy/container.libsonnet') {
+                      (kubeRbacProxyContainer {
                          config+:: {
                            kubeRbacProxy: {
                              local cfg = self,
@@ -112,7 +115,7 @@
                            },
                          },
                        }).deploymentMixin +
-                      ((import 'kube-prometheus/kube-rbac-proxy/container.libsonnet') {
+                      (kubeRbacProxyContainer {
                          config+:: {
                            kubeRbacProxy: {
                              local cfg = self,

--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -16,117 +16,117 @@ local ksm = import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-state-
   },
   kubeStateMetrics+::
     ksm + {
-                        local version = self.version,
-                        name:: 'kube-state-metrics',
-                        namespace:: $._config.namespace,
-                        version:: $._config.versions.kubeStateMetrics,
-                        image:: $._config.imageRepos.kubeStateMetrics + ':v' + $._config.versions.kubeStateMetrics,
-                        service+: {
-                          spec+: {
-                            ports: [
-                              {
-                                name: 'https-main',
-                                port: 8443,
-                                targetPort: 'https-main',
-                              },
-                              {
-                                name: 'https-self',
-                                port: 9443,
-                                targetPort: 'https-self',
-                              },
-                            ],
-                          },
-                        },
-                        deployment+: {
-                          spec+: {
-                            template+: {
-                              spec+: {
-                                containers: std.map(function(c) c {
-                                  ports:: null,
-                                  livenessProbe:: null,
-                                  readinessProbe:: null,
-                                  args: ['--host=127.0.0.1', '--port=8081', '--telemetry-host=127.0.0.1', '--telemetry-port=8082'],
-                                }, super.containers),
-                              },
-                            },
-                          },
-                        },
-                        serviceMonitor:
-                          {
-                            apiVersion: 'monitoring.coreos.com/v1',
-                            kind: 'ServiceMonitor',
-                            metadata: {
-                              name: 'kube-state-metrics',
-                              namespace: $._config.namespace,
-                              labels: {
-                                'app.kubernetes.io/name': 'kube-state-metrics',
-                                'app.kubernetes.io/version': version,
-                              },
-                            },
-                            spec: {
-                              jobLabel: 'app.kubernetes.io/name',
-                              selector: {
-                                matchLabels: {
-                                  'app.kubernetes.io/name': 'kube-state-metrics',
-                                },
-                              },
-                              endpoints: [
-                                {
-                                  port: 'https-main',
-                                  scheme: 'https',
-                                  interval: $._config.kubeStateMetrics.scrapeInterval,
-                                  scrapeTimeout: $._config.kubeStateMetrics.scrapeTimeout,
-                                  honorLabels: true,
-                                  bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
-                                  relabelings: [
-                                    {
-                                      regex: '(pod|service|endpoint|namespace)',
-                                      action: 'labeldrop',
-                                    },
-                                  ],
-                                  tlsConfig: {
-                                    insecureSkipVerify: true,
-                                  },
-                                },
-                                {
-                                  port: 'https-self',
-                                  scheme: 'https',
-                                  interval: $._config.kubeStateMetrics.scrapeInterval,
-                                  bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
-                                  tlsConfig: {
-                                    insecureSkipVerify: true,
-                                  },
-                                },
-                              ],
-                            },
-                          },
-                      } +
-                      (kubeRbacProxyContainer {
-                         config+:: {
-                           kubeRbacProxy: {
-                             local cfg = self,
-                             image: $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy,
-                             name: 'kube-rbac-proxy-main',
-                             securePortName: 'https-main',
-                             securePort: 8443,
-                             secureListenAddress: ':%d' % self.securePort,
-                             upstream: 'http://127.0.0.1:8081/',
-                             tlsCipherSuites: $._config.tlsCipherSuites,
-                           },
-                         },
-                       }).deploymentMixin +
-                      (kubeRbacProxyContainer {
-                         config+:: {
-                           kubeRbacProxy: {
-                             local cfg = self,
-                             image: $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy,
-                             name: 'kube-rbac-proxy-self',
-                             securePortName: 'https-self',
-                             securePort: 9443,
-                             secureListenAddress: ':%d' % self.securePort,
-                             upstream: 'http://127.0.0.1:8082/',
-                             tlsCipherSuites: $._config.tlsCipherSuites,
-                           },
-                         },
-                       }).deploymentMixin,
+      local version = self.version,
+      name:: 'kube-state-metrics',
+      namespace:: $._config.namespace,
+      version:: $._config.versions.kubeStateMetrics,
+      image:: $._config.imageRepos.kubeStateMetrics + ':v' + $._config.versions.kubeStateMetrics,
+      service+: {
+        spec+: {
+          ports: [
+            {
+              name: 'https-main',
+              port: 8443,
+              targetPort: 'https-main',
+            },
+            {
+              name: 'https-self',
+              port: 9443,
+              targetPort: 'https-self',
+            },
+          ],
+        },
+      },
+      deployment+: {
+        spec+: {
+          template+: {
+            spec+: {
+              containers: std.map(function(c) c {
+                ports:: null,
+                livenessProbe:: null,
+                readinessProbe:: null,
+                args: ['--host=127.0.0.1', '--port=8081', '--telemetry-host=127.0.0.1', '--telemetry-port=8082'],
+              }, super.containers),
+            },
+          },
+        },
+      },
+      serviceMonitor:
+        {
+          apiVersion: 'monitoring.coreos.com/v1',
+          kind: 'ServiceMonitor',
+          metadata: {
+            name: 'kube-state-metrics',
+            namespace: $._config.namespace,
+            labels: {
+              'app.kubernetes.io/name': 'kube-state-metrics',
+              'app.kubernetes.io/version': version,
+            },
+          },
+          spec: {
+            jobLabel: 'app.kubernetes.io/name',
+            selector: {
+              matchLabels: {
+                'app.kubernetes.io/name': 'kube-state-metrics',
+              },
+            },
+            endpoints: [
+              {
+                port: 'https-main',
+                scheme: 'https',
+                interval: $._config.kubeStateMetrics.scrapeInterval,
+                scrapeTimeout: $._config.kubeStateMetrics.scrapeTimeout,
+                honorLabels: true,
+                bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+                relabelings: [
+                  {
+                    regex: '(pod|service|endpoint|namespace)',
+                    action: 'labeldrop',
+                  },
+                ],
+                tlsConfig: {
+                  insecureSkipVerify: true,
+                },
+              },
+              {
+                port: 'https-self',
+                scheme: 'https',
+                interval: $._config.kubeStateMetrics.scrapeInterval,
+                bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+                tlsConfig: {
+                  insecureSkipVerify: true,
+                },
+              },
+            ],
+          },
+        },
+      } +
+      (kubeRbacProxyContainer {
+        config+:: {
+          kubeRbacProxy: {
+            local cfg = self,
+            image: $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy,
+            name: 'kube-rbac-proxy-main',
+            securePortName: 'https-main',
+            securePort: 8443,
+            secureListenAddress: ':%d' % self.securePort,
+            upstream: 'http://127.0.0.1:8081/',
+            tlsCipherSuites: $._config.tlsCipherSuites,
+          },
+        },
+      }).deploymentMixin +
+      (kubeRbacProxyContainer {
+        config+:: {
+          kubeRbacProxy: {
+            local cfg = self,
+            image: $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy,
+            name: 'kube-rbac-proxy-self',
+            securePortName: 'https-self',
+            securePort: 9443,
+            secureListenAddress: ':%d' % self.securePort,
+            upstream: 'http://127.0.0.1:8082/',
+            tlsCipherSuites: $._config.tlsCipherSuites,
+          },
+        },
+      }).deploymentMixin,
 }


### PR DESCRIPTION
- removing usage of use relative jb import paths for kube-rbac-proxy
- moving imports to the top of the file so this will be easier to catch in the future

This is a follow-up to #675 

/cc @prometheus-operator/kube-prometheus-reviewers 