### PR TITLE
add prometheus resources

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
@@ -15,6 +15,9 @@
       'node-exporter'+: {
         limits: {},
       },
+      'prometheus': {
+        limits: {},
+      },
     },
   },
   prometheusOperator+: {

--- a/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-strip-limits.libsonnet
@@ -15,7 +15,7 @@
       'node-exporter'+: {
         limits: {},
       },
-      'prometheus': {
+      'prometheus'+: {
         limits: {},
       },
     },

--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -190,6 +190,10 @@ local kubeRbacProxyContainer = import './kube-rbac-proxy/container.libsonnet';
         requests: { cpu: '102m', memory: '180Mi' },
         limits: { cpu: '250m', memory: '180Mi' },
       },
+      'prometheus': {
+        requests: { cpu: '200m', memory: '2048Mi' },
+        limits: { cpu: '500m', memory: '4096Mi' },
+      },
     },
     prometheus+:: {
       rules: $.prometheusRules + $.prometheusAlerts,

--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -169,7 +169,8 @@ local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 
       local resources =
         resourceRequirements.new() +
-        resourceRequirements.withRequests({ memory: '400Mi' });
+        container.mixin.resources.withRequests($._config.resources['prometheus'].requests) +
+        container.mixin.resources.withLimits($._config.resources['prometheus'].limits);
 
       {
         apiVersion: 'monitoring.coreos.com/v1',

--- a/manifests/prometheus-prometheus.yaml
+++ b/manifests/prometheus-prometheus.yaml
@@ -20,8 +20,13 @@ spec:
   probeSelector: {}
   replicas: 2
   resources:
-    requests:
-      memory: 400Mi
+    resources:
+      limits:
+        cpu: 500m
+        memory: 4096Mi
+      requests:
+        cpu: 200m
+        memory: 2048Mi
   ruleSelector:
     matchLabels:
       prometheus: k8s


### PR DESCRIPTION
This simply adds the cap to overwrite the prometheus requests/limits.
It also adds the cap to strip said limits for prometheus pods.

To keep in line with the current suggestions it can be configured through _config:
```
    _config+:: {
      resources+:: {
        'prometheus': {
          requests: { cpu: '200m', memory: '2048Mi' },
          limits: { cpu: '500m', memory: '4096Mi' },
        },
      },
    },
```

I got the defaults from the current usage of our mini test cluster (3 manager/5 nodes) so suggestions for the actual values are appreciated..