### PR TITLE
Windows addon

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -2,7 +2,8 @@
 
 The [Windows addon](../examples/windows.jsonnet) adds the dashboards and rules from  [kubernetes-monitoring/kubernetes-mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin#dashboards-for-windows-nodes).  
 
-Currently, Windows does not support running with [windows_exporter](https://github.com/prometheus-community/windows_exporter) in a pod so this add on uses [additional scrap configuration](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/additional-scrape-config.md) to set up a static configs to scrape the node ports where windows_exporter is configured.  
+Currently, Windows does not support running with [windows_exporter](https://github.com/prometheus-community/windows_exporter) in a pod so this add on uses [additional scrape configuration](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/additional-scrape-config.md) to set up a static config to scrape the node ports where windows_exporter is configured.
+
 
 The addon requires you to specify the node ips and ports where it can find the windows_exporter.  See the [full example](../examples/windows.jsonnet) for setup.
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,0 +1,21 @@
+# Windows
+
+The [Windows addon](../examples/windows.jsonnet) adds the dashboards and rules from  [kubernetes-monitoring/kubernetes-mixin](https://github.com/kubernetes-monitoring/kubernetes-mixin#dashboards-for-windows-nodes).  
+
+Currently, Windows does not support running with [windows_exporter](https://github.com/prometheus-community/windows_exporter) in a pod so this add on uses [additional scrap configuration](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/additional-scrape-config.md) to set up a static configs to scrape the node ports where windows_exporter is configured.  
+
+The addon requires you to specify the node ips and ports where it can find the windows_exporter.  See the [full example](../examples/windows.jsonnet) for setup.
+
+```
+local kp = (import 'kube-prometheus/main.libsonnet') +
+  (import 'kube-prometheus/addons/windows.libsonnet') +
+  {
+    values+:: {
+      windowsScrapeConfig+:: {
+          static_configs: {
+              targets: ["10.240.0.65:5000", "10.240.0.63:5000"],
+          },
+      },
+    },
+  };
+```

--- a/examples/windows.jsonnet
+++ b/examples/windows.jsonnet
@@ -1,0 +1,33 @@
+local kp =
+  (import 'kube-prometheus/main.libsonnet') +
+  (import 'kube-prometheus/addons/windows.libsonnet') +
+  {
+    values+:: {
+      common+: {
+        namespace: 'monitoring',
+      },
+      windowsScrapeConfig+:: {
+        static_configs: {
+          targets: ['10.240.0.65:5000', '10.240.0.63:5000'],
+        },
+      },
+    },
+  };
+
+{ 'setup/0namespace-namespace': kp.kubePrometheus.namespace } +
+{
+  ['setup/prometheus-operator-' + name]: kp.prometheusOperator[name]
+  for name in std.filter((function(name) name != 'serviceMonitor' && name != 'prometheusRule'), std.objectFields(kp.prometheusOperator))
+} +
+// serviceMonitor and prometheusRule are separated so that they can be created after the CRDs are ready
+{ 'prometheus-operator-serviceMonitor': kp.prometheusOperator.serviceMonitor } +
+{ 'prometheus-operator-prometheusRule': kp.prometheusOperator.prometheusRule } +
+{ 'kube-prometheus-prometheusRule': kp.kubePrometheus.prometheusRule } +
+{ ['alertmanager-' + name]: kp.alertmanager[name] for name in std.objectFields(kp.alertmanager) } +
+{ ['blackbox-exporter-' + name]: kp.blackboxExporter[name] for name in std.objectFields(kp.blackboxExporter) } +
+{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) } +
+{ ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
+{ ['kubernetes-' + name]: kp.kubernetesControlPlane[name] for name in std.objectFields(kp.kubernetesControlPlane) }
+{ ['node-exporter-' + name]: kp.nodeExporter[name] for name in std.objectFields(kp.nodeExporter) } +
+{ ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
+{ ['prometheus-adapter-' + name]: kp.prometheusAdapter[name] for name in std.objectFields(kp.prometheusAdapter) }

--- a/jsonnet/kube-prometheus/addons/windows.libsonnet
+++ b/jsonnet/kube-prometheus/addons/windows.libsonnet
@@ -1,0 +1,58 @@
+local windowsdashboards = import 'kubernetes-mixin/dashboards/windows.libsonnet';
+local windowsrules = import 'kubernetes-mixin/rules/windows.libsonnet';
+
+{
+  values+:: {
+    windowsScrapeConfig+:: {
+      job_name: 'windows-exporter',
+      static_configs: [
+        {
+          targets: [error 'must provide targets array'],
+        },
+      ],
+    },
+
+    grafana+:: {
+      dashboards+:: windowsdashboards {
+        _config: $.kubernetesControlPlane.mixin._config {
+          wmiExporterSelector: 'job="' + $.values.windowsScrapeConfig.job_name + '"',
+        },
+      }.grafanaDashboards,
+    },
+  },
+  kubernetesControlPlane+: {
+    mixin+:: {
+      prometheusRules+:: {
+        groups+: windowsrules {
+          _config: $.kubernetesControlPlane.mixin._config {
+            wmiExporterSelector: 'job="' + $.values.windowsScrapeConfig.job_name + '"',
+          },
+        }.prometheusRules.groups,
+      },
+    },
+  },
+  prometheus+: {
+    local p = self,
+    local sc = [$.values.windowsScrapeConfig],
+    prometheus+: {
+      spec+: {
+        additionalScrapeConfigs: {
+          name: 'prometheus-' + p.config.name + '-additional-scrape-config',
+          key: 'prometheus-additional.yaml',
+        },
+      },
+
+    },
+    windowsConfig: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'prometheus-' + p.config.name + '-additional-scrape-config',
+        namespace: p.config.namespace,
+      },
+      stringData: {
+        'prometheus-additional.yaml': std.manifestYamlDoc(sc),
+      },
+    },
+  },
+}


### PR DESCRIPTION
This adds a windows addon for use with `windows_exporter`. Currently windows is not able to run in pods so it used the extra scrape config to scrape the windows nodes.  There is an open [KEP for Windows privileged containers](https://github.com/kubernetes/enhancements/pull/2288) which would enable a different workflow in the future but is still in development.

This sets up everything for a working dashboard: 

![dash](https://user-images.githubusercontent.com/648372/106657991-931f7200-6551-11eb-88c8-c7bedc7a8ece.png)


It did require several changes to the surrounding projects to get the dashboard to render everything correctly:

https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/544
https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/545
https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/546

And if you want to use containerd: 

https://github.com/prometheus-community/windows_exporter/pull/716

### note for reviewers
This was my first pass at using jsonnet and these libraries. If there is a better way to configure this please let me know :-) 