### PR TITLE
Vendor lib updates. (was:  Add SD devices to the list of node disks)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ generate: manifests **.md
 manifests: examples/kustomize.jsonnet $(GOJSONTOYAML_BIN) vendor build.sh
 	./build.sh $<
 
+update_libs: $(JB_BIN)
+	$(JB_BIN) update
+
 vendor: $(JB_BIN) jsonnetfile.json jsonnetfile.lock.json
 	rm -rf vendor
 	$(JB_BIN) install

--- a/examples/tolerations.libsonnet
+++ b/examples/tolerations.libsonnet
@@ -15,16 +15,20 @@ local toleration = statefulSet.mixin.spec.template.spec.tolerationsType;
         key: 'key2',
         operator: 'Exists',
       },
-    ]
+    ],
   },
 
   local withTolerations() = {
     tolerations: [
       toleration.new() + (
-      if std.objectHas(t, 'key') then toleration.withKey(t.key) else toleration) + (
-      if std.objectHas(t, 'operator') then toleration.withOperator(t.operator) else toleration) + (
-      if std.objectHas(t, 'value') then toleration.withValue(t.value) else toleration) + (
-      if std.objectHas(t, 'effect') then toleration.withEffect(t.effect) else toleration),
+        if std.objectHas(t, 'key') then toleration.withKey(t.key) else toleration
+      ) + (
+        if std.objectHas(t, 'operator') then toleration.withOperator(t.operator) else toleration
+      ) + (
+        if std.objectHas(t, 'value') then toleration.withValue(t.value) else toleration
+      ) + (
+        if std.objectHas(t, 'effect') then toleration.withEffect(t.effect) else toleration
+      )
       for t in $._config.tolerations
     ],
   },

