### PR TITLE
Pin kube-state-metrics to last stable release branch

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -63,7 +63,7 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "master"
+      "version": "release-1.9"
     },
     {
       "source": {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana"
         }
       },
-      "version": "d7c1a53462ecd533593c60e5277b92fbf7ea7623",
-      "sum": "8OnIwMhzWtgoWYHNrDlkzUAMr/CPsWKauYEv0vnH1zs="
+      "version": "02ac326459f46d6f30a766ce2f9a45337a745db0",
+      "sum": "r7kj5f5w7aVB7vO++dI9vbHhzoW8PpyVLSA7gOiouZ0="
     },
     {
       "source": {
@@ -18,8 +18,8 @@
           "subdir": "Documentation/etcd-mixin"
         }
       },
-      "version": "ab4cc3caef3d6a1bb7c8c9e79749357eafef42df",
-      "sum": "5awm+ZMs5J/nOFB+hLAb7hdeQxz/iIrls5hEZoEkXjM="
+      "version": "8866d55b9bc8539f5f15db33cc78b9737cad0394",
+      "sum": "L+PGlPK9mykGCJ9TIoEWdhMBjz+9lKuQ4YZ8fOeP9sk="
     },
     {
       "source": {
@@ -28,8 +28,8 @@
           "subdir": "grafonnet"
         }
       },
-      "version": "4ae0ba995612d3fe71bb74ec23a49815b6896817",
-      "sum": "J5CaYYEP02FleLx34/qgS+ckWUaxUaADlfnV7CriSo8="
+      "version": "356bd73e4792ffe107725776ca8946895969c191",
+      "sum": "CSMZ3dJrpJpwvffie8BqcfrIVVwiKNqdPEN+1XWRBGU="
     },
     {
       "source": {
@@ -38,7 +38,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "b8cb0881befce313a6741489c6018662be663d5e",
+      "version": "dfa2a427d884da8d169eb356bfb85717aed61b13",
       "sum": "mD0zEP9FVFXeag7EaeS5OvUr2A9D6DQhGemoNn6+PLc="
     },
     {
@@ -59,8 +59,8 @@
           "subdir": ""
         }
       },
-      "version": "5c07e1de2c8ea4f8fdcc1985712daa5e751a327f",
-      "sum": "k4V7WfQtyb2JXDczC6fBXjqph2RmLZfKpWTv3mmuj2s="
+      "version": "8a98e9c6fab000ef090b8d313292043696a8b3bb",
+      "sum": "btFPZfE2paWZdvLtFwv4gfDoygj1axt7Q4ACGSdeuJ8="
     },
     {
       "source": {
@@ -69,7 +69,7 @@
           "subdir": "lib/promgrafonnet"
         }
       },
