### PR TITLE
addons/anti-affinity: Support soft/hard podAntiAffinity and topologyKey

### DIFF
--- a/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet
+++ b/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet
@@ -1,38 +1,69 @@
 {
-  local antiaffinity(key, values, namespace) = {
-    affinity: {
-      podAntiAffinity: {
-        preferredDuringSchedulingIgnoredDuringExecution: [
-          {
-            weight: 100,
-            podAffinityTerm: {
-              namespaces: [namespace],
-              topologyKey: 'kubernetes.io/hostname',
-              labelSelector: {
-                matchExpressions: [{
-                  key: key,
-                  operator: 'In',
-                  values: values,
-                }],
-              },
-            },
-          },
-        ],
+  values+:: {
+    alertmanager+: {
+      podAntiAffinity: 'soft',
+      podAntiAffinityTopologyKey: 'kubernetes.io/hostname',
+    },
+    prometheus+: {
+      podAntiAffinity: 'soft',
+      podAntiAffinityTopologyKey: 'kubernetes.io/hostname',
+    },
+    blackboxExporter+: {
+      podAntiAffinity: 'soft',
+      podAntiAffinityTopologyKey: 'kubernetes.io/hostname',
+    },
+  },
+
+  local antiaffinity(key, values, namespace, type, topologyKey) = {
+    local podAffinityTerm = {
+      namespaces: [namespace],
+      topologyKey: topologyKey,
+      labelSelector: {
+        matchExpressions: [{
+          key: key,
+          operator: 'In',
+          values: values,
+        }],
       },
+    },
+
+    affinity: {
+      podAntiAffinity: if type == 'soft' then {
+        preferredDuringSchedulingIgnoredDuringExecution: [{
+          weight: 100,
+          podAffinityTerm: podAffinityTerm,
+        }],
+      } else if type == 'hard' then {
+        requiredDuringSchedulingIgnoredDuringExecution: [
+          podAffinityTerm,
+        ],
+      } else error 'podAntiAffinity must be either "soft" or "hard"',
     },
   },
 
   alertmanager+: {
     alertmanager+: {
       spec+:
-        antiaffinity('alertmanager', [$.values.alertmanager.name], $.values.common.namespace),
+        antiaffinity(
+          'alertmanager',
+          [$.values.alertmanager.name],
+          $.values.common.namespace,
+          $.values.alertmanager.podAntiAffinity,
+          $.values.alertmanager.podAntiAffinityTopologyKey,
+        ),
     },
   },
 
   prometheus+: {
     prometheus+: {
       spec+:
-        antiaffinity('prometheus', [$.values.prometheus.name], $.values.common.namespace),
+        antiaffinity(
+          'prometheus',
+          [$.values.prometheus.name],
+          $.values.common.namespace,
+          $.values.prometheus.podAntiAffinity,
+          $.values.prometheus.podAntiAffinityTopologyKey,
+        ),
     },
   },
 
@@ -41,7 +72,13 @@
       spec+: {
         template+: {
           spec+:
-            antiaffinity('app.kubernetes.io/name', ['blackbox-exporter'], $.values.common.namespace),
+            antiaffinity(
+              'app.kubernetes.io/name',
+              ['blackbox-exporter'],
+              $.values.common.namespace,
+              $.values.blackboxExporter.podAntiAffinity,
+              $.values.blackboxExporter.podAntiAffinityTopologyKey,
+            ),
         },
       },
     },


### PR DESCRIPTION
Handy configuration of pod anti-affinities:

* `podAntiAffinity == 'soft'` → `preferredDuringSchedulingIgnoredDuringExecution` (default)
* `podAntiAffinity == 'hard'` → `requiredDuringSchedulingIgnoredDuringExecution`
* Allow configuring `topologyKey`. For example: `topology.kubernetes.io/zone` (default: `kubernetes.io/hostname`)

This changes nothing for users  already using the add-on.