### PR TITLE
Add PodDisruptionBudget objects

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -165,6 +165,24 @@ function(params) {
     },
   },
 
+  podDisruptionBudget: {
+    apiVersion: 'policy/v1beta1',
+    kind: 'PodDisruptionBudget',
+    metadata: {
+      name: 'alertmanager-' + am.config.name,
+      namespace: am.config.namespace,
+      labels: am.config.commonLabels,
+    },
+    spec: {
+      maxUnavailable: 1,
+      selector: {
+        matchLabels: {
+          alertmanager: am.config.name,
+        } + am.config.selectorLabels,
+      },
+    },
+  },
+
   alertmanager: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'Alertmanager',

--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -236,6 +236,24 @@ function(params) {
       items: [newSpecificRole(x) for x in p.config.namespaces],
     },
 
+  podDisruptionBudget: {
+    apiVersion: 'policy/v1beta1',
+    kind: 'PodDisruptionBudget',
+    metadata: {
+      name: 'prometheus-' + p.config.name,
+      namespace: p.config.namespace,
+      labels: p.config.commonLabels,
+    },
+    spec: {
+      minAvailable: 1,
+      selector: {
+        matchLabels: {
+          prometheus: p.config.name,
+        } + p.config.selectorLabels,
+      },
+    },
+  },
+
   prometheus: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'Prometheus',

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ./manifests/alertmanager-alertmanager.yaml
+- ./manifests/alertmanager-podDisruptionBudget.yaml
 - ./manifests/alertmanager-prometheusRule.yaml
 - ./manifests/alertmanager-secret.yaml
 - ./manifests/alertmanager-service.yaml
@@ -58,6 +59,7 @@ resources:
 - ./manifests/prometheus-clusterRoleBinding.yaml
 - ./manifests/prometheus-operator-prometheusRule.yaml
 - ./manifests/prometheus-operator-serviceMonitor.yaml
+- ./manifests/prometheus-podDisruptionBudget.yaml
 - ./manifests/prometheus-prometheus.yaml
 - ./manifests/prometheus-prometheusRule.yaml
 - ./manifests/prometheus-roleBindingConfig.yaml

--- a/manifests/alertmanager-podDisruptionBudget.yaml
+++ b/manifests/alertmanager-podDisruptionBudget.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.21.0
+  name: alertmanager-main
+  namespace: monitoring
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      alertmanager: main
+      app.kubernetes.io/component: alert-router
+      app.kubernetes.io/name: alertmanager
+      app.kubernetes.io/part-of: kube-prometheus

--- a/manifests/prometheus-podDisruptionBudget.yaml
+++ b/manifests/prometheus-podDisruptionBudget.yaml
@@ -1,0 +1,18 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.25.0
+  name: prometheus-k8s
+  namespace: monitoring
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: kube-prometheus
+      prometheus: k8s


### PR DESCRIPTION
Making sure there is always one prometheus replica and that alertmanager cluster is up and running. Those settings should ensure monitoring is operational during upgrades.