### PR TITLE
jsonnet/alertmanager: add default alertmanager resource requirements

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -3,7 +3,10 @@ local defaults = {
   namespace: error 'must provide namespace',
   image: error 'must provide image',
   version: error 'must provide version',
-  resources: {},
+  resources: {
+    limits: { cpu: '100m', memory: '100Mi' },
+    requests: { cpu: '4m', memory: '100Mi' },
+  },
   commonLabels:: {
     'app.kubernetes.io/name': 'alertmanager',
     'app.kubernetes.io/version': defaults.version,

--- a/manifests/alertmanager-alertmanager.yaml
+++ b/manifests/alertmanager-alertmanager.yaml
@@ -20,7 +20,13 @@ spec:
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 0.21.0
   replicas: 3
-  resources: {}
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
+    requests:
+      cpu: 4m
+      memory: 100Mi
   securityContext:
     fsGroup: 2000
     runAsNonRoot: true


### PR DESCRIPTION
Reimplementation of #164 adapted with our findings from running alertmanager in OpenShift.