--- a/jsonnet/kube-prometheus/ksm-autoscaler/ksm-autoscaler.libsonnet
+++ b/jsonnet/kube-prometheus/ksm-autoscaler/ksm-autoscaler.libsonnet
@@ -3,11 +3,11 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 {
   _config+:: {
     versions+:: {
-      clusterVerticalAutoscaler: "v0.8.1"
+      clusterVerticalAutoscaler: 'v0.8.1',
     },
 
     imageRepos+:: {
-      clusterVerticalAutoscaler: 'gcr.io/google_containers/cpvpa-amd64'
+      clusterVerticalAutoscaler: 'gcr.io/google_containers/cpvpa-amd64',
     },
 
     kubeStateMetrics+:: {
@@ -45,7 +45,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 
     roleBinding:
       local roleBinding = k.rbac.v1.roleBinding;
-  
+
       roleBinding.new() +
       roleBinding.mixin.metadata.withName('ksm-autoscaler') +
       roleBinding.mixin.metadata.withNamespace($._config.namespace) +
@@ -57,7 +57,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
     role:
       local role = k.rbac.v1.role;
       local rulesType = role.rulesType;
-  
+
       local extensionsRule = rulesType.new() +
                              rulesType.withApiGroups(['extensions']) +
                              rulesType.withResources([
@@ -65,7 +65,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
                              ]) +
                              rulesType.withVerbs(['patch']) +
                              rulesType.withResourceNames(['kube-state-metrics']);
-  
+
       local appsRule = rulesType.new() +
                        rulesType.withApiGroups(['apps']) +
                        rulesType.withResources([
@@ -73,17 +73,17 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
                        ]) +
                        rulesType.withVerbs(['patch']) +
                        rulesType.withResourceNames(['kube-state-metrics']);
-  
+
       local rules = [extensionsRule, appsRule];
-  
+
       role.new() +
       role.mixin.metadata.withName('ksm-autoscaler') +
       role.mixin.metadata.withNamespace($._config.namespace) +
       role.withRules(rules),
-  
+
     serviceAccount:
       local serviceAccount = k.core.v1.serviceAccount;
-  
+
       serviceAccount.new('ksm-autoscaler') +
       serviceAccount.mixin.metadata.withNamespace($._config.namespace),
     deployment:
@@ -91,7 +91,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
       local container = deployment.mixin.spec.template.spec.containersType;
       local podSelector = deployment.mixin.spec.template.spec.selectorType;
       local podLabels = { app: 'ksm-autoscaler' };
-  
+
       local kubeStateMetricsAutoscaler =
         container.new('ksm-autoscaler', $._config.imageRepos.clusterVerticalAutoscaler + ':' + $._config.versions.clusterVerticalAutoscaler) +
         container.withArgs([
@@ -100,12 +100,12 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
           '--namespace=' + $._config.namespace,
           '--logtostderr=true',
           '--poll-period-seconds=10',
-          '--default-config={"kube-state-metrics":{"requests":{"cpu":{"base":"' + $._config.kubeStateMetrics.baseCPU + '","step":"' + $._config.kubeStateMetrics.stepCPU + '","nodesPerStep":1},"memory":{"base":"' + $._config.kubeStateMetrics.baseMemory + '","step":"' + $._config.kubeStateMetrics.stepMemory + '","nodesPerStep":1}},"limits":{"cpu":{"base":"' + $._config.kubeStateMetrics.baseCPU + '","step":"' + $._config.kubeStateMetrics.stepCPU + '","nodesPerStep":1},"memory":{"base":"' + $._config.kubeStateMetrics.baseMemory + '","step":"' + $._config.kubeStateMetrics.stepMemory + '","nodesPerStep":1}}}}'
+          '--default-config={"kube-state-metrics":{"requests":{"cpu":{"base":"' + $._config.kubeStateMetrics.baseCPU + '","step":"' + $._config.kubeStateMetrics.stepCPU + '","nodesPerStep":1},"memory":{"base":"' + $._config.kubeStateMetrics.baseMemory + '","step":"' + $._config.kubeStateMetrics.stepMemory + '","nodesPerStep":1}},"limits":{"cpu":{"base":"' + $._config.kubeStateMetrics.baseCPU + '","step":"' + $._config.kubeStateMetrics.stepCPU + '","nodesPerStep":1},"memory":{"base":"' + $._config.kubeStateMetrics.baseMemory + '","step":"' + $._config.kubeStateMetrics.stepMemory + '","nodesPerStep":1}}}}',
         ]) +
-        container.mixin.resources.withRequests({cpu: '20m', memory: '10Mi'}); 
-  
+        container.mixin.resources.withRequests({ cpu: '20m', memory: '10Mi' });
+
       local c = [kubeStateMetricsAutoscaler];
-  
+
       deployment.new('ksm-autoscaler', 1, c, podLabels) +
       deployment.mixin.metadata.withNamespace($._config.namespace) +
       deployment.mixin.metadata.withLabels(podLabels) +

--- a/jsonnet/kube-prometheus/kube-prometheus-all-namespaces.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-all-namespaces.libsonnet
@@ -1,20 +1,20 @@
 local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 
 {
-    prometheus+:: {
-        clusterRole+: {
-            rules+: 
-            local role = k.rbac.v1.role;
-            local policyRule = role.rulesType;
-            local rule = policyRule.new() +
-                            policyRule.withApiGroups(['']) +
-                            policyRule.withResources([
-                            'services',
-                            'endpoints',
-                            'pods',
-                            ]) +
-                            policyRule.withVerbs(['get', 'list', 'watch']);
-            [rule]
-      },
-    }
+  prometheus+:: {
+    clusterRole+: {
+      rules+:
+        local role = k.rbac.v1.role;
+        local policyRule = role.rulesType;
+        local rule = policyRule.new() +
+                     policyRule.withApiGroups(['']) +
+                     policyRule.withResources([
+                       'services',
+                       'endpoints',
+                       'pods',
+                     ]) +
+                     policyRule.withVerbs(['get', 'list', 'watch']);
+        [rule],
+    },
+  },
 }

--- a/jsonnet/kube-prometheus/kube-prometheus-config-mixins.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-config-mixins.libsonnet
@@ -9,9 +9,9 @@ local withImageRepository(repository) = {
     if repository == null then image else repository + '/' + l.imageName(image),
   _config+:: {
     imageRepos:: {
-      [field]: substituteRepository(oldRepos[field], repository),
+      [field]: substituteRepository(oldRepos[field], repository)
       for field in std.objectFields(oldRepos)
-    }
+    },
   },
 };
 

--- a/jsonnet/kube-prometheus/kube-prometheus-custom-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-custom-metrics.libsonnet
@@ -15,18 +15,18 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
             resources: {
               overrides: {
                 namespace: {
-                  resource: 'namespace'
+                  resource: 'namespace',
                 },
                 pod: {
-                  resource: 'pod'
-                }
+                  resource: 'pod',
+                },
               },
             },
             name: {
               matches: '^container_(.*)_seconds_total$',
-              as: ""
+              as: '',
             },
-            metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[1m])) by (<<.GroupBy>>)'
+            metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[1m])) by (<<.GroupBy>>)',
           },
           {
             seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}',
