### PR TITLE
Fix cannot find service monitor targets

### DIFF
--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -100,8 +100,8 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
       rules: [
         {
           apiGroups: [''],
-          resources: ['nodes/metrics'],
-          verbs: ['get'],
+          resources: ['nodes/metrics', 'services', 'endpoints', 'pods'],
+          verbs: ['get', 'list'],
         },
         {
           nonResourceURLs: ['/metrics'],

--- a/manifests/prometheus-clusterRole.yaml
+++ b/manifests/prometheus-clusterRole.yaml
@@ -7,8 +7,12 @@ rules:
   - ""
   resources:
   - nodes/metrics
+  - services
+  - endpoints
+  - pods
   verbs:
   - get
+  - list
 - nonResourceURLs:
   - /metrics
   verbs:


### PR DESCRIPTION
If a servicemonitor is created in a namespace other than the default `monitoring` ns, 
the new target cannot be found in prometheus target UI