### PR TITLE
ignore timestamps from cadvisor metrics

### DIFF
--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -312,6 +312,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
               path: '/metrics/cadvisor',
               interval: '30s',
               honorLabels: true,
+              honorTimestamps: false,
               tlsConfig: {
                 insecureSkipVerify: true,
               },

--- a/manifests/prometheus-serviceMonitorKubelet.yaml
+++ b/manifests/prometheus-serviceMonitorKubelet.yaml
@@ -53,6 +53,7 @@ spec:
       insecureSkipVerify: true
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     honorLabels: true
+    honorTimestamps: false
     interval: 30s
     metricRelabelings:
     - action: drop


### PR DESCRIPTION
Over a year ago cAdvisor v0.33.0 started to include timestamps in their metrics. This change was included in k8s 1.18 and kubelet started to do the same on `/metrics/cadvisor` endpoint. This can lead to stale data being ingested as can be observed for example when the container is OOMKilled (as in the image below).

![image](https://user-images.githubusercontent.com/3531758/94785800-7242e680-03d0-11eb-9acc-c413c3dfbe87.png)

This issue was observed by one of prometheus users and reported on prometheus IRC. The proposed fix was to discard timestamps and was later confirmed to be working.

Creating it now, when I have data from prometheus IRC and don't need to reproduce everything.