### PR TITLE
Add print to find

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ vendor: $(JB_BIN) jsonnetfile.json jsonnetfile.lock.json
 
 .PHONY: fmt
 fmt: $(JSONNETFMT_BIN)
-	find . -name 'vendor' -prune -o -name '*.libsonnet' -o -name '*.jsonnet' -print | \
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
 		xargs -n 1 -- $(JSONNETFMT_BIN) $(JSONNETFMT_ARGS) -i
 
 .PHONY: test


### PR DESCRIPTION
The `find` call in the Makefile doesn't actually output any `*.libsonnet` file due to the way `find` handles operators. This was discovered using GNU `find` on a Mac. From the manpages:

> Please  note  that -a when specified implicitly (for example by two tests appearing without an explicit operator between them) or explicitly has higher precedence than -o.  This means that find . -name afile -o -name bfile -print will never print afile.

A simple addition of `-print` to force the print fixes the issue.