### PR TITLE
Remove ksonnet from jsonnet/kube-prometheus

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-all-namespaces.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-all-namespaces.libsonnet
@@ -1,20 +1,11 @@
-local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
-
 {
-    prometheus+:: {
-        clusterRole+: {
-            rules+: 
-            local role = k.rbac.v1.role;
-            local policyRule = role.rulesType;
-            local rule = policyRule.new() +
-                            policyRule.withApiGroups(['']) +
-                            policyRule.withResources([
-                            'services',
-                            'endpoints',
-                            'pods',
-                            ]) +
-                            policyRule.withVerbs(['get', 'list', 'watch']);
-            [rule]
-      },
-    }
+  prometheus+:: {
+    clusterRole+: {
+      rules+: [{
+        apiGroups: [''],
+        resources: ['services', 'endpoints', 'pods'],
+        verbs: ['get', 'list', 'watch'],
+      }],
+    },
+  },
 }

--- a/jsonnet/kube-prometheus/kube-prometheus-anti-affinity.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-anti-affinity.libsonnet
@@ -1,23 +1,22 @@
-local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
-local statefulSet = k.apps.v1.statefulSet;
-local affinity = statefulSet.mixin.spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecutionType;
-local matchExpression = affinity.mixin.podAffinityTerm.labelSelector.matchExpressionsType;
-
 {
   local antiaffinity(key, values, namespace) = {
     affinity: {
       podAntiAffinity: {
         preferredDuringSchedulingIgnoredDuringExecution: [
-          affinity.new() +
-          affinity.withWeight(100) +
-          affinity.mixin.podAffinityTerm.withNamespaces(namespace) +
-          affinity.mixin.podAffinityTerm.withTopologyKey('kubernetes.io/hostname') +
-          affinity.mixin.podAffinityTerm.labelSelector.withMatchExpressions([
-            matchExpression.new() +
-            matchExpression.withKey(key) +
-            matchExpression.withOperator('In') +
-            matchExpression.withValues(values),
-          ]),
+          {
+            podAffinityTerm: {
+              namespaces: [namespace],
+              topologyKey: 'kubernetes.io/hostname',
+              labelSelector: {
+                matchExpressions: [{
+                  key: key,
+                  operator: 'In',
+                  values: values,
+                }],
+              },
+              weight: 100,
+            },
+          },
         ],
       },
     },


### PR DESCRIPTION
Signed-off-by: Kemal Akkoyun <kakkoyun@gmail.com>

Removes ksonnet from `jsonnet/kube-prometheus/kube-prometheus-anti-affinity.libsonnet` and `jsonnet/kube-prometheus/kube-prometheus-all-namespaces.libsonnet`