### PR TITLE
jsonnet,scripts: better version updater

### DIFF
--- a/jsonnet/kube-prometheus/versions.json
+++ b/jsonnet/kube-prometheus/versions.json
@@ -2,6 +2,7 @@
   "alertmanager": "0.21.0",
   "blackboxExporter": "0.18.0",
   "grafana": "7.4.3",
+  "kubeStateMetrics": "1.9.8",
   "nodeExporter": "1.1.1",
   "prometheus": "2.25.0",
   "prometheusAdapter": "0.8.3",

--- a/scripts/generate-versions.sh
+++ b/scripts/generate-versions.sh
@@ -2,10 +2,37 @@
 
 set -euo pipefail
 
+# Get component version from GitHub API
 get_latest_version() {
   echo >&2 "Checking release version for ${1}"
   curl --retry 5 --silent --fail -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${1}/releases/latest" | jq '.tag_name' | tr -d '"v'
 }
+
+# Get component version from version file
+get_current_version() {
+  echo >&2 "Reading currently used version of ${1}"
+  jq -r ".${1}" "$VERSION_FILE"
+}
+
+# Get version from online source and filter out unstable releases. In case of unstable release use what is set in version file
+get_version() {
+  component="${1}"
+  v="$(get_latest_version "${component}")"
+  
+  # Advanced AI heurestics to filter out common patterns suggesting new version is not stable /s
+  if [[ "$v" == *"alpha"* ]] || [[ "$v" == *"beta"* ]] || [[ "$v" == *"rc"* ]] || [[ "$v" == *"helm"* ]]; then
+     component="$(convert_to_camel_case "$(echo "${component}" | sed 's/^.*\///')")"
+     v="$(get_current_version "${component}")"
+  fi
+  echo "$v"
+}
+
+convert_to_camel_case() {
+  echo "${1}" | sed -E 's/[ _-]([a-z])/\U\1/gi;s/^([A-Z])/\l\1/'
+}
+
+# File is used to read current versions
+VERSION_FILE="jsonnet/kube-prometheus/versions.json"
 
 # token can be passed as `GITHUB_TOKEN` variable or passed as first argument
 GITHUB_TOKEN=${GITHUB_TOKEN:-${1}}
@@ -17,12 +44,13 @@ fi
 
 cat <<-EOF
 {
-  "alertmanager": "$(get_latest_version "prometheus/alertmanager")",
-  "blackboxExporter": "$(get_latest_version "prometheus/blackbox_exporter")",
-  "grafana": "$(get_latest_version "grafana/grafana")",
-  "nodeExporter": "$(get_latest_version "prometheus/node_exporter")",
-  "prometheus": "$(get_latest_version "prometheus/prometheus")",
-  "prometheusAdapter": "$(get_latest_version "kubernetes-sigs/prometheus-adapter")",
-  "prometheusOperator": "$(get_latest_version "prometheus-operator/prometheus-operator")"
+  "alertmanager": "$(get_version "prometheus/alertmanager")",
+  "blackboxExporter": "$(get_version "prometheus/blackbox_exporter")",
+  "grafana": "$(get_version "grafana/grafana")",
+  "kubeStateMetrics": "$(get_version "kubernetes/kube-state-metrics")",
+  "nodeExporter": "$(get_version "prometheus/node_exporter")",
+  "prometheus": "$(get_version "prometheus/prometheus")",
+  "prometheusAdapter": "$(get_version "kubernetes-sigs/prometheus-adapter")",
+  "prometheusOperator": "$(get_version "prometheus-operator/prometheus-operator")"
 }
 EOF


### PR DESCRIPTION
Adding AI-based heuristics to version updater /s

This will discard releases that use patterns suggesting this is not a stable release, like `alpha`. Additionally, it will also discard `helm` word so we can use it to get the latest kube-state-metrics releases. As a fallback, it uses currently set versions from the version file. 

The script doesn't save changes to the file and this is intentional.

Merging this should prevent having PRs like https://github.com/prometheus-operator/kube-prometheus/pull/1000 where bot tries to update kube-prometheus components to unstable versions.