### PR TITLE
enable alternate namespace for prometheus adapter

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-custom-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-custom-metrics.libsonnet
@@ -4,6 +4,7 @@
 {
   _config+:: {
     prometheusAdapter+:: {
+      namespace: $._config.namespace,
       // Rules for custom-metrics
       config+:: {
         rules+: [
@@ -87,7 +88,7 @@
       spec: {
         service: {
           name: $.prometheusAdapter.service.metadata.name,
-          namespace: $._config.namespace,
+          namespace: $._config.prometheusAdapter.namespace,
         },
         group: 'custom.metrics.k8s.io',
         version: 'v1beta1',
@@ -105,7 +106,7 @@
       spec: {
         service: {
           name: $.prometheusAdapter.service.metadata.name,
-          namespace: $._config.namespace,
+          namespace: $._config.prometheusAdapter.namespace,
         },
         group: 'custom.metrics.k8s.io',
         version: 'v1beta2',
@@ -141,7 +142,7 @@
       subjects: [{
         kind: 'ServiceAccount',
         name: $.prometheusAdapter.serviceAccount.metadata.name,
-        namespace: $._config.namespace,
+        namespace: $._config.prometheusAdapter.namespace,
       }],
     },
     customMetricsClusterRoleBindingHPA: {

--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -14,8 +14,9 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 
     prometheusAdapter+:: {
       name: 'prometheus-adapter',
+      namespace: $._config.namespace,
       labels: { name: $._config.prometheusAdapter.name },
-      prometheusURL: 'http://prometheus-' + $._config.prometheus.name + '.' + $._config.namespace + '.svc.cluster.local:9090/',
+      prometheusURL: 'http://prometheus-' + $._config.prometheus.name + '.' + $._config.prometheusAdapter.namespace + '.svc.cluster.local:9090/',
       config: {
         resourceRules: {
           cpu: {
@@ -71,7 +72,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
         spec: {
           service: {
             name: $.prometheusAdapter.service.metadata.name,
-            namespace: $._config.namespace,
+            namespace: $._config.prometheusAdapter.namespace,
           },
           group: 'metrics.k8s.io',
           version: 'v1beta1',
@@ -85,7 +86,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
       local configmap = k.core.v1.configMap;
       configmap.new('adapter-config', { 'config.yaml': std.manifestYamlDoc($._config.prometheusAdapter.config) }) +
 
-      configmap.mixin.metadata.withNamespace($._config.namespace),
+      configmap.mixin.metadata.withNamespace($._config.prometheusAdapter.namespace),
 
     serviceMonitor:
       {
@@ -93,7 +94,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
         kind: 'ServiceMonitor',
         metadata: {
           name: $._config.prometheusAdapter.name,
-          namespace: $._config.namespace,
+          namespace: $._config.prometheusAdapter.namespace,
           labels: $._config.prometheusAdapter.labels,
         },
         spec: {
@@ -123,7 +124,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
         $._config.prometheusAdapter.labels,
         servicePort.newNamed('https', 443, 6443),
       ) +
-      service.mixin.metadata.withNamespace($._config.namespace) +
+      service.mixin.metadata.withNamespace($._config.prometheusAdapter.namespace) +
       service.mixin.metadata.withLabels($._config.prometheusAdapter.labels),
 
     deployment:
@@ -150,7 +151,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
         ],);
 
       deployment.new($._config.prometheusAdapter.name, 1, c, $._config.prometheusAdapter.labels) +
-      deployment.mixin.metadata.withNamespace($._config.namespace) +
+      deployment.mixin.metadata.withNamespace($._config.prometheusAdapter.namespace) +
       deployment.mixin.spec.selector.withMatchLabels($._config.prometheusAdapter.labels) +
       deployment.mixin.spec.template.spec.withServiceAccountName($.prometheusAdapter.serviceAccount.metadata.name) +
       deployment.mixin.spec.template.spec.withNodeSelector({ 'kubernetes.io/os': 'linux' }) +
@@ -166,7 +167,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
       local serviceAccount = k.core.v1.serviceAccount;
 
       serviceAccount.new($._config.prometheusAdapter.name) +
-      serviceAccount.mixin.metadata.withNamespace($._config.namespace),
+      serviceAccount.mixin.metadata.withNamespace($._config.prometheusAdapter.namespace),
 
     clusterRole:
       local clusterRole = k.rbac.v1.clusterRole;
@@ -193,7 +194,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
       clusterRoleBinding.withSubjects([{
         kind: 'ServiceAccount',
         name: $.prometheusAdapter.serviceAccount.metadata.name,
-        namespace: $._config.namespace,
+        namespace: $._config.prometheusAdapter.namespace,
       }]),
 
     clusterRoleBindingDelegator:
@@ -207,7 +208,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
       clusterRoleBinding.withSubjects([{
         kind: 'ServiceAccount',
         name: $.prometheusAdapter.serviceAccount.metadata.name,
-        namespace: $._config.namespace,
+        namespace: $._config.prometheusAdapter.namespace,
       }]),
 
     clusterRoleServerResources:
@@ -255,7 +256,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
       roleBinding.withSubjects([{
         kind: 'ServiceAccount',
         name: $.prometheusAdapter.serviceAccount.metadata.name,
-        namespace: $._config.namespace,
+        namespace: $._config.prometheusAdapter.namespace,
       }]),
   },
 }

--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -16,7 +16,7 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
       name: 'prometheus-adapter',
       namespace: $._config.namespace,
       labels: { name: $._config.prometheusAdapter.name },
-      prometheusURL: 'http://prometheus-' + $._config.prometheus.name + '.' + $._config.prometheusAdapter.namespace + '.svc.cluster.local:9090/',
+      prometheusURL: 'http://prometheus-' + $._config.prometheus.name + '.' + $._config.namespace + '.svc.cluster.local:9090/',
       config: {
         resourceRules: {
           cpu: {


### PR DESCRIPTION
deleting namespaces where prometheus adapter is installed is problematic because it registers an api service there. i prefer to install to kube-system but not everyone will have the ability to do that. best option is to make namespace for prometheus adapter configurable in $._config.prometheusAdapter and default to $._config.namespace to not break current code.