### PR TITLE
Add instructions for community support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This stack is meant for cluster monitoring, so it is pre-configured to collect m
       - [Authorization problem](#authorization-problem)
     - [kube-state-metrics resource usage](#kube-state-metrics-resource-usage)
   - [Contributing](#contributing)
+  - [License](#license)
 
 ## Prerequisites
 
@@ -327,7 +328,7 @@ These are the available fields with their respective default values:
         prometheus: "quay.io/prometheus/prometheus",
         alertmanager: "quay.io/prometheus/alertmanager",
         kubeStateMetrics: "quay.io/coreos/kube-state-metrics",
-        kubeRbacProxy: "quay.io/coreos/kube-rbac-proxy",
+        kubeRbacProxy: "quay.io/brancz/kube-rbac-proxy",
         nodeExporter: "quay.io/prometheus/node-exporter",
         prometheusOperator: "quay.io/prometheus-operator/prometheus-operator",
     },
@@ -737,6 +738,8 @@ Working examples of use with continuous delivery tools are found in examples/con
 
 ## Troubleshooting
 
+See the general [guidelines](docs/community-support.md) for getting support from the community.
+
 ### Error retrieving kubelet metrics
 
 Should the Prometheus `/targets` page show kubelet targets, but not able to successfully scrape the metrics, then most likely it is a problem with the authentication and authorization setup of the kubelets.
@@ -787,3 +790,7 @@ the following process:
 3. Update the pinned kube-prometheus dependency in `jsonnetfile.lock.json`: `jb update`
 3. Generate dependent `*.yaml` files: `make generate`
 4. Commit the generated changes.
+
+## License
+
+Apache License 2.0, see [LICENSE](https://github.com/prometheus-operator/kube-prometheus/blob/master/LICENSE).

--- a/docs/community-support.md
+++ b/docs/community-support.md
@@ -1,0 +1,84 @@
+# Community support
+
+For bugs, you can use the GitHub [issue tracker](https://github.com/prometheus-operator/kube-prometheus/issues/new/choose).
+
+For questions, you can use the GitHub [discussions forum](https://github.com/prometheus-operator/kube-prometheus/discussions).
+
+Many of the `kube-prometheus` project's contributors and users can also be found on the #prometheus-operator channel of the [Kubernetes Slack][Kubernetes Slack].
+
+`kube-prometheus` is the aggregation of many projects that all have different
+channels to reach out for help and support. This community strives at
+supporting all users and you should never be afraid of asking us first. However
+if your request relates specifically to one of the projects listed below, it is
+often more efficient to reach out to the project directly. If you are unsure,
+please feel free to open an issue in this repository and we will redirect you
+if applicable.
+
+## prometheus-operator
+
+For documentation, check the project's [documentation directory](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation).
+
+For questions, use the #prometheus-operator channel on the [Kubernetes Slack][Kubernetes Slack].
+
+For bugs, use the GitHub [issue tracker](https://github.com/prometheus-operator/prometheus-operator/issues/new/choose).
+
+## Prometheus, Alertmanager, node_exporter
+
+For documentation, check the Prometheus [online docs](https://prometheus.io/docs/). There is a
+[section](https://prometheus.io/docs/introduction/media/) with links to blog
+posts, recorded talks and presentations. This [repository](https://github.com/roaldnefs/awesome-prometheus) 
+(not affiliated to the Prometheus project) has also a list of curated resources
+related to the Prometheus ecosystem.
+
+For questions, see the Prometheus [community page](https://prometheus.io/community/) for the various channels.
+
+There is also a #prometheus channel on the [CNCF Slack][CNCF Slack].
+
+## kube-state-metrics
+
+For documentation, see the project's [docs directory](https://github.com/kubernetes/kube-state-metrics/tree/master/docs).
+
+For questions, use the #kube-state-metrics channel on the [Kubernetes Slack][Kubernetes Slack].
+
+For bugs, use the GitHub [issue tracker](https://github.com/kubernetes/kube-state-metrics/issues/new/choose).
+
+## Kubernetes
+
+For documentation, check the [Kubernetes docs](https://kubernetes.io/docs/home/).
+
+For questions, use the [community forums](https://discuss.kubernetes.io/) and the [Kubernetes Slack][Kubernetes Slack]. Check also the [community page](https://kubernetes.io/community/#discuss).
+
+For bugs, use the GitHub [issue tracker](https://github.com/kubernetes/kubernetes/issues/new/choose).
+
+## Prometheus adapter
+
+For documentation, check the project's [README](https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/master/README.md).
+
+For questions, use the #sig-instrumentation channel on the [Kubernetes Slack][Kubernetes Slack].
+
+For bugs, use the GitHub [issue tracker](https://github.com/DirectXMan12/k8s-prometheus-adapter/issues/new).
+
+## Grafana
+
+For documentation, check the [Grafana docs](https://grafana.com/docs/grafana/latest/).
+
+For questions, use the [community forums](https://community.grafana.com/).
+
+For bugs, use the GitHub [issue tracker](https://github.com/grafana/grafana/issues/new/choose).
+
+## kubernetes-mixin
+
+For documentation, check the project's [README](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/master/README.md).
+
+For questions, use #monitoring-mixins channel on the [Kubernetes Slack][Kubernetes Slack].
+
+For bugs, use the GitHub [issue tracker](https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/new).
+
+## Jsonnet
+
+For documentation, check the [Jsonnet](https://jsonnet.org/) website.
+
+For questions, use the [mailing list](https://groups.google.com/forum/#!forum/jsonnet).
+
+[Kubernetes Slack]: https://slack.k8s.io/
+[CNCF Slack]: https://slack.cncf.io/


### PR DESCRIPTION
This change documents where to find documentation and support for the
various components of kube-prometheus.