### PR TITLE
jsonnet: Upgrade configmap-reload image to v0.5.0 to fix CVE

### DIFF
--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -20,7 +20,7 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if !std.setMember(labelName, ['app.kubernetes.io/version'])
   },
-  configmapReloaderImage: 'jimmidyson/configmap-reload:v0.4.0',
+  configmapReloaderImage: 'jimmidyson/configmap-reload:v0.5.0',
 
   port: 9115,
   internalPort: 19115,

--- a/manifests/blackbox-exporter-deployment.yaml
+++ b/manifests/blackbox-exporter-deployment.yaml
@@ -49,7 +49,7 @@ spec:
       - args:
         - --webhook-url=http://localhost:19115/-/reload
         - --volume-dir=/etc/blackbox_exporter/
-        image: jimmidyson/configmap-reload:v0.4.0
+        image: jimmidyson/configmap-reload:v0.5.0
         name: module-configmap-reloader
         resources:
           limits:


### PR DESCRIPTION
This PR upgrades to jimmidyson/configmap-reload:v0.5.0 which includes updated busybox, fixing a [CVE](https://nvd.nist.gov/vuln/detail/CVE-2018-1000500) that was present in old vesions of busybox.