### PR TITLE
increase default CPU values for main kube-rbac-proxy sidecar in kube-state-metrics

### DIFF
--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -89,6 +89,10 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
     ports: [
       { name: 'https-main', containerPort: 8443 },
     ],
+    resources+: {
+      limits+: { cpu: '40m' },
+      requests+: { cpu: '20m' },
+    },
   }),
 
   local kubeRbacProxySelf = krp({

--- a/manifests/kube-state-metrics-deployment.yaml
+++ b/manifests/kube-state-metrics-deployment.yaml
@@ -50,10 +50,10 @@ spec:
           name: https-main
         resources:
           limits:
-            cpu: 20m
+            cpu: 40m
             memory: 40Mi
           requests:
-            cpu: 10m
+            cpu: 20m
             memory: 20Mi
         securityContext:
           runAsGroup: 65532


### PR DESCRIPTION
Due to amount of data and restrictive resource settings, main kube-rbac-proxy is triggering CPUThrottlingHigh alert as well as massively delaying scrapes in prometheus. By increasing available CPU limits I got from 5s to 2s in prometheus scrape duration on a small k3s cluster.

I am creating PR now, but I need to do some more testing as CPUThrottlingHigh is still firing with a value of >80.