### PR TITLE
Managed-cluster addon shouldn't fully override prometheus object

### DIFF
--- a/jsonnet/kube-prometheus/addons/managed-cluster.libsonnet
+++ b/jsonnet/kube-prometheus/addons/managed-cluster.libsonnet
@@ -27,7 +27,7 @@
 
   // Same as above but for ServiceMonitor's
   local p = super.prometheus,
-  prometheus: {
+  prometheus+: {
     [q]: p[q]
     for q in std.objectFields(p)
     if !std.setMember(q, ['serviceMonitorKubeControllerManager', 'serviceMonitorKubeScheduler'])


### PR DESCRIPTION
The managed cluster addon is fully overriding the Prometheus object. I've noticed when enabling the `platform/gke` libsonnet.

It just doesn't build with the error
```
RUNTIME ERROR: Field does not exist: mixin
        vendor/kube-prometheus/main.libsonnet:62:60-78
        vendor/kube-prometheus/components/grafana.libsonnet:76:39-55    thunk from <object <anonymous>>
        vendor/kube-prometheus/components/grafana.libsonnet:76:28-56    object <anonymous>
        main.jsonnet:31:24-47   object <anonymous>
        Field "grafana/dashboardDefinitions"
        During manifestation
```

To try it out, just try to build before and after the PR:
```
local kp =
  (import 'kube-prometheus/main.libsonnet') +
  (import 'kube-prometheus/addons/managed-cluster.libsonnet');

{ 'setup/0namespace-namespace': kp.kubePrometheus.namespace } +
{
  ['setup/prometheus-operator-' + name]: kp.prometheusOperator[name]
  for name in std.filter((function(name) name != 'serviceMonitor' && name != 'prometheusRule'), std.objectFields(kp.prometheusOperator))
} +
// serviceMonitor and prometheusRule are separated so that they can be created after the CRDs are ready
{ 'prometheus-operator-serviceMonitor': kp.prometheusOperator.serviceMonitor } +
{ 'prometheus-operator-prometheusRule': kp.prometheusOperator.prometheusRule } +
{ 'kube-prometheus-prometheusRule': kp.kubePrometheus.prometheusRule } +
{ ['alertmanager-' + name]: kp.alertmanager[name] for name in std.objectFields(kp.alertmanager) } +
{ ['blackbox-exporter-' + name]: kp.blackboxExporter[name] for name in std.objectFields(kp.blackboxExporter) } +
{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) } +
{ ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
{ ['kubernetes-' + name]: kp.kubernetesControlPlane[name] for name in std.objectFields(kp.kubernetesControlPlane) }
{ ['node-exporter-' + name]: kp.nodeExporter[name] for name in std.objectFields(kp.nodeExporter) } +
{ ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
{ ['prometheus-adapter-' + name]: kp.prometheusAdapter[name] for name in std.objectFields(kp.prometheusAdapter) }

```

fixes #1012