@@ -36,18 +36,18 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
             resources: {
               overrides: {
                 namespace: {
-                  resource: 'namespace'
+                  resource: 'namespace',
                 },
                 pod: {
-                  resource: 'pod'
-                }
+                  resource: 'pod',
+                },
               },
             },
             name: {
               matches: '^container_(.*)_total$',
-              as: ''
+              as: '',
             },
-            metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[1m])) by (<<.GroupBy>>)'
+            metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[1m])) by (<<.GroupBy>>)',
           },
           {
             seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}',
@@ -57,18 +57,18 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
             resources: {
               overrides: {
                 namespace: {
-                  resource: 'namespace'
+                  resource: 'namespace',
                 },
                 pod: {
-                  resource: 'pod'
-                }
+                  resource: 'pod',
+                },
               },
             },
             name: {
               matches: '^container_(.*)$',
-              as: ''
+              as: '',
             },
-            metricsQuery: 'sum(<<.Series>>{<<.LabelMatchers>>,container!="POD"}) by (<<.GroupBy>>)'
+            metricsQuery: 'sum(<<.Series>>{<<.LabelMatchers>>,container!="POD"}) by (<<.GroupBy>>)',
           },
           {
             seriesQuery: '{namespace!="",__name__!~"^container_.*"}',
@@ -76,13 +76,13 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
               { isNot: '.*_total$' },
             ],
             resources: {
-              template: '<<.Resource>>'
+              template: '<<.Resource>>',
             },
             name: {
               matches: '',
-              as: ''
+              as: '',
             },
-            metricsQuery: 'sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)'
+            metricsQuery: 'sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)',
           },
           {
             seriesQuery: '{namespace!="",__name__!~"^container_.*"}',
@@ -90,26 +90,26 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
               { isNot: '.*_seconds_total' },
             ],
             resources: {
-              template: '<<.Resource>>'
+              template: '<<.Resource>>',
             },
             name: {
               matches: '^(.*)_total$',
-              as: ''
+              as: '',
             },
-            metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)'
+            metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)',
           },
           {
             seriesQuery: '{namespace!="",__name__!~"^container_.*"}',
             seriesFilters: [],
             resources: {
-              template: '<<.Resource>>'
+              template: '<<.Resource>>',
             },
             name: {
               matches: '^(.*)_seconds_total$',
-              as: ''
+              as: '',
             },
-            metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)'
-          }
+            metricsQuery: 'sum(rate(<<.Series>>{<<.LabelMatchers>>}[1m])) by (<<.GroupBy>>)',
+          },
         ],
       },
     },
@@ -193,5 +193,5 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
         name: 'horizontal-pod-autoscaler',
         namespace: 'kube-system',
       }]),
-  }
+  },
 }

