### PR TITLE
bump node-exporter to 1.1.0 and remove deprecated flag

### DIFF
--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -173,8 +173,7 @@ function(params) {
         '--no-collector.hwmon',
         '--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)',
         '--collector.netclass.ignored-devices=^(veth.*)$',
-        '--collector.netdev.device-blacklist=^(veth.*)$',
-        // '--collector.netdev.device-exclude=^(veth.*)$', // TODO(paulfantom): change with next version of node_exporter (post 1.0.1)
+        '--collector.netdev.device-exclude=^(veth.*)$',
       ],
       volumeMounts: [
         { name: 'sys', mountPath: '/host/sys', mountPropagation: 'HostToContainer', readOnly: true },

--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -23,7 +23,7 @@ local prometheus = import './components/prometheus.libsonnet';
         blackboxExporter: '0.18.0',
         grafana: '7.3.7',
         kubeStateMetrics: '1.9.7',
-        nodeExporter: '1.0.1',
+        nodeExporter: '1.1.0',
         prometheus: '2.24.0',
         prometheusAdapter: '0.8.3',
         prometheusOperator: '0.45.0',

--- a/manifests/node-exporter-clusterRole.yaml
+++ b/manifests/node-exporter-clusterRole.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.0.1
+    app.kubernetes.io/version: 1.1.0
   name: node-exporter
 rules:
 - apiGroups:

--- a/manifests/node-exporter-clusterRoleBinding.yaml
+++ b/manifests/node-exporter-clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.0.1
+    app.kubernetes.io/version: 1.1.0
   name: node-exporter
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.0.1
+    app.kubernetes.io/version: 1.1.0
   name: node-exporter
   namespace: monitoring
 spec:
@@ -20,7 +20,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: node-exporter
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 1.0.1
+        app.kubernetes.io/version: 1.1.0
     spec:
       containers:
       - args:
@@ -31,8 +31,8 @@ spec:
         - --no-collector.hwmon
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
         - --collector.netclass.ignored-devices=^(veth.*)$
-        - --collector.netdev.device-blacklist=^(veth.*)$
-        image: quay.io/prometheus/node-exporter:v1.0.1
+        - --collector.netdev.device-exclude=^(veth.*)$
+        image: quay.io/prometheus/node-exporter:v1.1.0
         name: node-exporter
         resources:
           limits:

--- a/manifests/node-exporter-prometheusRule.yaml
+++ b/manifests/node-exporter-prometheusRule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.0.1
+    app.kubernetes.io/version: 1.1.0
     prometheus: k8s
     role: alert-rules
   name: node-exporter-rules

--- a/manifests/node-exporter-service.yaml
+++ b/manifests/node-exporter-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.0.1
+    app.kubernetes.io/version: 1.1.0
   name: node-exporter
   namespace: monitoring
 spec:

--- a/manifests/node-exporter-serviceAccount.yaml
+++ b/manifests/node-exporter-serviceAccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.0.1
+    app.kubernetes.io/version: 1.1.0
   name: node-exporter
   namespace: monitoring

--- a/manifests/node-exporter-serviceMonitor.yaml
+++ b/manifests/node-exporter-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.0.1
+    app.kubernetes.io/version: 1.1.0
   name: node-exporter
   namespace: monitoring
 spec:


### PR DESCRIPTION
Recently node-exporter 1.1.0 was released - https://github.com/prometheus/node_exporter/releases/tag/v1.1.0