### PR TITLE
Add podSecurityPolicies to all components of kube-prometheus

### DIFF
--- a/examples/pod-security-policies.jsonnet
+++ b/examples/pod-security-policies.jsonnet
@@ -1,0 +1,23 @@
+local kp =
+  (import 'kube-prometheus/main.libsonnet') +
+  (import 'kube-prometheus/addons/podsecuritypolicies.libsonnet');
+
+{ 'setup/0namespace-namespace': kp.kubePrometheus.namespace } +
+// Add the restricted psp to setup
+{ 'setup/0podsecuritypolicy-restricted': kp.restrictedPodSecurityPolicy } +
+{
+  ['setup/prometheus-operator-' + name]: kp.prometheusOperator[name]
+  for name in std.filter((function(name) name != 'serviceMonitor' && name != 'prometheusRule'), std.objectFields(kp.prometheusOperator))
+} +
+// serviceMonitor and prometheusRule are separated so that they can be created after the CRDs are ready
+{ 'prometheus-operator-serviceMonitor': kp.prometheusOperator.serviceMonitor } +
+{ 'prometheus-operator-prometheusRule': kp.prometheusOperator.prometheusRule } +
+{ 'kube-prometheus-prometheusRule': kp.kubePrometheus.prometheusRule } +
+{ ['alertmanager-' + name]: kp.alertmanager[name] for name in std.objectFields(kp.alertmanager) } +
+{ ['blackbox-exporter-' + name]: kp.blackboxExporter[name] for name in std.objectFields(kp.blackboxExporter) } +
+{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) } +
+{ ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
+{ ['kubernetes-' + name]: kp.kubernetesControlPlane[name] for name in std.objectFields(kp.kubernetesControlPlane) }
+{ ['node-exporter-' + name]: kp.nodeExporter[name] for name in std.objectFields(kp.nodeExporter) } +
+{ ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
+{ ['prometheus-adapter-' + name]: kp.prometheusAdapter[name] for name in std.objectFields(kp.prometheusAdapter) }

--- a/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
+++ b/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
@@ -1,0 +1,242 @@
+local restrictedPodSecurityPolicy = {
+  apiVersion: 'policy/v1beta1',
+  kind: 'PodSecurityPolicy',
+  metadata: {
+    name: 'restricted',
+  },
+  spec: {
+    privileged: false,
+    // Required to prevent escalations to root.
+    allowPrivilegeEscalation: false,
+    // This is redundant with non-root + disallow privilege escalation,
+    // but we can provide it for defense in depth.
+    requiredDropCapabilities: ['ALL'],
+    // Allow core volume types.
+    volumes: [
+      'configMap',
+      'emptyDir',
+      'secret',
+      // Assume that persistentVolumes set up by the cluster admin are safe to use.
+      'persistentVolumeClaim',
+    ],
+    hostNetwork: false,
+    hostIPC: false,
+    hostPID: false,
+    runAsUser: {
+      // Require the container to run without root privileges.
+      rule: 'MustRunAsNonRoot',
+    },
+    seLinux: {
+      // This policy assumes the nodes are using AppArmor rather than SELinux.
+      rule: 'RunAsAny',
+    },
+    supplementalGroups: {
+      rule: 'MustRunAs',
+      ranges: [{
+        // Forbid adding the root group.
+        min: 1,
+        max: 65535,
+      }],
+    },
+    fsGroup: {
+      rule: 'MustRunAs',
+      ranges: [{
+        // Forbid adding the root group.
+        min: 1,
+        max: 65535,
+      }],
+    },
+    readOnlyRootFilesystem: false,
+  },
+};
+
+{
+  restrictedPodSecurityPolicy: restrictedPodSecurityPolicy,
+
+  alertmanager+: {
+    role: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'Role',
+      metadata: {
+        name: 'alertmanager-' + $.values.alertmanager.name,
+      },
+      rules: [{
+        apiGroups: ['policy'],
+        resources: ['podsecuritypolicies'],
+        verbs: ['use'],
+        resourceNames: [restrictedPodSecurityPolicy.metadata.name],
+      }],
+    },
+
+    roleBinding: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'RoleBinding',
+      metadata: {
+        name: 'alertmanager-' + $.values.alertmanager.name,
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'Role',
+        name: 'alertmanager-' + $.values.alertmanager.name,
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: 'alertmanager-' + $.values.alertmanager.name,
+        namespace: $.values.alertmanager.namespace,
+      }],
+    },
+  },
+
+  blackboxExporter+: {
+    clusterRole+: {
+      rules+: [
+        {
+          apiGroups: ['policy'],
+          resources: ['podsecuritypolicies'],
+          verbs: ['use'],
+          resourceNames: ['blackbox-exporter-psp'],
+        },
+      ],
+    },
+
+    podSecurityPolicy:
+      local blackboxExporterPspPrivileged =
+        if $.blackboxExporter.config.privileged then
+          {
+            metadata+: {
+              name: 'blackbox-exporter-psp',
+            },
+            spec+: {
+              privileged: true,
+              allowedCapabilities: ['NET_RAW'],
+              runAsUser: {
+                rule: 'RunAsAny',
+              },
+            },
+          }
+        else
+          {};
+
+      restrictedPodSecurityPolicy + blackboxExporterPspPrivileged,
+  },
+
+  grafana+: {
+    role: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'Role',
+      metadata: {
+        name: 'grafana',
+      },
+      rules: [{
+        apiGroups: ['policy'],
+        resources: ['podsecuritypolicies'],
+        verbs: ['use'],
+        resourceNames: [restrictedPodSecurityPolicy.metadata.name],
+      }],
+    },
+
+    roleBinding: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'RoleBinding',
+      metadata: {
+        name: 'grafana',
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'Role',
+        name: 'grafana',
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: $.grafana.serviceAccount.metadata.name,
+        namespace: $.grafana.serviceAccount.metadata.namespace,
+      }],
+    },
+  },
+
+  kubeStateMetrics+: {
+    clusterRole+: {
+      rules+: [{
+        apiGroups: ['policy'],
+        resources: ['podsecuritypolicies'],
+        verbs: ['use'],
+        resourceNames: [restrictedPodSecurityPolicy.metadata.name],
+      }],
+    },
+  },
+
+  nodeExporter+: {
+    clusterRole+: {
+      rules+: [{
+        apiGroups: ['policy'],
+        resources: ['podsecuritypolicies'],
+        verbs: ['use'],
+        resourceNames: ['node-exporter-psp'],
+      }],
+    },
+
+    podSecurityPolicy: restrictedPodSecurityPolicy {
+      metadata+: {
+        name: 'node-exporter-psp',
+      },
+      spec+: {
+        allowedHostPaths+: [
+          {
+            pathPrefix: '/proc',
+            readOnly: true,
+          },
+          {
+            pathPrefix: '/sys',
+            readOnly: true,
+          },
+          {
+            pathPrefix: '/',
+            readOnly: true,
+          },
+        ],
+        hostNetwork: true,
+        hostPID: true,
+        hostPorts: [
+          {
+            max: 9100,
+            min: 9100,
+          },
+        ],
+        readOnlyRootFilesystem: true,
+      },
+    },
+  },
+
+  prometheusAdapter+: {
+    clusterRole+: {
+      rules+: [{
+        apiGroups: ['policy'],
+        resources: ['podsecuritypolicies'],
+        verbs: ['use'],
+        resourceNames: [restrictedPodSecurityPolicy.metadata.name],
+      }],
+    },
+  },
+
+  prometheusOperator+: {
+    clusterRole+: {
+      rules+: [{
+        apiGroups: ['policy'],
+        resources: ['podsecuritypolicies'],
+        verbs: ['use'],
+        resourceNames: [restrictedPodSecurityPolicy.metadata.name],
+      }],
+    },
+  },
+
+  prometheus+: {
+    clusterRole+: {
+      rules+: [{
+        apiGroups: ['policy'],
+        resources: ['podsecuritypolicies'],
+        verbs: ['use'],
+        resourceNames: [restrictedPodSecurityPolicy.metadata.name],
+      }],
+    },
+  },
+}

