### PR TITLE
node-exporter: Make host mounts read only and set mount propagation

### DIFF
--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -79,11 +79,15 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
                                toleration.withOperator('Exists');
       local procVolumeName = 'proc';
       local procVolume = volume.fromHostPath(procVolumeName, '/proc');
-      local procVolumeMount = containerVolumeMount.new(procVolumeName, '/host/proc');
+      local procVolumeMount = containerVolumeMount.new(procVolumeName, '/host/proc').
+        withMountPropagation('HostToContainer').
+        withReadOnly(true);
 
       local sysVolumeName = 'sys';
       local sysVolume = volume.fromHostPath(sysVolumeName, '/sys');
-      local sysVolumeMount = containerVolumeMount.new(sysVolumeName, '/host/sys');
+      local sysVolumeMount = containerVolumeMount.new(sysVolumeName, '/host/sys').
+        withMountPropagation('HostToContainer').
+        withReadOnly(true);
 
       local rootVolumeName = 'root';
       local rootVolume = volume.fromHostPath(rootVolumeName, '/');

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -36,11 +36,13 @@ spec:
             memory: 180Mi
         volumeMounts:
         - mountPath: /host/proc
+          mountPropagation: HostToContainer
           name: proc
-          readOnly: false
+          readOnly: true
         - mountPath: /host/sys
+          mountPropagation: HostToContainer
           name: sys
-          readOnly: false
+          readOnly: true
         - mountPath: /host/root
           mountPropagation: HostToContainer
           name: root


### PR DESCRIPTION
These mounts should not be writable, and we only want propagation from host to container, not the other way.

@prometheus-operator/kube-prometheus-reviewers 