--- a/jsonnet/kube-prometheus/kube-prometheus-eks.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-eks.libsonnet
@@ -6,26 +6,26 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
   _config+:: {
     eks: {
       minimumAvailableIPs: 10,
-      minimumAvailableIPsTime: '10m'
-    }
+      minimumAvailableIPsTime: '10m',
+    },
   },
   prometheus+: {
     serviceMonitorCoreDNS+: {
-        spec+: {
-          endpoints: [
-            {
-              bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
-              interval: "15s",
-              targetPort: 9153
-            }
-          ]
-        },
+      spec+: {
+        endpoints: [
+          {
+            bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+            interval: '15s',
+            targetPort: 9153,
+          },
+        ],
       },
+    },
     AwsEksCniMetricService:
-        service.new('aws-node', { 'k8s-app' : 'aws-node' } , servicePort.newNamed('cni-metrics-port', 61678, 61678)) +
-        service.mixin.metadata.withNamespace('kube-system') +
-        service.mixin.metadata.withLabels({ 'k8s-app': 'aws-node' }) +
-        service.mixin.spec.withClusterIp('None'),
+      service.new('aws-node', { 'k8s-app': 'aws-node' }, servicePort.newNamed('cni-metrics-port', 61678, 61678)) +
+      service.mixin.metadata.withNamespace('kube-system') +
+      service.mixin.metadata.withLabels({ 'k8s-app': 'aws-node' }) +
+      service.mixin.spec.withClusterIp('None'),
     serviceMonitorAwsEksCNI:
       {
         apiVersion: 'monitoring.coreos.com/v1',
@@ -70,10 +70,10 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
               severity: 'critical',
             },
             annotations: {
-              message: 'Instance {{ $labels.instance }} has less than 10 IPs available.'
+              message: 'Instance {{ $labels.instance }} has less than 10 IPs available.',
             },
             'for': $._config.eks.minimumAvailableIPsTime,
-            alert: 'EksAvailableIPs'
+            alert: 'EksAvailableIPs',
           },
         ],
       },

--- a/jsonnet/kube-prometheus/kube-prometheus-insecure-kubelet.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-insecure-kubelet.libsonnet
@@ -12,7 +12,7 @@
               relabelings: [
                 {
                   sourceLabels: ['__metrics_path__'],
-                  targetLabel: 'metrics_path'
+                  targetLabel: 'metrics_path',
                 },
               ],
             },
