### PR TITLE
blackbox-exporter: Prefer ipv4 by default in probe config

### DIFF
--- a/jsonnet/kube-prometheus/blackbox-exporter/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/blackbox-exporter/blackbox-exporter.libsonnet
@@ -34,15 +34,22 @@ local kubeRbacProxyContainer = import '../kube-rbac-proxy/container.libsonnet';
       modules: {
         http_2xx: {
           prober: 'http',
+          http: {
+            preferred_ip_protocol: 'ip4',
+          },
         },
         http_post_2xx: {
           prober: 'http',
           http: {
             method: 'POST',
+            preferred_ip_protocol: 'ip4',
           },
         },
         tcp_connect: {
           prober: 'tcp',
+          tcp: {
+            preferred_ip_protocol: 'ip4',
+          },
         },
         pop3s_banner: {
           prober: 'tcp',
@@ -54,6 +61,7 @@ local kubeRbacProxyContainer = import '../kube-rbac-proxy/container.libsonnet';
             tls_config: {
               insecure_skip_verify: false,
             },
+            preferred_ip_protocol: 'ip4',
           },
         },
         ssh_banner: {
@@ -62,6 +70,7 @@ local kubeRbacProxyContainer = import '../kube-rbac-proxy/container.libsonnet';
             query_response: [
               { expect: '^SSH-2.0-' },
             ],
+            preferred_ip_protocol: 'ip4',
           },
         },
         irc_banner: {
@@ -73,6 +82,7 @@ local kubeRbacProxyContainer = import '../kube-rbac-proxy/container.libsonnet';
               { expect: 'PING :([^ ]+)', send: 'PONG ${1}' },
               { expect: '^:[^ ]+ 001' },
             ],
+            preferred_ip_protocol: 'ip4',
           },
         },
       },

--- a/manifests/blackbox-exporter-configuration.yaml
+++ b/manifests/blackbox-exporter-configuration.yaml
@@ -3,14 +3,18 @@ data:
   config.yml: |-
     "modules":
       "http_2xx":
+        "http":
+          "preferred_ip_protocol": "ip4"
         "prober": "http"
       "http_post_2xx":
         "http":
           "method": "POST"
+          "preferred_ip_protocol": "ip4"
         "prober": "http"
       "irc_banner":
         "prober": "tcp"
         "tcp":
+          "preferred_ip_protocol": "ip4"
           "query_response":
           - "send": "NICK prober"
           - "send": "USER prober prober prober :prober"
@@ -20,6 +24,7 @@ data:
       "pop3s_banner":
         "prober": "tcp"
         "tcp":
+          "preferred_ip_protocol": "ip4"
           "query_response":
           - "expect": "^+OK"
           "tls": true
@@ -28,10 +33,13 @@ data:
       "ssh_banner":
         "prober": "tcp"
         "tcp":
+          "preferred_ip_protocol": "ip4"
           "query_response":
           - "expect": "^SSH-2.0-"
       "tcp_connect":
         "prober": "tcp"
+        "tcp":
+          "preferred_ip_protocol": "ip4"
 kind: ConfigMap
 metadata:
   name: blackbox-exporter-configuration


### PR DESCRIPTION
As I was setting up probes for the Polar Signals production cluster, I noticed that the default configuration we have in kube-prometheus prefers ipv6 only, and fails the probes when only ipv4 is available. This patch reverses this.

@prometheus-operator/kube-prometheus-reviewers 