### PR TITLE
Better name for alertmanager prometheusRule object

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -82,7 +82,7 @@ function(params) {
     kind: 'PrometheusRule',
     metadata: {
       labels: am.config.commonLabels + am.config.mixin.ruleLabels,
-      name: am.config.name + '-rules',
+      name: 'alertmanager-' + am.config.name + '-rules',
       namespace: am.config.namespace,
     },
     spec: {

--- a/manifests/alertmanager-prometheusRule.yaml
+++ b/manifests/alertmanager-prometheusRule.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/version: 0.21.0
     prometheus: k8s
     role: alert-rules
-  name: main-rules
+  name: alertmanager-main-rules
   namespace: monitoring
 spec:
   groups:


### PR DESCRIPTION
The current name can be confusing so I applied the same schema we use for [a similar object in a prometheus component](https://github.com/prometheus-operator/kube-prometheus/blob/main/jsonnet/kube-prometheus/components/prometheus.libsonnet#L67).

/cc @simonpasquier 