-      "version": "5c07e1de2c8ea4f8fdcc1985712daa5e751a327f",
+      "version": "8a98e9c6fab000ef090b8d313292043696a8b3bb",
       "sum": "zv7hXGui6BfHzE9wPatHI/AGZa4A2WKo6pq7ZdqBsps="
     },
     {
@@ -79,8 +79,8 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "392f9249f808041612a8d3c5348fc48b64cece74",
-      "sum": "WJGwddC7KJnEN7CWGELiOHKam+vmv9XYkwrMCwmXi2M="
+      "version": "89aaf6c524ee891140c4c8f2a05b1b16f5847309",
+      "sum": "zD/pbQLnQq+5hegEelaheHS8mn1h09GTktFO74iwlBI="
     },
     {
       "source": {
@@ -89,7 +89,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "392f9249f808041612a8d3c5348fc48b64cece74",
+      "version": "2323702757a75e12b1dd1efecedfc0a340c1d104",
       "sum": "Yf8mNAHrV1YWzrdV8Ry5dJ8YblepTGw3C0Zp10XIYLo="
     },
     {
@@ -99,8 +99,8 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "fbd01683839aa408b31fa15fa1aa91c68f13d7ef",
-      "sum": "vqz67twCROf5kVgo/61luBOx25Mk7Okbt8YP+/7xjT0="
+      "version": "e32c86ffa4c6e9c582cc76785e711d695b641d46",
+      "sum": "6reUygVmQrLEWQzTKcH8ceDbvM+2ztK3z2VBR2K2l+U="
     },
     {
       "source": {
@@ -119,8 +119,8 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "9c9c63630572ac706dcd0bd0e79dc03179f6d02c",
-      "sum": "GE8EJdQvnaaj31avW1OaJGY6xP+Vd6MqMu7/GgudRDQ="
+      "version": "ed104850737ccad9a815277641ac2549cbbde931",
+      "sum": "3b9xJI6cjh58SMfpUBhyrC+IG8D/5lpNyRGJibFi+5g="
     },
     {
       "source": {

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -144,6 +144,7 @@ items:
                           "decimals": 3,
                           "description": "How much error budget is left looking at our 0.990% availability gurantees?",
                           "fill": 10,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -338,6 +339,7 @@ items:
                           "datasource": "$datasource",
                           "description": "How many read requests (LIST,GET) per second do the apiservers get by code?",
                           "fill": 10,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -446,6 +448,7 @@ items:
                           "datasource": "$datasource",
                           "description": "How many percent of read requests (LIST,GET) per second are returned with errors (5xx)?",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -539,6 +542,7 @@ items:
                           "datasource": "$datasource",
                           "description": "How many seconds is the 99th percentile for reading (LIST|GET) a given resource?",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -731,6 +735,7 @@ items:
                           "datasource": "$datasource",
                           "description": "How many write requests (POST|PUT|PATCH|DELETE) per second do the apiservers get by code?",
                           "fill": 10,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -839,6 +844,7 @@ items:
                           "datasource": "$datasource",
                           "description": "How many percent of write requests (POST|PUT|PATCH|DELETE) per second are returned with errors (5xx)?",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -932,6 +938,7 @@ items:
                           "datasource": "$datasource",
                           "description": "How many seconds is the 99th percentile for writing (POST|PUT|PATCH|DELETE) a given resource?",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -1037,6 +1044,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -1129,6 +1137,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -1221,6 +1230,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -1326,6 +1336,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -1418,6 +1429,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -1510,6 +1522,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -1780,6 +1793,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -1882,6 +1896,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -2325,6 +2340,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -2427,6 +2443,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -2559,6 +2576,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 24,
@@ -2659,6 +2677,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 24,
@@ -2770,6 +2789,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 24,
@@ -2870,6 +2890,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 24,
@@ -2990,6 +3011,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 24,
@@ -3090,6 +3112,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 24,
@@ -3190,6 +3213,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 24,
@@ -3294,6 +3318,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 24,
@@ -3668,6 +3693,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -3773,6 +3799,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -3878,6 +3905,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -3983,6 +4011,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -4096,6 +4125,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -4201,6 +4231,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -4306,6 +4337,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -4398,6 +4430,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -4490,6 +4523,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -6895,7 +6929,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\".+\"}[$__interval])) by (namespace)",
+                                  "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=~\".+\"}[$__interval])) by (namespace)",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{namespace}}",
@@ -9138,7 +9172,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                                  "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
                                   "format": "time_series",
                                   "intervalFactor": 2,
                                   "legendFormat": "{{pod}}",
@@ -16978,6 +17012,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -17070,6 +17105,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -17175,6 +17211,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -17280,6 +17317,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -17379,6 +17417,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -17491,6 +17530,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -17585,6 +17625,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -17692,6 +17733,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -17799,6 +17841,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -17891,6 +17934,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -17997,6 +18041,7 @@ items:
                           "datasource": "$datasource",
                           "description": "Pod lifecycle event generator",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -18089,6 +18134,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -18194,6 +18240,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -18299,6 +18346,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -18425,6 +18473,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -18530,6 +18579,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -18622,6 +18672,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -18714,6 +18765,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -19527,6 +19579,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -19627,6 +19680,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -19738,6 +19792,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 10,
                               "w": 12,
@@ -19838,6 +19893,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 10,
                               "w": 12,
@@ -19958,6 +20014,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 10,
                               "w": 12,
@@ -20058,6 +20115,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 10,
                               "w": 12,
@@ -20400,6 +20458,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -20502,6 +20561,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -20945,6 +21005,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -21047,6 +21108,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -21179,6 +21241,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -21279,6 +21342,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -21390,6 +21454,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -21490,6 +21555,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -21610,6 +21676,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -21710,6 +21777,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -23983,6 +24051,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -24076,6 +24145,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 0,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -24202,6 +24272,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -24412,6 +24483,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 0,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -24455,7 +24527,7 @@ items:
                           "steppedLine": false,
                           "targets": [
                               {
-                                  "expr": "rate(node_disk_read_bytes_total{job=\"node-exporter\", instance=\"$instance\", device=~\"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\"}[$__interval])",
+                                  "expr": "rate(node_disk_read_bytes_total{job=\"node-exporter\", instance=\"$instance\", device=~\"mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\"}[$__interval])",
                                   "format": "time_series",
                                   "interval": "1m",
                                   "intervalFactor": 2,
@@ -24463,7 +24535,7 @@ items:
                                   "refId": "A"
                               },
                               {
-                                  "expr": "rate(node_disk_written_bytes_total{job=\"node-exporter\", instance=\"$instance\", device=~\"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\"}[$__interval])",
+                                  "expr": "rate(node_disk_written_bytes_total{job=\"node-exporter\", instance=\"$instance\", device=~\"mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\"}[$__interval])",
                                   "format": "time_series",
                                   "interval": "1m",
                                   "intervalFactor": 2,
@@ -24471,7 +24543,7 @@ items:
                                   "refId": "B"
                               },
                               {
-                                  "expr": "rate(node_disk_io_time_seconds_total{job=\"node-exporter\", instance=\"$instance\", device=~\"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\"}[$__interval])",
+                                  "expr": "rate(node_disk_io_time_seconds_total{job=\"node-exporter\", instance=\"$instance\", device=~\"mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\"}[$__interval])",
                                   "format": "time_series",
                                   "interval": "1m",
                                   "intervalFactor": 2,
@@ -24528,6 +24600,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -24647,6 +24720,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 0,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -24740,6 +24814,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 0,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -24961,6 +25036,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -25157,6 +25233,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -25819,6 +25896,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -25919,6 +25997,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -26030,6 +26109,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 10,
                               "w": 12,
@@ -26130,6 +26210,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 10,
                               "w": 12,
@@ -26250,6 +26331,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 10,
                               "w": 12,
@@ -26350,6 +26432,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 10,
                               "w": 12,
@@ -26700,6 +26783,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -26792,6 +26876,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -26897,6 +26982,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -27002,6 +27088,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -27095,6 +27182,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -27187,6 +27275,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -27279,6 +27368,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -27384,6 +27474,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -27476,6 +27567,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -27581,6 +27673,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -27673,6 +27766,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -27778,6 +27872,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -27870,6 +27965,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -27962,6 +28058,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -28054,6 +28151,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -29634,6 +29732,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -29726,6 +29825,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -29831,6 +29931,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -29923,6 +30024,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -30028,6 +30130,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -30141,6 +30244,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -30246,6 +30350,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -30351,6 +30456,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -30443,6 +30549,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -30535,6 +30642,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -30839,6 +30947,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -30952,6 +31061,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -31078,6 +31188,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -31191,6 +31302,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -31296,6 +31408,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -31401,6 +31514,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -31493,6 +31607,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -31585,6 +31700,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -32417,6 +32533,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 1,
+                          "fillGradient": 0,
                           "gridPos": {
 
                           },
@@ -32740,6 +32857,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -32842,6 +32960,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -32955,6 +33074,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -33057,6 +33177,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -33189,6 +33310,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -33289,6 +33411,7 @@ items:
                   "dashes": false,
                   "datasource": "$datasource",
                   "fill": 2,
+                  "fillGradient": 0,
                   "gridPos": {
                       "h": 9,
                       "w": 12,
@@ -33400,6 +33523,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -33500,6 +33624,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -33620,6 +33745,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,
@@ -33720,6 +33846,7 @@ items:
                           "dashes": false,
                           "datasource": "$datasource",
                           "fill": 2,
+                          "fillGradient": 0,
                           "gridPos": {
                               "h": 9,
                               "w": 12,

--- a/manifests/grafana-service.yaml
+++ b/manifests/grafana-service.yaml
@@ -12,3 +12,4 @@ spec:
     targetPort: http
   selector:
     app: grafana
+  type: NodePort

--- a/manifests/kube-state-metrics-clusterRole.yaml
+++ b/manifests/kube-state-metrics-clusterRole.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.7
+    app.kubernetes.io/version: v1.9.7
   name: kube-state-metrics
 rules:
 - apiGroups:
@@ -105,13 +105,6 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
   verbs:
   - list
   - watch

--- a/manifests/kube-state-metrics-clusterRoleBinding.yaml
+++ b/manifests/kube-state-metrics-clusterRoleBinding.yaml
@@ -3,7 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.7
+    app.kubernetes.io/version: v1.9.7
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/kube-state-metrics-deployment.yaml
+++ b/manifests/kube-state-metrics-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.7
+    app.kubernetes.io/version: v1.9.7
   name: kube-state-metrics
   namespace: monitoring
 spec:
@@ -15,7 +15,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 1.9.7
+        app.kubernetes.io/version: v1.9.7
     spec:
       containers:
       - args:
@@ -25,8 +25,6 @@ spec:
         - --telemetry-port=8082
         image: quay.io/coreos/kube-state-metrics:v1.9.7
         name: kube-state-metrics
-        securityContext:
-          runAsUser: 65534
       - args:
         - --logtostderr
         - --secure-listen-address=:8443

--- a/manifests/kube-state-metrics-service.yaml
+++ b/manifests/kube-state-metrics-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.7
+    app.kubernetes.io/version: v1.9.7
   name: kube-state-metrics
   namespace: monitoring
 spec:

--- a/manifests/kube-state-metrics-serviceAccount.yaml
+++ b/manifests/kube-state-metrics-serviceAccount.yaml
@@ -3,6 +3,6 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 1.9.7
+    app.kubernetes.io/version: v1.9.7
   name: kube-state-metrics
   namespace: monitoring

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -40,10 +40,10 @@ spec:
         rate(node_vmstat_pgmajfault{job="node-exporter"}[1m])
       record: instance:node_vmstat_pgmajfault:rate1m
     - expr: |
-        rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"}[1m])
+        rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"}[1m])
       record: instance_device:node_disk_io_time_seconds:rate1m
     - expr: |
-        rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"}[1m])
+        rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"}[1m])
       record: instance_device:node_disk_io_time_weighted_seconds:rate1m
     - expr: |
         sum without (device) (
@@ -1041,6 +1041,16 @@ spec:
       for: 15m
       labels:
         severity: warning
+    - alert: PrometheusOperatorSyncFailed
+      annotations:
+        description: Controller {{ $labels.controller }} in {{ $labels.namespace }} namespace fails to reconcile {{ $value }} objects.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatorsyncfailed
+        summary: Last controller reconciliation failed
+      expr: |
+        min_over_time(prometheus_operator_syncs{status="failed",job="prometheus-operator",namespace="monitoring"}[5m]) > 0
+      for: 10m
+      labels:
+        severity: warning
     - alert: PrometheusOperatorReconcileErrors
       annotations:
         description: '{{ $value | humanizePercentage }} of reconciling operations failed for {{ $labels.controller }} controller in {{ $labels.namespace }} namespace.'
@@ -1059,6 +1069,26 @@ spec:
       expr: |
         rate(prometheus_operator_node_address_lookup_errors_total{job="prometheus-operator",namespace="monitoring"}[5m]) > 0.1
       for: 10m
+      labels:
+        severity: warning
+    - alert: PrometheusOperatorNotReady
+      annotations:
+        description: Prometheus operator in {{ $labels.namespace }} namespace isn't ready to reconcile {{ $labels.controller }} resources.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatornotready
+        summary: Prometheus operator not ready
+      expr: |
+        min by(namespace, controller) (max_over_time(prometheus_operator_ready{job="prometheus-operator",namespace="monitoring"}[5m]) == 0)
+      for: 5m
+      labels:
+        severity: warning
+    - alert: PrometheusOperatorRejectedResources
+      annotations:
+        description: Prometheus operator in {{ $labels.namespace }} namespace rejected {{ printf "%0.0f" $value }} {{ $labels.controller }}/{{ $labels.resource }} resources.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatorrejectedresources
+        summary: Resources rejected by Prometheus operator
+      expr: |
+        min_over_time(prometheus_operator_managed_resources{state="rejected",job="prometheus-operator",namespace="monitoring"}[5m]) > 0
+      for: 5m
       labels:
         severity: warning
   - name: kubernetes-apps
@@ -1251,7 +1281,7 @@ spec:
         severity: warning
     - alert: KubeJobFailed
       annotations:
-        description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
+        description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete. Removing failed job after investigation should clear this alert.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed
         summary: Job failed to complete.
       expr: |


### PR DESCRIPTION
Due to master going through breaking changes, using latest stable release branch release-1.9 is safest for users. Once release-2.0 branch is a bit more stable I plan on bumping it to that release.

cc @prometheus-operator/kube-prometheus-reviewers PTAL, thanks!