### PR TITLE
Add GKE patch

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-gke.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-gke.libsonnet
@@ -1,0 +1,13 @@
+(import './kube-prometheus-managed-cluster.libsonnet') + {
+  _config+:: {
+    prometheusAdapter+:: {
+      config+: {
+        resourceRules:: null,
+      },
+    },
+  },
+
+  prometheusAdapter+:: {
+    apiService:: null,
+  },
+}


### PR DESCRIPTION
Follow up from https://github.com/prometheus-operator/prometheus-operator/issues/2211

GKE enforces `metrics-server` to be used and there is nothing we can do against that, so for GKE we should disable the resource metrics API.

cc @lilic @paulfantom @simonpasquier 

Tested on @polarsignals prod cluster :wink: 