--- a/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
+++ b/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
@@ -209,8 +209,8 @@ local restrictedPodSecurityPolicy = {
         hostPID: true,
         hostPorts: [
           {
-            max: 9100,
-            min: 9100,
+            max: $.nodeExporter.config.port,
+            min: $.nodeExporter.config.port,
           },
         ],
         readOnlyRootFilesystem: true,

--- a/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
+++ b/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
@@ -214,6 +214,9 @@ local restrictedPodSecurityPolicy = {
           },
         ],
         readOnlyRootFilesystem: true,
+        volumes+: [
+          'hostPath',
+        ],
       },
     },
   },

--- a/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
+++ b/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
@@ -160,8 +160,19 @@ local restrictedPodSecurityPolicy = {
         apiGroups: ['policy'],
         resources: ['podsecuritypolicies'],
         verbs: ['use'],
-        resourceNames: [restrictedPodSecurityPolicy.metadata.name],
+        resourceNames: ['kube-state-metrics-psp'],
       }],
+    },
+
+    podSecurityPolicy: restrictedPodSecurityPolicy {
+      metadata+: {
+        name: 'kube-state-metrics-psp',
+      },
+      spec+: {
+        runAsUser: {
+          rule: 'RunAsAny',
+        },
+      },
     },
   },
 

