### PR TITLE
[release-0.7] Pin Jsonnet dependencies

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -71,7 +71,7 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "master"
+      "version": "8b466360a35581e0301bd22918be7011cf4203c3"
     },
     {
       "source": {
@@ -90,7 +90,7 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "master",
+      "version": "193ebba04d1e70d971047e983a0b489112610460",
       "name": "alertmanager"
     },
     {


### PR DESCRIPTION
Pin all Jsonnet dependencies to current commit SHA.

Signed-off-by: Simon Rüegg <simon@rueggs.ch>

Relates to https://github.com/prometheus-operator/kube-prometheus/issues/939 https://github.com/projectsyn/component-rancher-monitoring/issues/5