### PR TITLE
jsonnet: add missing labels

### DIFF
--- a/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/alertmanager/alertmanager.libsonnet
@@ -52,9 +52,9 @@
       },
       replicas: 3,
       labels: {
-        'app.kubernetes.io/name': 'alertmanager-' + $._config.alertmanager.name,
+        'app.kubernetes.io/name': 'alertmanager',
         'app.kubernetes.io/version': $._config.versions.alertmanager,
-        'app.kubernetes.io/component': 'router',
+        'app.kubernetes.io/component': 'alert-router',
         'app.kubernetes.io/part-of': 'kube-prometheus',
       },
       selectorLabels: {
@@ -73,6 +73,7 @@
       metadata: {
         name: 'alertmanager-' + $._config.alertmanager.name,
         namespace: $._config.namespace,
+        labels: { alertmanager: $._config.alertmanager.name } + $._config.alertmanager.labels,
       },
       stringData: {
         'alertmanager.yaml': if std.type($._config.alertmanager.config) == 'object'
@@ -89,6 +90,7 @@
       metadata: {
         name: 'alertmanager-' + $._config.alertmanager.name,
         namespace: $._config.namespace,
+        labels: { alertmanager: $._config.alertmanager.name } + $._config.alertmanager.labels,
       },
     },
 
@@ -106,7 +108,7 @@
         ],
         selector: {
           app: 'alertmanager',
-          alertmanager: $._config.alertmanager.name
+          alertmanager: $._config.alertmanager.name,
         } + $._config.alertmanager.selectorLabels,
         sessionAffinity: 'ClientIP',
       },

--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -86,6 +86,7 @@ local kubeRbacProxyContainer = import './kube-rbac-proxy/container.libsonnet';
 
   grafana+:: {
     local dashboardDefinitions = super.dashboardDefinitions,
+
     dashboardDefinitions: {
       apiVersion: 'v1',
       kind: 'ConfigMapList',
@@ -97,6 +98,7 @@ local kubeRbacProxyContainer = import './kube-rbac-proxy/container.libsonnet';
       metadata: {
         name: 'grafana',
         namespace: $._config.namespace,
+        labels: $._config.grafana.labels,
       },
       spec: {
         selector: {
@@ -200,6 +202,14 @@ local kubeRbacProxyContainer = import './kube-rbac-proxy/container.libsonnet';
       },
     },
     prometheus+:: { rules: $.prometheusRules + $.prometheusAlerts },
-    grafana+:: { dashboards: $.grafanaDashboards },
+    grafana+:: {
+      labels: {
+        'app.kubernetes.io/name': 'grafana',
+        'app.kubernetes.io/version': $._config.versions.grafana,
+        'app.kubernetes.io/component': 'grafana',
+        'app.kubernetes.io/part-of': 'kube-prometheus',
+      },
+      dashboards: $.grafanaDashboards,
+    },
   },
 }