--- a/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
+++ b/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
@@ -54,9 +54,9 @@ local restrictedPodSecurityPolicy = {
   restrictedPodSecurityPolicy: restrictedPodSecurityPolicy,
 
   alertmanager+: {
-    role: {
+    clusterRole: {
       apiVersion: 'rbac.authorization.k8s.io/v1',
-      kind: 'Role',
+      kind: 'ClusterRole',
       metadata: {
         name: 'alertmanager-' + $.values.alertmanager.name,
       },
@@ -68,15 +68,15 @@ local restrictedPodSecurityPolicy = {
       }],
     },
 
-    roleBinding: {
+    clusterRoleBinding: {
       apiVersion: 'rbac.authorization.k8s.io/v1',
-      kind: 'RoleBinding',
+      kind: 'ClusterRoleBinding',
       metadata: {
         name: 'alertmanager-' + $.values.alertmanager.name,
       },
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',
-        kind: 'Role',
+        kind: 'ClusterRole',
         name: 'alertmanager-' + $.values.alertmanager.name,
       },
       subjects: [{
@@ -121,9 +121,9 @@ local restrictedPodSecurityPolicy = {
   },
 
   grafana+: {
-    role: {
+    clusterRole: {
       apiVersion: 'rbac.authorization.k8s.io/v1',
-      kind: 'Role',
+      kind: 'ClusterRole',
       metadata: {
         name: 'grafana',
       },
@@ -135,15 +135,15 @@ local restrictedPodSecurityPolicy = {
       }],
     },
 
-    roleBinding: {
+    clusterRoleBinding: {
       apiVersion: 'rbac.authorization.k8s.io/v1',
-      kind: 'RoleBinding',
+      kind: 'ClusterRoleBinding',
       metadata: {
         name: 'grafana',
       },
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',
-        kind: 'Role',
+        kind: 'ClusterRole',
         name: 'grafana',
       },
       subjects: [{


### PR DESCRIPTION
I'm basically copying what I use to ship my kube-prometheus into GKE, but I don't use all of them. The podSecurityPolicies for the components that I don't use (blackbox-exporter and prometheus-adapter) were not tested at all.

As someone that doesn't have much expertise around Kubernetes security policies, I expect that whoever is reviewing this PR could double-check if I'm not being too permissive/restrictive. 

When ready, this PR should fix #572 