### PR TITLE
jsonnet: better name for prometheus PrometheusRule object

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -66,7 +66,7 @@ function(params) {
     kind: 'PrometheusRule',
     metadata: {
       labels: p.config.commonLabels + p.config.mixin.ruleLabels,
-      name: p.config.name + '-rules',
+      name: 'prometheus-' + p.config.name + '-prometheus-rules',
       namespace: p.config.namespace,
     },
     spec: {

--- a/manifests/prometheus-prometheusRule.yaml
+++ b/manifests/prometheus-prometheusRule.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/version: 2.24.0
     prometheus: k8s
     role: alert-rules
-  name: k8s-rules
+  name: prometheus-k8s-prometheus-rules
   namespace: monitoring
 spec:
   groups:


### PR DESCRIPTION
The previous name resulted in `k8s-rules` by default and was confusing.