### PR TITLE
Remove mutating global state in blackbox-exporter objects

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus.libsonnet
@@ -5,11 +5,12 @@ local alertmanager = import './alertmanager/alertmanager.libsonnet';
 
 local prometheusAdapter = import './prometheus-adapter/prometheus-adapter.libsonnet';
 
+local blackboxExporter = import './blackbox-exporter/blackbox-exporter.libsonnet';
+
 (import 'github.com/brancz/kubernetes-grafana/grafana/grafana.libsonnet') +
 (import './kube-state-metrics/kube-state-metrics.libsonnet') +
 (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-state-metrics-mixin/mixin.libsonnet') +
 (import 'github.com/prometheus/node_exporter/docs/node-mixin/mixin.libsonnet') +
-(import './blackbox-exporter/blackbox-exporter.libsonnet') +
 (import 'github.com/prometheus/alertmanager/doc/alertmanager-mixin/mixin.libsonnet') +
 (import 'github.com/prometheus-operator/prometheus-operator/jsonnet/prometheus-operator/prometheus-operator.libsonnet') +
 (import 'github.com/prometheus-operator/prometheus-operator/jsonnet/mixin/mixin.libsonnet') +
@@ -35,6 +36,11 @@ local prometheusAdapter = import './prometheus-adapter/prometheus-adapter.libson
     version: '0.8.2',
     image: 'directxman12/k8s-prometheus-adapter:v0.8.2',
     prometheusURL: 'http://prometheus-' + $._config.prometheus.name + '.' + $._config.namespace + '.svc.cluster.local:9090/',
+  }),
+  blackboxExporter: blackboxExporter({
+    namespace: $._config.namespace,
+    version: '0.18.0',
+    image: 'quay.io/prometheus/blackbox-exporter:v0.18.0',
   }),
   kubePrometheus+:: {
     namespace: {

--- a/manifests/blackbox-exporter-configuration.yaml
+++ b/manifests/blackbox-exporter-configuration.yaml
@@ -42,5 +42,10 @@ data:
           "preferred_ip_protocol": "ip4"
 kind: ConfigMap
 metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: blackbox-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.18.0
   name: blackbox-exporter-configuration
   namespace: monitoring

--- a/manifests/blackbox-exporter-deployment.yaml
+++ b/manifests/blackbox-exporter-deployment.yaml
@@ -2,20 +2,26 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
+    app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.18.0
   name: blackbox-exporter
   namespace: monitoring
 spec:
   replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/component: exporter
       app.kubernetes.io/name: blackbox-exporter
+      app.kubernetes.io/part-of: kube-prometheus
   template:
     metadata:
       labels:
+        app.kubernetes.io/component: exporter
         app.kubernetes.io/name: blackbox-exporter
-        app.kubernetes.io/version: v0.18.0
+        app.kubernetes.io/part-of: kube-prometheus
+        app.kubernetes.io/version: 0.18.0
     spec:
       containers:
       - args:
@@ -71,6 +77,13 @@ spec:
         ports:
         - containerPort: 9115
           name: https
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
         securityContext:
           runAsGroup: 65532
           runAsNonRoot: true

--- a/manifests/blackbox-exporter-service.yaml
+++ b/manifests/blackbox-exporter-service.yaml
@@ -2,8 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.18.0
   name: blackbox-exporter
   namespace: monitoring
 spec:
@@ -15,4 +17,6 @@ spec:
     port: 19115
     targetPort: http
   selector:
+    app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
+    app.kubernetes.io/part-of: kube-prometheus

--- a/manifests/blackbox-exporter-serviceMonitor.yaml
+++ b/manifests/blackbox-exporter-serviceMonitor.yaml
@@ -2,8 +2,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
+    app.kubernetes.io/component: exporter
     app.kubernetes.io/name: blackbox-exporter
-    app.kubernetes.io/version: v0.18.0
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.18.0
   name: blackbox-exporter
   namespace: monitoring
 spec:
@@ -17,4 +19,6 @@ spec:
       insecureSkipVerify: true
   selector:
     matchLabels:
+      app.kubernetes.io/component: exporter
       app.kubernetes.io/name: blackbox-exporter
+      app.kubernetes.io/part-of: kube-prometheus


### PR DESCRIPTION
Same as #857 but for blackbox-exporter.

Additionally this adds resource requests/limits for kube-rbac-proxy and unifies assigning labels for objects.

Part of #566.

WIP until #857 is merged and I rebase this PR.