--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -27,6 +27,7 @@
       kind: 'ClusterRoleBinding',
       metadata: {
         name: 'node-exporter',
+        labels: $._config.nodeExporter.labels,
       },
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',
@@ -45,6 +46,7 @@
       kind: 'ClusterRole',
       metadata: {
         name: 'node-exporter',
+        labels: $._config.nodeExporter.labels,
       },
       rules: [
         {
@@ -157,6 +159,7 @@
       metadata: {
         name: 'node-exporter',
         namespace: $._config.namespace,
+        labels: $._config.nodeExporter.labels,
       },
     },
 

--- a/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus-adapter/prometheus-adapter.libsonnet
@@ -9,7 +9,7 @@
       name: 'prometheus-adapter',
       namespace: $._config.namespace,
       labels: {
-        'app.kubernetes.io/name': $._config.prometheusAdapter.name,
+        'app.kubernetes.io/name': 'prometheus-adapter',
         'app.kubernetes.io/version': $._config.versions.prometheusAdapter,
         'app.kubernetes.io/component': 'metrics-adapter',
         'app.kubernetes.io/part-of': 'kube-prometheus',
@@ -58,6 +58,7 @@
       kind: 'APIService',
       metadata: {
         name: 'v1beta1.metrics.k8s.io',
+        labels: $._config.prometheusAdapter.labels,
       },
       spec: {
         service: {
@@ -78,6 +79,7 @@
       metadata: {
         name: 'adapter-config',
         namespace: $._config.prometheusAdapter.namespace,
+        labels: $._config.prometheusAdapter.labels,
       },
       data: { 'config.yaml': std.manifestYamlDoc($._config.prometheusAdapter.config) },
     },
@@ -150,6 +152,7 @@
         metadata: {
           name: $._config.prometheusAdapter.name,
           namespace: $._config.prometheusAdapter.namespace,
+          labels: $._config.prometheusAdapter.labels,
         },
         spec: {
           replicas: 1,
@@ -182,6 +185,7 @@
       metadata: {
         name: $._config.prometheusAdapter.name,
         namespace: $._config.prometheusAdapter.namespace,
+        labels: $._config.prometheusAdapter.labels,
       },
     },
 
@@ -190,6 +194,7 @@
       kind: 'ClusterRole',
       metadata: {
         name: $._config.prometheusAdapter.name,
+        labels: $._config.prometheusAdapter.labels,
       },
       rules: [{
         apiGroups: [''],
@@ -203,6 +208,7 @@
       kind: 'ClusterRoleBinding',
       metadata: {
         name: $._config.prometheusAdapter.name,
+        labels: $._config.prometheusAdapter.labels,
       },
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',
@@ -221,6 +227,7 @@
       kind: 'ClusterRoleBinding',
       metadata: {
         name: 'resource-metrics:system:auth-delegator',
+        labels: $._config.prometheusAdapter.labels,
       },
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',
@@ -239,6 +246,7 @@
       kind: 'ClusterRole',
       metadata: {
         name: 'resource-metrics-server-resources',
+        labels: $._config.prometheusAdapter.labels,
       },
       rules: [{
         apiGroups: ['metrics.k8s.io'],
@@ -256,7 +264,7 @@
           'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
           'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
           'rbac.authorization.k8s.io/aggregate-to-view': 'true',
-        },
+        } + $._config.prometheusAdapter.labels,
       },
       rules: [{
         apiGroups: ['metrics.k8s.io'],
@@ -271,6 +279,7 @@
       metadata: {
         name: 'resource-metrics-auth-reader',
         namespace: 'kube-system',
+        labels: $._config.prometheusAdapter.labels,
       },
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',

--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -14,7 +14,7 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
       rules: {},
       namespaces: ['default', 'kube-system', $._config.namespace],
       labels: {
-        'app.kubernetes.io/name': 'prometheus-' + $._config.prometheus.name,
+        'app.kubernetes.io/name': 'prometheus',
         'app.kubernetes.io/version': $._config.versions.prometheus,
         'app.kubernetes.io/component': 'prometheus',
         'app.kubernetes.io/part-of': 'kube-prometheus',
@@ -43,6 +43,7 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
       metadata: {
         name: 'prometheus-' + p.name,
         namespace: p.namespace,
+        labels: $._config.prometheus.labels,
       },
     },
 
@@ -70,7 +71,7 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
         labels: {
           prometheus: p.name,
           role: 'alert-rules',
-        },
+        } + $._config.prometheus.labels,
         name: 'prometheus-' + p.name + '-rules',
         namespace: p.namespace,
       },
@@ -86,6 +87,7 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
         metadata: {
           name: 'prometheus-' + p.name,
           namespace: namespace,
+          labels: $._config.prometheus.labels,
         },
         roleRef: {
           apiGroup: 'rbac.authorization.k8s.io',
@@ -107,7 +109,10 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
     clusterRole: {
       apiVersion: 'rbac.authorization.k8s.io/v1',
       kind: 'ClusterRole',
-      metadata: { name: 'prometheus-' + p.name },
+      metadata: {
+        name: 'prometheus-' + p.name,
+        labels: $._config.prometheus.labels,
+      },
       rules: [
         {
           apiGroups: [''],
@@ -127,6 +132,7 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
       metadata: {
         name: 'prometheus-' + p.name + '-config',
         namespace: p.namespace,
+        labels: $._config.prometheus.labels,
       },
       rules: [{
         apiGroups: [''],
@@ -141,6 +147,7 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
       metadata: {
         name: 'prometheus-' + p.name + '-config',
         namespace: p.namespace,
+        labels: $._config.prometheus.labels,
       },
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',
@@ -157,7 +164,10 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
     clusterRoleBinding: {
       apiVersion: 'rbac.authorization.k8s.io/v1',
       kind: 'ClusterRoleBinding',
-      metadata: { name: 'prometheus-' + p.name },
+      metadata: {
+        name: 'prometheus-' + p.name,
+        labels: $._config.prometheus.labels,
+      },
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',
         kind: 'ClusterRole',
@@ -177,6 +187,7 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
         metadata: {
           name: 'prometheus-' + p.name,
           namespace: namespace,
+          labels: $._config.prometheus.labels,
         },
         rules: [
           {
@@ -210,7 +221,7 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
         version: $._config.versions.prometheus,
         image: $._config.imageRepos.prometheus + ':' + $._config.versions.prometheus,
         podMetadata: {
-          labels: $._config.prometheus.labels
+          labels: $._config.prometheus.labels,
         },
         serviceAccountName: 'prometheus-' + p.name,
         serviceMonitorSelector: {},

--- a/manifests/alertmanager-alertmanager.yaml
+++ b/manifests/alertmanager-alertmanager.yaml
@@ -3,8 +3,8 @@ kind: Alertmanager
 metadata:
   labels:
     alertmanager: main
-    app.kubernetes.io/component: router
-    app.kubernetes.io/name: alertmanager-main
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: v0.21.0
   name: main
@@ -15,8 +15,8 @@ spec:
     kubernetes.io/os: linux
   podMetadata:
     labels:
-      app.kubernetes.io/component: router
-      app.kubernetes.io/name: alertmanager-main
+      app.kubernetes.io/component: alert-router
+      app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: v0.21.0
   replicas: 3

--- a/manifests/alertmanager-secret.yaml
+++ b/manifests/alertmanager-secret.yaml
@@ -1,6 +1,12 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  labels:
+    alertmanager: main
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v0.21.0
   name: alertmanager-main
   namespace: monitoring
 stringData:

--- a/manifests/alertmanager-service.yaml
+++ b/manifests/alertmanager-service.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   labels:
     alertmanager: main
-    app.kubernetes.io/component: router
-    app.kubernetes.io/name: alertmanager-main
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: v0.21.0
   name: alertmanager-main
@@ -17,7 +17,7 @@ spec:
   selector:
     alertmanager: main
     app: alertmanager
-    app.kubernetes.io/component: router
-    app.kubernetes.io/name: alertmanager-main
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
   sessionAffinity: ClientIP

--- a/manifests/alertmanager-serviceAccount.yaml
+++ b/manifests/alertmanager-serviceAccount.yaml
@@ -1,5 +1,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    alertmanager: main
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v0.21.0
   name: alertmanager-main
   namespace: monitoring

--- a/manifests/alertmanager-serviceMonitor.yaml
+++ b/manifests/alertmanager-serviceMonitor.yaml
@@ -2,8 +2,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/component: router
-    app.kubernetes.io/name: alertmanager-main
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: v0.21.0
   name: alertmanager
@@ -15,6 +15,6 @@ spec:
   selector:
     matchLabels:
       alertmanager: main
-      app.kubernetes.io/component: router
-      app.kubernetes.io/name: alertmanager-main
+      app.kubernetes.io/component: alert-router
+      app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: kube-prometheus

--- a/manifests/grafana-serviceMonitor.yaml
+++ b/manifests/grafana-serviceMonitor.yaml
@@ -1,6 +1,11 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
+  labels:
+    app.kubernetes.io/component: grafana
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 7.3.5
   name: grafana
   namespace: monitoring
 spec:

--- a/manifests/node-exporter-clusterRole.yaml
+++ b/manifests/node-exporter-clusterRole.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v1.0.1
   name: node-exporter
 rules:
 - apiGroups:

--- a/manifests/node-exporter-clusterRoleBinding.yaml
+++ b/manifests/node-exporter-clusterRoleBinding.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v1.0.1
   name: node-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/node-exporter-serviceAccount.yaml
+++ b/manifests/node-exporter-serviceAccount.yaml
@@ -1,5 +1,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v1.0.1
   name: node-exporter
   namespace: monitoring

--- a/manifests/prometheus-adapter-apiService.yaml
+++ b/manifests/prometheus-adapter-apiService.yaml
@@ -1,6 +1,11 @@
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v0.8.2
   name: v1beta1.metrics.k8s.io
 spec:
   group: metrics.k8s.io

--- a/manifests/prometheus-adapter-clusterRole.yaml
+++ b/manifests/prometheus-adapter-clusterRole.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v0.8.2
   name: prometheus-adapter
 rules:
 - apiGroups:

--- a/manifests/prometheus-adapter-clusterRoleAggregatedMetricsReader.yaml
+++ b/manifests/prometheus-adapter-clusterRoleAggregatedMetricsReader.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v0.8.2
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/manifests/prometheus-adapter-clusterRoleBinding.yaml
+++ b/manifests/prometheus-adapter-clusterRoleBinding.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v0.8.2
   name: prometheus-adapter
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/prometheus-adapter-clusterRoleBindingDelegator.yaml
+++ b/manifests/prometheus-adapter-clusterRoleBindingDelegator.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v0.8.2
   name: resource-metrics:system:auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/prometheus-adapter-clusterRoleServerResources.yaml
+++ b/manifests/prometheus-adapter-clusterRoleServerResources.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v0.8.2
   name: resource-metrics-server-resources
 rules:
 - apiGroups:

--- a/manifests/prometheus-adapter-configMap.yaml
+++ b/manifests/prometheus-adapter-configMap.yaml
@@ -29,5 +29,10 @@ data:
       "window": "5m"
 kind: ConfigMap
 metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v0.8.2
   name: adapter-config
   namespace: monitoring

--- a/manifests/prometheus-adapter-deployment.yaml
+++ b/manifests/prometheus-adapter-deployment.yaml
@@ -1,6 +1,11 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v0.8.2
   name: prometheus-adapter
   namespace: monitoring
 spec:

--- a/manifests/prometheus-adapter-roleBindingAuthReader.yaml
+++ b/manifests/prometheus-adapter-roleBindingAuthReader.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v0.8.2
   name: resource-metrics-auth-reader
   namespace: kube-system
 roleRef:

--- a/manifests/prometheus-adapter-serviceAccount.yaml
+++ b/manifests/prometheus-adapter-serviceAccount.yaml
@@ -1,5 +1,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v0.8.2
   name: prometheus-adapter
   namespace: monitoring

--- a/manifests/prometheus-clusterRole.yaml
+++ b/manifests/prometheus-clusterRole.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v2.22.1
   name: prometheus-k8s
 rules:
 - apiGroups:

--- a/manifests/prometheus-clusterRoleBinding.yaml
+++ b/manifests/prometheus-clusterRoleBinding.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v2.22.1
   name: prometheus-k8s
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/prometheus-prometheus.yaml
+++ b/manifests/prometheus-prometheus.yaml
@@ -3,7 +3,7 @@ kind: Prometheus
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/name: prometheus-k8s
+    app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: v2.22.1
     prometheus: k8s
@@ -21,7 +21,7 @@ spec:
   podMetadata:
     labels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/name: prometheus-k8s
+      app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: v2.22.1
   podMonitorNamespaceSelector: {}

--- a/manifests/prometheus-roleBindingConfig.yaml
+++ b/manifests/prometheus-roleBindingConfig.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v2.22.1
   name: prometheus-k8s-config
   namespace: monitoring
 roleRef:

--- a/manifests/prometheus-roleBindingSpecificNamespaces.yaml
+++ b/manifests/prometheus-roleBindingSpecificNamespaces.yaml
@@ -3,6 +3,11 @@ items:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
+    labels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: kube-prometheus
+      app.kubernetes.io/version: v2.22.1
     name: prometheus-k8s
     namespace: default
   roleRef:
@@ -16,6 +21,11 @@ items:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
+    labels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: kube-prometheus
+      app.kubernetes.io/version: v2.22.1
     name: prometheus-k8s
     namespace: kube-system
   roleRef:
@@ -29,6 +39,11 @@ items:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:
+    labels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: kube-prometheus
+      app.kubernetes.io/version: v2.22.1
     name: prometheus-k8s
     namespace: monitoring
   roleRef:

--- a/manifests/prometheus-roleConfig.yaml
+++ b/manifests/prometheus-roleConfig.yaml
@@ -1,6 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v2.22.1
   name: prometheus-k8s-config
   namespace: monitoring
 rules:

--- a/manifests/prometheus-roleSpecificNamespaces.yaml
+++ b/manifests/prometheus-roleSpecificNamespaces.yaml
@@ -3,6 +3,11 @@ items:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
+    labels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: kube-prometheus
+      app.kubernetes.io/version: v2.22.1
     name: prometheus-k8s
     namespace: default
   rules:
@@ -27,6 +32,11 @@ items:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
+    labels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: kube-prometheus
+      app.kubernetes.io/version: v2.22.1
     name: prometheus-k8s
     namespace: kube-system
   rules:
@@ -51,6 +61,11 @@ items:
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
+    labels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: kube-prometheus
+      app.kubernetes.io/version: v2.22.1
     name: prometheus-k8s
     namespace: monitoring
   rules:

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -2,6 +2,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v2.22.1
     prometheus: k8s
     role: alert-rules
   name: prometheus-k8s-rules

--- a/manifests/prometheus-service.yaml
+++ b/manifests/prometheus-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/name: prometheus-k8s
+    app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: v2.22.1
     prometheus: k8s
@@ -17,7 +17,7 @@ spec:
   selector:
     app: prometheus
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/name: prometheus-k8s
+    app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     prometheus: k8s
   sessionAffinity: ClientIP

--- a/manifests/prometheus-serviceAccount.yaml
+++ b/manifests/prometheus-serviceAccount.yaml
@@ -1,5 +1,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: v2.22.1
   name: prometheus-k8s
   namespace: monitoring

--- a/manifests/prometheus-serviceMonitor.yaml
+++ b/manifests/prometheus-serviceMonitor.yaml
@@ -3,7 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
-    app.kubernetes.io/name: prometheus-k8s
+    app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: v2.22.1
   name: prometheus
@@ -15,6 +15,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus
-      app.kubernetes.io/name: prometheus-k8s
+      app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
       prometheus: k8s


### PR DESCRIPTION
This is a follow-up to https://github.com/prometheus-operator/kube-prometheus/pull/832. After merging this and bringing in https://github.com/brancz/kubernetes-grafana/pull/109 all objects should have recommended labels set.