### PR TITLE
[release-0.5] Pin Jsonnet dependencies

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -35,7 +35,7 @@
           "subdir": ""
         }
       },
-      "version": "master",
+      "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f",
       "name": "ksonnet"
     },
     {
@@ -72,7 +72,7 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "master"
+      "version": "fa4edd700ebc1b3614bcd953c215d3f2ab2e0b35"
     },
     {
       "source": {
@@ -81,7 +81,7 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "master",
+      "version": "cd12f0873c3eb2031f7ba9b2e169449aa1012e3f",
       "name": "prometheus"
     }
   ],


### PR DESCRIPTION
Pin all Jsonnet dependencies to current commit SHA.

Signed-off-by: Simon Rüegg <simon@rueggs.ch>

Relates to https://github.com/prometheus-operator/kube-prometheus/issues/939 https://github.com/projectsyn/component-rancher-monitoring/issues/5