### PR TITLE
Use etcd release-3.4 instead of master to fix broken dependency

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -48,7 +48,7 @@
                     "subdir": "Documentation/etcd-mixin"
                 }
             },
-            "version": "master"
+            "version": "release-3.4"
         },
         {
             "name": "prometheus",


### PR DESCRIPTION
kube-prometheus release-0.3 is using master branch of  `coreos/etcd` and this commit https://github.com/etcd-io/etcd/commit/7fca120587c26eab0469acef7f21476f3da5e7fd removed `Documentation/etcd-mixin` which is required by kube-prometheus. Switching to `release-3.4` of `coreos/etcd` to fix the build.