### PR TITLE
anti-affinity addon should also affect blackbox exporter

### DIFF
--- a/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet
+++ b/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet
@@ -22,17 +22,29 @@
     },
   },
 
-  alertmanager+:: {
+  alertmanager+: {
     alertmanager+: {
       spec+:
         antiaffinity('alertmanager', [$.values.alertmanager.name], $.values.common.namespace),
     },
   },
 
-  prometheus+:: {
+  prometheus+: {
     prometheus+: {
       spec+:
         antiaffinity('prometheus', [$.values.prometheus.name], $.values.common.namespace),
     },
   },
+
+  blackboxExporter+: {
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+:
+            antiaffinity('app.kubernetes.io/name', ['blackbox-exporter'], $.values.common.namespace),
+        },
+      },
+    },
+  },
+
 }


### PR DESCRIPTION
As in title.

Also, unhide prometheus and alertmanager objects.