### PR TITLE
Default alerting to Alertmanager API v2

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -251,6 +251,7 @@ function(params) {
           namespace: p.config.namespace,
           name: 'alertmanager-' + p.config.alertmanagerName,
           port: 'web',
+          apiVersion: 'v2',
         }],
       },
       securityContext: {

--- a/manifests/prometheus-prometheus.yaml
+++ b/manifests/prometheus-prometheus.yaml
@@ -12,7 +12,8 @@ metadata:
 spec:
   alerting:
     alertmanagers:
-    - name: alertmanager-main
+    - apiVersion: v2
+      name: alertmanager-main
       namespace: monitoring
       port: web
   image: quay.io/prometheus/prometheus:v2.24.0


### PR DESCRIPTION
Alertmanager API v2 is available for more than 2 years now, there's no
reason to not use it by default.

cc @paulfantom 

see also https://github.com/prometheus/alertmanager/issues/2469 and https://github.com/prometheus/prometheus/issues/8398