### PR TITLE
Ensure Prometheus ServiceMonitor is unique

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -282,7 +282,7 @@ function(params) {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'ServiceMonitor',
     metadata: {
-      name: 'prometheus',
+      name: 'prometheus-' + p.config.name,
       namespace: p.config.namespace,
       labels: p.config.commonLabels,
     },

--- a/manifests/prometheus-serviceMonitor.yaml
+++ b/manifests/prometheus-serviceMonitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.24.0
-  name: prometheus
+  name: prometheus-k8s
   namespace: monitoring
 spec:
   endpoints:


### PR DESCRIPTION
The name of the Prometheus ServiceMonitor must be unique like other resources to allow deploying multiple "shards" in the same namespace.
This has been tested, we have be deploying with this patch for quite some time now.