### PR TITLE
Pin etcd-mixin version in release 0.4

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -48,7 +48,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "master"
+            "version": "e8ba375032e8e48d009759dfb285f7812e7bcb8c"
         },
         {
             "name": "prometheus",


### PR DESCRIPTION
`etcd-mixin` was moved upstream and this PR pins the version to the commit before the move. This way changes on master will not brake the existing release-0.4