### PR TITLE
remove virtual interfaces from node_exporter metrics

### DIFF
--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -172,6 +172,9 @@ function(params) {
         '--no-collector.wifi',
         '--no-collector.hwmon',
         '--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)',
+        '--collector.netclass.ignored-devices=^(veth.*)$',
+        '--collector.netdev.device-blacklist=^(veth.*)$',
+        // '--collector.netdev.device-exclude=^(veth.*)$', // TODO(paulfantom): change with next version of node_exporter (post 1.0.1)
       ],
       volumeMounts: [
         { name: 'sys', mountPath: '/host/sys', mountPropagation: 'HostToContainer', readOnly: true },

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -30,6 +30,8 @@ spec:
         - --no-collector.wifi
         - --no-collector.hwmon
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
+        - --collector.netclass.ignored-devices=^(veth.*)$
+        - --collector.netdev.device-blacklist=^(veth.*)$
         image: quay.io/prometheus/node-exporter:v1.0.1
         name: node-exporter
         resources:


### PR DESCRIPTION
Since networking data for pods is gathered directly from kubelet (by cadvisor) there is no need for duplicating that data by collecting it from veth interfaces via node_exporter

/cc @simonpasquier 

Signed-off-by: paulfantom <pawel@krupa.net.pl>