### PR TITLE
Bump grafana to v7.3.5

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -115,7 +115,7 @@ local kubeRbacProxyContainer = import './kube-rbac-proxy/container.libsonnet';
   _config+:: {
     namespace: 'default',
 
-    versions+:: { grafana: '7.3.4', kubeRbacProxy: 'v0.8.0' },
+    versions+:: { grafana: '7.3.5', kubeRbacProxy: 'v0.8.0' },
     imageRepos+:: { kubeRbacProxy: 'quay.io/brancz/kube-rbac-proxy' },
 
     tlsCipherSuites: [

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - env: []
-        image: grafana/grafana:7.3.4
+        image: grafana/grafana:7.3.5
         name: grafana
         ports:
         - containerPort: 3000


### PR DESCRIPTION
This new version includes the following bug fixes: https://github.com/grafana/grafana/releases/tag/v7.3.5