### PR TITLE
.github/workflows: do not persist credentials

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - uses: actions/setup-go@v2
     - uses: romoh/dependencies-autoupdate@v1.1
       with:


### PR DESCRIPTION
A PR created by a GitHub action cannot start new GH actions. Such situation happened with https://github.com/prometheus-operator/kube-prometheus/pull/985.

To work around this limitation `actions/checkout@v2` needs to be configured to stop persisting credentials. (source: https://github.community/t/push-from-action-even-with-pat-does-not-trigger-action/17622/5).

I am not sure if this needs to be configured only on the version updater workflow (I assume so) or should it be done in all workflows. Let's try first with only a small change and if this won't work I'll create a follow-up PR.