@@ -26,7 +26,7 @@
               relabelings: [
                 {
                   sourceLabels: ['__metrics_path__'],
-                  targetLabel: 'metrics_path'
+                  targetLabel: 'metrics_path',
                 },
               ],
               metricRelabelings: [

--- a/jsonnet/kube-prometheus/kube-prometheus-kops-coredns.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kops-coredns.libsonnet
@@ -4,7 +4,7 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 
 {
   prometheus+:: {
-      kubeDnsPrometheusDiscoveryService:
+    kubeDnsPrometheusDiscoveryService:
       service.new('kube-dns-prometheus-discovery', { 'k8s-app': 'kube-dns' }, [servicePort.newNamed('metrics', 9153, 9153)]) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-dns' }) +

--- a/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kubespray.libsonnet
@@ -6,12 +6,12 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 
   prometheus+: {
     kubeControllerManagerPrometheusDiscoveryService:
-      service.new('kube-controller-manager-prometheus-discovery', { 'component': 'kube-controller-manager' }, servicePort.newNamed('https-metrics', 10257, 10257)) +
+      service.new('kube-controller-manager-prometheus-discovery', { component: 'kube-controller-manager' }, servicePort.newNamed('https-metrics', 10257, 10257)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-controller-manager' }) +
       service.mixin.spec.withClusterIp('None'),
     kubeSchedulerPrometheusDiscoveryService:
-      service.new('kube-scheduler-prometheus-discovery', { 'component': 'kube-scheduler' }, servicePort.newNamed('https-metrics', 10259, 10259)) +
+      service.new('kube-scheduler-prometheus-discovery', { component: 'kube-scheduler' }, servicePort.newNamed('https-metrics', 10259, 10259)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'kube-scheduler' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
@@ -23,9 +23,9 @@
         template+: {
           spec+: {
             local addArgs(c) =
-                if c.name == 'prometheus-operator'
-                then c + {args+: ['--config-reloader-cpu=0']}
-                else c,
+              if c.name == 'prometheus-operator'
+              then c { args+: ['--config-reloader-cpu=0'] }
+              else c,
             containers: std.map(addArgs, super.containers),
           },
         },

--- a/jsonnet/kube-prometheus/kube-prometheus-thanos-sidecar.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-thanos-sidecar.libsonnet
@@ -33,7 +33,7 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
       service.new('prometheus-' + $._config.prometheus.name + '-thanos-sidecar', { app: 'prometheus', prometheus: $._config.prometheus.name }) +
       service.mixin.spec.withPorts([thanosGrpcSidecarPort, thanosHttpSidecarPort]) +
       service.mixin.spec.withClusterIp('None') +
-      service.mixin.metadata.withLabels({'prometheus': $._config.prometheus.name, 'app': 'thanos-sidecar'}) +
+      service.mixin.metadata.withLabels({ prometheus: $._config.prometheus.name, app: 'thanos-sidecar' }) +
       service.mixin.metadata.withNamespace($._config.namespace),
     prometheus+: {
       spec+: {

--- a/jsonnet/kube-prometheus/kube-prometheus-weave-net.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-weave-net.libsonnet
@@ -5,7 +5,7 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 {
   prometheus+: {
     serviceWeaveNet:
-      service.new('weave-net', { 'name': 'weave-net' }, servicePort.newNamed('weave-net-metrics', 6782, 6782)) +
+      service.new('weave-net', { name: 'weave-net' }, servicePort.newNamed('weave-net-metrics', 6782, 6782)) +
       service.mixin.metadata.withNamespace('kube-system') +
       service.mixin.metadata.withLabels({ 'k8s-app': 'weave-net' }) +
       service.mixin.spec.withClusterIp('None'),

--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -1,5 +1,5 @@
-local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local k3 = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local configMapList = k3.core.v1.configMapList;
 local kubeRbacProxyContainer = import './kube-rbac-proxy/container.libsonnet';
 
@@ -21,61 +21,61 @@ local kubeRbacProxyContainer = import './kube-rbac-proxy/container.libsonnet';
     namespace: k.core.v1.namespace.new($._config.namespace),
   },
   prometheusOperator+:: {
-    service+: {
-      spec+: {
-        ports: [
-          {
-            name: 'https',
-            port: 8443,
-            targetPort: 'https',
-          },
-        ],
-      },
-    },
-    serviceMonitor+: {
-      spec+: {
-        endpoints: [
-          {
-            port: 'https',
-            scheme: 'https',
-            honorLabels: true,
-            bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
-            tlsConfig: {
-              insecureSkipVerify: true,
-            },
-          },
-        ]
-      },
-    },
-    clusterRole+: {
-      rules+: [
-        {
-          apiGroups: ['authentication.k8s.io'],
-          resources: ['tokenreviews'],
-          verbs: ['create'],
-        },
-        {
-          apiGroups: ['authorization.k8s.io'],
-          resources: ['subjectaccessreviews'],
-          verbs: ['create'],
-        },
-      ],
-    },
-  } +
-  (kubeRbacProxyContainer {
-    config+:: {
-      kubeRbacProxy: {
-        local cfg = self,
-        image: $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy,
-        name: 'kube-rbac-proxy',
-        securePortName: 'https',
-        securePort: 8443,
-        secureListenAddress: ':%d' % self.securePort,
-        upstream: 'http://127.0.0.1:8080/',
-        tlsCipherSuites: $._config.tlsCipherSuites,
-      },
-    },
-  }).deploymentMixin,
+                          service+: {
+                            spec+: {
+                              ports: [
+                                {
+                                  name: 'https',
+                                  port: 8443,
+                                  targetPort: 'https',
+                                },
+                              ],
+                            },
+                          },
+                          serviceMonitor+: {
+                            spec+: {
+                              endpoints: [
+                                {
+                                  port: 'https',
+                                  scheme: 'https',
+                                  honorLabels: true,
+                                  bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+                                  tlsConfig: {
+                                    insecureSkipVerify: true,
+                                  },
+                                },
+                              ],
+                            },
+                          },
+                          clusterRole+: {
+                            rules+: [
+                              {
+                                apiGroups: ['authentication.k8s.io'],
+                                resources: ['tokenreviews'],
+                                verbs: ['create'],
+                              },
+                              {
+                                apiGroups: ['authorization.k8s.io'],
+                                resources: ['subjectaccessreviews'],
+                                verbs: ['create'],
+                              },
+                            ],
+                          },
+                        } +
+                        (kubeRbacProxyContainer {
+                           config+:: {
+                             kubeRbacProxy: {
+                               local cfg = self,
+                               image: $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy,
+                               name: 'kube-rbac-proxy',
+                               securePortName: 'https',
+                               securePort: 8443,
+                               secureListenAddress: ':%d' % self.securePort,
+                               upstream: 'http://127.0.0.1:8080/',
+                               tlsCipherSuites: $._config.tlsCipherSuites,
+                             },
+                           },
+                         }).deploymentMixin,
 
   grafana+:: {
     dashboardDefinitions: configMapList.new(super.dashboardDefinitions),

--- a/jsonnet/kube-prometheus/kube-rbac-proxy/container.libsonnet
+++ b/jsonnet/kube-prometheus/kube-rbac-proxy/container.libsonnet
@@ -35,7 +35,7 @@ local containerPort = container.portsType;
         spec+: {
           containers+: [
             container.new(krp.config.kubeRbacProxy.name, krp.config.kubeRbacProxy.image) +
-            container.mixin.securityContext.withRunAsUser(65534) +	    
+            container.mixin.securityContext.withRunAsUser(65534) +
             container.withArgs([
               '--logtostderr',
               '--secure-listen-address=' + krp.config.kubeRbacProxy.secureListenAddress,

--- a/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-state-metrics/kube-state-metrics.libsonnet
@@ -15,7 +15,7 @@ local ksm = import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-state-
     },
   },
   kubeStateMetrics+::
-    ksm + {
+    ksm {
       local version = self.version,
       name:: 'kube-state-metrics',
       namespace:: $._config.namespace,
@@ -100,33 +100,33 @@ local ksm = import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-state-
             ],
           },
         },
-      } +
-      (kubeRbacProxyContainer {
-        config+:: {
-          kubeRbacProxy: {
-            local cfg = self,
-            image: $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy,
-            name: 'kube-rbac-proxy-main',
-            securePortName: 'https-main',
-            securePort: 8443,
-            secureListenAddress: ':%d' % self.securePort,
-            upstream: 'http://127.0.0.1:8081/',
-            tlsCipherSuites: $._config.tlsCipherSuites,
-          },
-        },
-      }).deploymentMixin +
-      (kubeRbacProxyContainer {
-        config+:: {
-          kubeRbacProxy: {
-            local cfg = self,
-            image: $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy,
-            name: 'kube-rbac-proxy-self',
-            securePortName: 'https-self',
-            securePort: 9443,
-            secureListenAddress: ':%d' % self.securePort,
-            upstream: 'http://127.0.0.1:8082/',
-            tlsCipherSuites: $._config.tlsCipherSuites,
-          },
-        },
-      }).deploymentMixin,
+    } +
+    (kubeRbacProxyContainer {
+       config+:: {
+         kubeRbacProxy: {
+           local cfg = self,
+           image: $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy,
+           name: 'kube-rbac-proxy-main',
+           securePortName: 'https-main',
+           securePort: 8443,
+           secureListenAddress: ':%d' % self.securePort,
+           upstream: 'http://127.0.0.1:8081/',
+           tlsCipherSuites: $._config.tlsCipherSuites,
+         },
+       },
+     }).deploymentMixin +
+    (kubeRbacProxyContainer {
+       config+:: {
+         kubeRbacProxy: {
+           local cfg = self,
+           image: $._config.imageRepos.kubeRbacProxy + ':' + $._config.versions.kubeRbacProxy,
+           name: 'kube-rbac-proxy-self',
+           securePortName: 'https-self',
+           securePort: 9443,
+           secureListenAddress: ':%d' % self.securePort,
+           upstream: 'http://127.0.0.1:8082/',
+           tlsCipherSuites: $._config.tlsCipherSuites,
+         },
+       },
+     }).deploymentMixin,
 }

--- a/jsonnet/kube-prometheus/lib/image.libsonnet
+++ b/jsonnet/kube-prometheus/lib/image.libsonnet
@@ -5,16 +5,16 @@ local imageName(image) =
   local parts = std.split(image, '/');
   local len = std.length(parts);
   if len == 3 then
-    # registry.com/org/image
+    // registry.com/org/image
     parts[2]
   else if len == 2 then
-    # org/image
+    // org/image
     parts[1]
   else if len == 1 then
-    # image, ie. busybox
+    // image, ie. busybox
     parts[0]
   else
-      error 'unknown image format: ' + image;
+    error 'unknown image format: ' + image;
 
 {
   imageName:: imageName,

--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -24,17 +24,17 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
             resources: {
               overrides: {
                 node: {
-                  resource: 'node'
+                  resource: 'node',
                 },
                 namespace: {
-                  resource: 'namespace'
+                  resource: 'namespace',
                 },
                 pod: {
-                  resource: 'pod'
+                  resource: 'pod',
                 },
               },
             },
-            containerLabel: 'container'
+            containerLabel: 'container',
           },
           memory: {
             containerQuery: 'sum(container_memory_working_set_bytes{<<.LabelMatchers>>,container!="POD",container!="",pod!=""}) by (<<.GroupBy>>)',
@@ -42,21 +42,21 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
             resources: {
               overrides: {
                 instance: {
-                  resource: 'node'
+                  resource: 'node',
                 },
                 namespace: {
-                  resource: 'namespace'
+                  resource: 'namespace',
                 },
                 pod: {
-                  resource: 'pod'
+                  resource: 'pod',
                 },
               },
             },
-            containerLabel: 'container'
+            containerLabel: 'container',
           },
           window: '5m',
         },
-      }
+      },
     },
   },
 
@@ -232,14 +232,14 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
         policyRule.new() +
         policyRule.withApiGroups(['metrics.k8s.io']) +
         policyRule.withResources(['pods', 'nodes']) +
-        policyRule.withVerbs(['get','list','watch']);
+        policyRule.withVerbs(['get', 'list', 'watch']);
 
       clusterRole.new() +
       clusterRole.mixin.metadata.withName('system:aggregated-metrics-reader') +
       clusterRole.mixin.metadata.withLabels({
-        "rbac.authorization.k8s.io/aggregate-to-admin": "true",
-        "rbac.authorization.k8s.io/aggregate-to-edit": "true",
-        "rbac.authorization.k8s.io/aggregate-to-view": "true",
+        'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
+        'rbac.authorization.k8s.io/aggregate-to-view': 'true',
       }) +
       clusterRole.withRules(rules),
 

--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -256,11 +256,11 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
             {
               port: 'https-metrics',
               interval: '30s',
-              scheme: "https",
-              bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+              scheme: 'https',
+              bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
               tlsConfig: {
-                insecureSkipVerify: true
-              }
+                insecureSkipVerify: true,
+              },
             },
           ],
           selector: {
@@ -380,10 +380,10 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
             {
               port: 'https-metrics',
               interval: '30s',
-              scheme: "https",
-              bearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+              scheme: 'https',
+              bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
               tlsConfig: {
-                insecureSkipVerify: true
+                insecureSkipVerify: true,
               },
               metricRelabelings: (import 'kube-prometheus/dropping-deprecated-metrics-relabelings.libsonnet') + [
                 {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -18,7 +18,7 @@
           "subdir": "Documentation/etcd-mixin"
         }
       },
-      "version": "7da5182f1d02c0baaefd52f361fd0459d5b6703e",
+      "version": "6e800b9b0161ef874784fc6c679325acd67e2452",
       "sum": "L+PGlPK9mykGCJ9TIoEWdhMBjz+9lKuQ4YZ8fOeP9sk="
     },
     {
@@ -38,7 +38,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "fe3e027c5a0d8311e1bd6cd9de2c295707c3ae76",
+      "version": "8488040f4687d6b00959254d6258c8a947a47ce1",
       "sum": "mD0zEP9FVFXeag7EaeS5OvUr2A9D6DQhGemoNn6+PLc="
     },
     {
@@ -59,8 +59,8 @@
           "subdir": ""
         }
       },
