### PR TITLE
Fix managed cluster addon

### DIFF
--- a/jsonnet/kube-prometheus/addons/managed-cluster.libsonnet
+++ b/jsonnet/kube-prometheus/addons/managed-cluster.libsonnet
@@ -11,10 +11,17 @@
       for k in std.objectFields(j)
       if !std.setMember(k, ['KubeControllerManager', 'KubeScheduler'])
     },
+  },
 
-    // Skip alerting rules too
-    prometheus+: {
-      rules+:: {
+  local k = super.kubernetesControlPlane,
+
+  kubernetesControlPlane+: {
+    [q]: null
+    for q in std.objectFields(k)
+    if std.setMember(q, ['serviceMonitorKubeControllerManager', 'serviceMonitorKubeScheduler'])
+  } + {
+    prometheusRule+: {
+      spec+: {
         local g = super.groups,
         groups: [
           h
@@ -23,13 +30,5 @@
         ],
       },
     },
-  },
-
-  // Same as above but for ServiceMonitor's
-  local p = super.prometheus,
-  prometheus+: {
-    [q]: p[q]
-    for q in std.objectFields(p)
-    if !std.setMember(q, ['serviceMonitorKubeControllerManager', 'serviceMonitorKubeScheduler'])
   },
 }


### PR DESCRIPTION
I opened #1012 since the managed cluster addon did not compile when using >0.7. A fix was merged(#1031) which made it compile, but don't think it actually does anything. This should remove the serviceMonitors and remove the alerting rules tied to the controller manager and kube scheduler.

Using GKE, `tk diff . -t=prometheusRule/kubernetes-monitoring-rules`:

```
+  generation: 3
   labels:
     app.kubernetes.io/name: kube-prometheus
     app.kubernetes.io/part-of: kube-prometheus
     prometheus: k8s
     role: alert-rules
@@ -729,31 +728,6 @@
       for: 15m
       labels:
         severity: critical
-  - name: kubernetes-system-scheduler
-    rules:
-    - alert: KubeSchedulerDown
-      annotations:
-        description: KubeScheduler has disappeared from Prometheus target discovery.
-        runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/kubescheduler
down
-        summary: Target disappeared from Prometheus target discovery.
-      expr: |
-        absent(up{job="kube-scheduler"} == 1)
-      for: 15m
-      labels:
-        severity: critical
-  - name: kubernetes-system-controller-manager
-    rules:
-    - alert: KubeControllerManagerDown
-      annotations:
-        description: KubeControllerManager has disappeared from Prometheus target
-          discovery.
-        runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/kubecontrolle
rmanagerdown
-        summary: Target disappeared from Prometheus target discovery.
-      expr: |
-        absent(up{job="kube-controller-manager"} == 1)
-      for: 15m
-      labels:
-        severity: critical
   - name: kube-apiserver.rules
     rules:
     - expr: |
```