### PR TITLE
Revert kubeadm selector and replace nodePort

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-kubeadm.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kubeadm.libsonnet
@@ -19,14 +19,14 @@ local service(name, namespace, labels, selector, ports) = {
       'kube-controller-manager-prometheus-discovery',
       'kube-system',
       { 'k8s-app': 'kube-controller-manager' },
-      { 'k8s-app': 'kube-controller-manager' },
+      { 'component': 'kube-controller-manager' },
       [{ name: 'https-metrics', port: 10257, targetPort: 10257 }]
     ),
     kubeSchedulerPrometheusDiscoveryService: service(
       'kube-scheduler-prometheus-discovery',
       'kube-system',
       { 'k8s-app': 'kube-scheduler' },
-      { 'k8s-app': 'kube-scheduler' },
+      { 'component': 'kube-scheduler' },
       [{ name: 'https-metrics', port: 10259, targetPort: 10259 }],
     ),
   },

--- a/jsonnet/kube-prometheus/kube-prometheus-node-ports.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-node-ports.libsonnet
@@ -1,6 +1,6 @@
 local patch(ports) = {
   spec+: {
-    ports+: ports,
+    ports: ports,
     type: 'NodePort',
   },
 };


### PR DESCRIPTION
While I don't use the kubeadm, I try to keep my Kubernetes deployments compatible with it. During some ksonnet removal the selector was recently changed from component to k8s-app, which I think was accidental. (https://github.com/prometheus-operator/kube-prometheus/pull/764)

As far as I can tell, kubeadm still uses the component label: https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/util/staticpod/utils.go#L63

Also the node-ports mixin now adds a second port with the same name, so I end up with two ports with same name and targetPort, but one of them defining the nodePort. I don't think this was intentional either.


This PR reverts the label for kubeadm to be 'component' and the node-ports mixin to replace the port instead of add a second one.