### PR TITLE
Cherry pick of #481: Allow to configure EKS available IPs alert

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-eks.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-eks.libsonnet
@@ -3,6 +3,12 @@ local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 
 {
+  _config+:: {
+    eks: {
+      minimumAvailableIPs: 10,
+      minimumAvailableIPsTime: '10m'
+    }
+  },
   prometheus+: {
     serviceMonitorCoreDNS+: {
         spec+: {
@@ -59,14 +65,14 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
         name: 'kube-prometheus-eks.rules',
         rules: [
           {
-            expr: 'sum by(instance) (awscni_total_ip_addresses) - sum by(instance) (awscni_assigned_ip_addresses) < 10',
+            expr: 'sum by(instance) (awscni_total_ip_addresses) - sum by(instance) (awscni_assigned_ip_addresses) < %s' % $._config.eks.minimumAvailableIPs,
             labels: {
               severity: 'critical',
             },
             annotations: {
               message: 'Instance {{ $labels.instance }} has less than 10 IPs available.'
             },
-            'for': '10m',
+            'for': $._config.eks.minimumAvailableIPsTime,
             alert: 'EksAvailableIPs'
           },
         ],


### PR DESCRIPTION
Cherry pick #481 into `release-0.4` to smoother upgrade from 0.3.

It is available from `release-0.5` and was cherry picked into `release-0.3`, leaving a gap in 0.4.