-      "version": "8a98e9c6fab000ef090b8d313292043696a8b3bb",
-      "sum": "btFPZfE2paWZdvLtFwv4gfDoygj1axt7Q4ACGSdeuJ8="
+      "version": "55feeb4a510cddc67f24751bf9c18408cd34e2f3",
+      "sum": "GOLbNBTZGM/t7P9Y0rvJWFlYs8NcR4DA7m4sIioGE50="
     },
     {
       "source": {
@@ -69,7 +69,7 @@
           "subdir": "lib/promgrafonnet"
         }
       },
-      "version": "8a98e9c6fab000ef090b8d313292043696a8b3bb",
+      "version": "55feeb4a510cddc67f24751bf9c18408cd34e2f3",
       "sum": "zv7hXGui6BfHzE9wPatHI/AGZa4A2WKo6pq7ZdqBsps="
     },
     {
@@ -89,7 +89,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "a4867d8809ba60a59013034646d0a4bc89576b9c",
+      "version": "b6e67d0d865a589ee05f697086de3fe917abf128",
       "sum": "Yf8mNAHrV1YWzrdV8Ry5dJ8YblepTGw3C0Zp10XIYLo="
     },
     {
@@ -99,7 +99,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "f6ce472ecd6064fb6769e306b55b149dfb6af903",
+      "version": "30b03e839a460ef230256873c10ad56f9a5abd37",
       "sum": "6reUygVmQrLEWQzTKcH8ceDbvM+2ztK3z2VBR2K2l+U="
     },
     {
@@ -109,7 +109,7 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "633ea519b2ce86396f6e006f7fd967c04bc45bda",
+      "version": "c070a93f97fbc967e404d81e12b9988a6631bf5f",
       "sum": "P8EcWO33RCyVTfwMdpy4S4jFZjJVHiu190j8yd/CGfs="
     },
     {

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -1299,6 +1299,14 @@ spec:
           !=
         kube_hpa_status_current_replicas{job="kube-state-metrics"})
           and
+        (kube_hpa_status_current_replicas{job="kube-state-metrics"}
+          >
+        kube_hpa_spec_min_replicas{job="kube-state-metrics"})
+          and
+        (kube_hpa_status_current_replicas{job="kube-state-metrics"}
+          <
+        kube_hpa_spec_max_replicas{job="kube-state-metrics"})
+          and
         changes(kube_hpa_status_current_replicas[15m]) == 0
       for: 15m
       labels:


### PR DESCRIPTION
Added a `make update_libs` target to Makefile, and committing the result.  This pulls in a number of changes, including the one originally requested in this PR.

* `fillGradient:  0` just... everywhere.
* [Update config.libsonnet to add SD cards to the list of block devices to monitor](https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/506)
* [Fix TX network queries resources dashboards ](https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/507)
* A small augmentation to the kube state metrics cluster role (moving the home of the `ingresses` resources)
* A few rule updates


Originally:
```
I've found that my Raspberry Pi nodes aren't reporting storage metrics for their SD cards on the standard k8s dashboards, and it looks like this is why...

Blocked on an upstream update [here](https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/506).
```