### PR TITLE
Fix: service names in kops for scheduler and kube-dns

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-kops.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-kops.libsonnet
@@ -23,14 +23,14 @@ local service(name, namespace, labels, selector, ports) = {
       [{ name: 'https-metrics', port: 10257, targetPort: 10257 }]
     ),
     kubeSchedulerPrometheusDiscoveryService: service(
-      'kube-controller-manager-prometheus-discovery',
+      'kube-scheduler-prometheus-discovery',
       'kube-system',
       { 'k8s-app': 'kube-scheduler' },
       { 'k8s-app': 'kube-scheduler' },
       [{ name: 'https-metrics', port: 10259, targetPort: 10259 }]
     ),
     kubeDnsPrometheusDiscoveryService: service(
-      'kube-controller-manager-prometheus-discovery',
+      'kube-dns-prometheus-discovery',
       'kube-system',
       { 'k8s-app': 'kube-dns' },
       { 'k8s-app': 'kube-dns' },


### PR DESCRIPTION
Fix for service names for #946 