### PR TITLE
Fix kube rbac proxy UID and GID

### DIFF
--- a/jsonnet/kube-prometheus/kube-rbac-proxy/container.libsonnet
+++ b/jsonnet/kube-prometheus/kube-rbac-proxy/container.libsonnet
@@ -41,7 +41,9 @@
               { name: krp.config.kubeRbacProxy.securePortName, containerPort: krp.config.kubeRbacProxy.securePort },
             ],
             securityContext: {
-              runAsUser: 65534,
+              runAsUser: 65532,
+              runAsGroup: 65532,
+              runAsNonRoot: true,
             },
           }],
         },

--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -103,6 +103,11 @@
           { name: 'https', containerPort: $._config.nodeExporter.port, hostPort: $._config.nodeExporter.port },
         ],
         resources: $._config.resources['kube-rbac-proxy'],
+        securityContext: {
+          runAsUser: 65532,
+          runAsGroup: 65532,
+          runAsNonRoot: true,
+        },
       };
 
       {

--- a/manifests/kube-state-metrics-deployment.yaml
+++ b/manifests/kube-state-metrics-deployment.yaml
@@ -36,7 +36,9 @@ spec:
         - containerPort: 8443
           name: https-main
         securityContext:
-          runAsUser: 65534
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       - args:
         - --logtostderr
         - --secure-listen-address=:9443
@@ -48,7 +50,9 @@ spec:
         - containerPort: 9443
           name: https-self
         securityContext:
-          runAsUser: 65534
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: kube-state-metrics

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -70,6 +70,10 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        securityContext:
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       hostNetwork: true
       hostPID: true
       nodeSelector:

--- a/manifests/setup/prometheus-operator-deployment.yaml
+++ b/manifests/setup/prometheus-operator-deployment.yaml
@@ -50,7 +50,9 @@ spec:
         - containerPort: 8443
           name: https
         securityContext:
-          runAsUser: 65534
+          runAsGroup: 65532
+          runAsNonRoot: true
+          runAsUser: 65532
       nodeSelector:
         beta.kubernetes.io/os: linux
       securityContext:


### PR DESCRIPTION
kube-rbac-proxy is running as [UID 65532 and GID 65532](https://github.com/brancz/kube-rbac-proxy/blob/master/Dockerfile#L6) and not 65534. This can lead to container crash looping as seen in #791.

Fixes #791