### PR TITLE
Pin etcd-mixin to last working version for release 0.6

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -17,7 +17,7 @@
           "subdir": "Documentation/etcd-mixin"
         }
       },
-      "version": "master"
+      "version": "e8ba375032e8e48d009759dfb285f7812e7bcb8c"
     },
     {
       "source": {


### PR DESCRIPTION
etcd refactored their repo moving and renaming etcd-mixin. The jsonnetfile depended on "master" even though the lock was for an older version. Checking out from the last commit before the move works.