### PR TITLE
Update prometheus-rules.yaml

### DIFF
--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -1416,9 +1416,13 @@ spec:
         runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/kubehpamaxedout
         summary: HPA is running at max replicas
       expr: |
-        kube_hpa_status_current_replicas{job="kube-state-metrics"}
+        (kube_hpa_status_current_replicas{job="kube-state-metrics"}
           ==
-        kube_hpa_spec_max_replicas{job="kube-state-metrics"}
+        kube_hpa_spec_max_replicas{job="kube-state-metrics"})
+        and 
+        (kube_hpa_spec_min_replicas{job="kube-state-metrics"})
+          !=
+        kube_hpa_spec_max_replicas{job="kube-state-metrics"})
       for: 15m
       labels:
         severity: warning

--- a/manifests/prometheus-rules.yaml
+++ b/manifests/prometheus-rules.yaml
@@ -1419,8 +1419,8 @@ spec:
         (kube_hpa_status_current_replicas{job="kube-state-metrics"}
           ==
         kube_hpa_spec_max_replicas{job="kube-state-metrics"})
-        and 
-        (kube_hpa_spec_min_replicas{job="kube-state-metrics"})
+          and
+        (kube_hpa_spec_min_replicas{job="kube-state-metrics"}
           !=
         kube_hpa_spec_max_replicas{job="kube-state-metrics"})
       for: 15m


### PR DESCRIPTION
fix HPAMaxedOut alert. If max and min hpa values are equal, it shouldn't fire alert or warning