### PR TITLE
Provide external-metrics as an add-on

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ local kp =
   // (import 'kube-prometheus/kube-prometheus-static-etcd.libsonnet') +
   // (import 'kube-prometheus/kube-prometheus-thanos-sidecar.libsonnet') +
   // (import 'kube-prometheus/kube-prometheus-custom-metrics.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-external-metrics.libsonnet') +
   {
     _config+:: {
       namespace: 'monitoring',

--- a/docs/developing-prometheus-rules-and-grafana-dashboards.md
+++ b/docs/developing-prometheus-rules-and-grafana-dashboards.md
@@ -19,6 +19,7 @@ local kp =
   // (import 'kube-prometheus/kube-prometheus-static-etcd.libsonnet') +
   // (import 'kube-prometheus/kube-prometheus-thanos-sidecar.libsonnet') +
   // (import 'kube-prometheus/kube-prometheus-custom-metrics.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-external-metrics.libsonnet') +
   {
     _config+:: {
       namespace: 'monitoring',

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -7,6 +7,7 @@ local kp =
   // (import 'kube-prometheus/kube-prometheus-static-etcd.libsonnet') +
   // (import 'kube-prometheus/kube-prometheus-thanos-sidecar.libsonnet') +
   // (import 'kube-prometheus/kube-prometheus-custom-metrics.libsonnet') +
+  // (import 'kube-prometheus/kube-prometheus-external-metrics.libsonnet') +
   {
     _config+:: {
       namespace: 'monitoring',

--- a/jsonnet/kube-prometheus/kube-prometheus-external-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-external-metrics.libsonnet
@@ -1,0 +1,95 @@
+// External metrics API allows the HPA v2 to scale based on metrics coming from outside of Kubernetes cluster
+// For more details on usage visit https://github.com/DirectXMan12/k8s-prometheus-adapter#quick-links
+
+{
+  _config+:: {
+    prometheusAdapter+:: {
+      namespace: $._config.namespace,
+      // Rules for external-metrics
+      config+:: {
+        externalRules+: [
+          // {
+          //   seriesQuery: '{__name__=~"^.*_queue$",namespace!=""}',
+          //   seriesFilters: [],
+          //   resources: {
+          //     overrides: {
+          //       namespace: { resource: 'namespace' }
+          //     },
+          //   },
+          //   name: { matches: '^.*_queue$', as: '$0' },
+          //   metricsQuery: 'max(<<.Series>>{<<.LabelMatchers>>})',
+          // },
+        ],
+      },
+    },
+  },
+
+  prometheusAdapter+:: {
+    externalMetricsApiService: {
+      apiVersion: 'apiregistration.k8s.io/v1',
+      kind: 'APIService',
+      metadata: {
+        name: 'v1beta1.external.metrics.k8s.io',
+      },
+      spec: {
+        service: {
+          name: $.prometheusAdapter.service.metadata.name,
+          namespace: $._config.prometheusAdapter.namespace,
+        },
+        group: 'external.metrics.k8s.io',
+        version: 'v1beta1',
+        insecureSkipTLSVerify: true,
+        groupPriorityMinimum: 100,
+        versionPriority: 100,
+      },
+    },
+    externalMetricsClusterRoleServerResources: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
+      metadata: {
+        name: 'external-metrics-server-resources',
+      },
+      rules: [{
+        apiGroups: ['external.metrics.k8s.io'],
+        resources: ['*'],
+        verbs: ['*'],
+      }],
+    },
+    externalMetricsClusterRoleBindingServerResources: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRoleBinding',
+      metadata: {
+        name: 'external-metrics-server-resources',
+      },
+
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: 'external-metrics-server-resources',
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: $.prometheusAdapter.serviceAccount.metadata.name,
+        namespace: $._config.prometheusAdapter.namespace,
+      }],
+    },
+    externalMetricsClusterRoleBindingHPA: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRoleBinding',
+      metadata: {
+        name: 'hpa-controller-external-metrics',
+      },
+
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: 'external-metrics-server-resources',
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: 'horizontal-pod-autoscaler',
+        namespace: 'kube-system',
+      }],
+    },
+  },
+}


### PR DESCRIPTION
In (#374) we include `custom-metrics` as an add-on. 
Given the fact that doc for `external-metrics` has improved recently [#302](https://github.com/DirectXMan12/k8s-prometheus-adapter/pull/302). I think we can also provide external-metrics as well. 
Before the performance issue is addressed we just keep it as an add-on.
> yes, agreed. I share the same assertion that prometheus-adapter is not production ready yet regarding custom and external metrics.
_Originally posted by @s-urbaniak in https://github.com/prometheus-operator/kube-prometheus/issues/374#issuecomment-573692256_

> The design started it's live here https://github.com/s-urbaniak/prometheus-adapter/blob/master/design.md, along side with an initial implementation (that actually also booted up).
The configmap proposal in that document for resource metrics is actually something I envisioned (aka a nearly zero-config expression of a sample query without templating)
The CRD design for custom and external metrics is TBD, but would follow the same idea above.
_Originally posted by @s-urbaniak in https://github.com/prometheus-operator/kube-prometheus/issues/374#issuecomment-575592123_

I am currently using it in production and looks good so far.