### PR TITLE
node-exporter: do not mount /proc as it is covered by hostPID

### DIFF
--- a/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/node-exporter/node-exporter.libsonnet
@@ -66,7 +66,6 @@
         image: $._config.imageRepos.nodeExporter + ':' + $._config.versions.nodeExporter,
         args: [
           '--web.listen-address=' + std.join(':', [$._config.nodeExporter.listenAddress, std.toString($._config.nodeExporter.port)]),
-          '--path.procfs=/host/proc',
           '--path.sysfs=/host/sys',
           '--path.rootfs=/host/root',
           '--no-collector.wifi',
@@ -74,7 +73,6 @@
           '--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)',
         ],
         volumeMounts: [
-          { name: 'proc', mountPath: '/host/proc', mountPropagation: 'HostToContainer', readOnly: true },
           { name: 'sys', mountPath: '/host/sys', mountPropagation: 'HostToContainer', readOnly: true },
           { name: 'root', mountPath: '/host/root', mountPropagation: 'HostToContainer', readOnly: true },
         ],
@@ -135,7 +133,6 @@
               }],
               containers: [nodeExporter, proxy],
               volumes: [
-                { name: 'proc', hostPath: { path: '/proc' } },
                 { name: 'sys', hostPath: { path: '/sys' } },
                 { name: 'root', hostPath: { path: '/' } },
               ],

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -25,7 +25,6 @@ spec:
       containers:
       - args:
         - --web.listen-address=127.0.0.1:9100
-        - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
         - --path.rootfs=/host/root
         - --no-collector.wifi
@@ -41,10 +40,6 @@ spec:
             cpu: 102m
             memory: 180Mi
         volumeMounts:
-        - mountPath: /host/proc
-          mountPropagation: HostToContainer
-          name: proc
-          readOnly: true
         - mountPath: /host/sys
           mountPropagation: HostToContainer
           name: sys
@@ -91,9 +86,6 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
-      - hostPath:
-          path: /proc
-        name: proc
       - hostPath:
           path: /sys
         name: sys


### PR DESCRIPTION
Fixes #842