### PR TITLE
jsonnet: pick kube-state-metrics version from versions.json file

### DIFF
--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -23,7 +23,7 @@ local prometheus = import './components/prometheus.libsonnet';
         alertmanager: error 'must provide version',
         blackboxExporter: error 'must provide version',
         grafana: error 'must provide version',
-        kubeStateMetrics: '1.9.8',  // FIXME(paulfantom): needs https://github.com/kubernetes/kube-state-metrics/issues/1392
+        kubeStateMetrics: error 'must provide version',
         nodeExporter: error 'must provide version',
         prometheus: error 'must provide version',
         prometheusAdapter: error 'must provide version',


### PR DESCRIPTION
There was a minor oversight in #1002. This PR should fix it and clarify the code-base.