### PR TITLE
kubelet: Revert label selector

### DIFF
--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -309,7 +309,7 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
         labels: { 'app.kubernetes.io/name': 'kubelet' },
       },
       spec: {
-        jobLabel: 'app.kubernetes.io/name',
+        jobLabel: 'k8s-app',
         endpoints: [
           {
             port: 'https-metrics',
@@ -364,7 +364,7 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
           },
         ],
         selector: {
-          matchLabels: { 'app.kubernetes.io/name': 'kubelet' },
+          matchLabels: { 'k8s-app': 'kubelet' },
         },
         namespaceSelector: {
           matchNames: ['kube-system'],

--- a/manifests/prometheus-serviceMonitorKubelet.yaml
+++ b/manifests/prometheus-serviceMonitorKubelet.yaml
@@ -81,10 +81,10 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: k8s-app
   namespaceSelector:
     matchNames:
     - kube-system
   selector:
     matchLabels:
-      app.kubernetes.io/name: kubelet
+      k8s-app: kubelet


### PR DESCRIPTION
The Kubelet's Service/Endpoints object maintained by the Prometheus
Operator does not have the recommended app label (yet). Therefore we
need to use the old label until a Prometheus Operator version has been
released and integrated in kube-promteheus that does use it.

@prometheus-operator/kube-prometheus-reviewers 

Related to https://github.com/prometheus-operator/prometheus-operator/pull/3768