### PR TITLE
[release-0.6] Pin Jsonnet dependencies

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -35,7 +35,7 @@
           "subdir": ""
         }
       },
-      "version": "master",
+      "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f",
       "name": "ksonnet"
     },
     {
@@ -72,7 +72,7 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "master"
+      "version": "ff2ff3410f4ea8195e51f5fb8d84151684f91b3f"
     },
     {
       "source": {

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -87,7 +87,7 @@ func TestQueryPrometheus(t *testing.T) {
 	}
 
 	// Wait for pod to respond at queries at all. Then start verifying their results.
-	err := wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err := wait.Poll(5*time.Second, 5*time.Minute, func() (bool, error) {
 		_, err := promClient.query("up")
 		return err == nil, nil
 	})


### PR DESCRIPTION
Pin all Jsonnet dependencies to current commit SHA.

Signed-off-by: Simon Rüegg <simon@rueggs.ch>

Relates to https://github.com/prometheus-operator/kube-prometheus/issues/939 https://github.com/projectsyn/component-rancher-monitoring/issues/5