### PR TITLE
Update prometheus-operator CRDs to 0.46

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -26,7 +26,7 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "release-0.45"
+      "version": "release-0.46"
     },
     {
       "source": {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -99,7 +99,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "788d4456425eaf8c1d613582995bdf7de02154b0",
+      "version": "7f94a06b86d41c20176f0d5b53aa0100fdc361e6",
       "sum": "6reUygVmQrLEWQzTKcH8ceDbvM+2ztK3z2VBR2K2l+U="
     },
     {
@@ -109,8 +109,8 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "5555f492df250168657b72bb8cb60bec071de71f",
-      "sum": "quzK9/gITldAfVGBkFUsLjQ3Y2F4NOJ2GQUjPSD8HHQ="
+      "version": "7f94a06b86d41c20176f0d5b53aa0100fdc361e6",
+      "sum": "2CCa4pHH08Pnyf+0c+ZhVjM5h6TfoCbhHypPigpB9AM="
     },
     {
       "source": {

--- a/manifests/setup/prometheus-operator-0alertmanagerConfigCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0alertmanagerConfigCustomResourceDefinition.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+    - prometheus-operator
     kind: AlertmanagerConfig
     listKind: AlertmanagerConfigList
     plural: alertmanagerconfigs

--- a/manifests/setup/prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0alertmanagerCustomResourceDefinition.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+    - prometheus-operator
     kind: Alertmanager
     listKind: AlertmanagerList
     plural: alertmanagers

--- a/manifests/setup/prometheus-operator-0podmonitorCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0podmonitorCustomResourceDefinition.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+    - prometheus-operator
     kind: PodMonitor
     listKind: PodMonitorList
     plural: podmonitors

--- a/manifests/setup/prometheus-operator-0probeCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0probeCustomResourceDefinition.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+    - prometheus-operator
     kind: Probe
     listKind: ProbeList
     plural: probes
@@ -145,6 +147,37 @@ spec:
                           type: string
                         description: Labels assigned to all metrics scraped from the targets.
                         type: object
+                      relabelingConfigs:
+                        description: 'RelabelConfigs to apply to samples before ingestion. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config'
+                        items:
+                          description: 'RelabelConfig allows dynamic rewriting of the label set, being applied to samples before ingestion. It defines `<metric_relabel_configs>`-section of Prometheus configuration. More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs'
+                          properties:
+                            action:
+                              description: Action to perform based on regex matching. Default is 'replace'
+                              type: string
+                            modulus:
+                              description: Modulus to take of the hash of the source label values.
+                              format: int64
+                              type: integer
+                            regex:
+                              description: Regular expression against which the extracted value is matched. Default is '(.*)'
+                              type: string
+                            replacement:
+                              description: Replacement value against which a regex replace is performed if the regular expression matches. Regex capture groups are available. Default is '$1'
+                              type: string
+                            separator:
+                              description: Separator placed between concatenated source label values. default is ';'.
+                              type: string
+                            sourceLabels:
+                              description: The source labels select values from existing labels. Their content is concatenated using the configured separator and matched against the configured regular expression for the replace, keep, and drop actions.
+                              items:
+                                type: string
+                              type: array
+                            targetLabel:
+                              description: Label to which the resulting value is written in a replace action. It is mandatory for replace actions. Regex capture groups are available.
+                              type: string
+                          type: object
+                        type: array
                       static:
                         description: Targets is a list of URLs to probe using the configured prober.
                         items:

--- a/manifests/setup/prometheus-operator-0prometheusCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0prometheusCustomResourceDefinition.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+    - prometheus-operator
     kind: Prometheus
     listKind: PrometheusList
     plural: prometheuses
@@ -2636,6 +2638,11 @@ spec:
                     bearerTokenFile:
                       description: File to read bearer token for remote write.
                       type: string
+                    headers:
+                      additionalProperties:
+                        type: string
+                      description: Custom HTTP headers to be sent along with each remote write request. Be aware that headers that are set by Prometheus itself can't be overwritten. Only valid in Prometheus versions 2.25.0 and newer.
+                      type: object
                     name:
                       description: The name of the remote write queue, must be unique if specified. The name is used in metrics and logging in order to differentiate queues. Only valid in Prometheus versions 2.15.0 and newer.
                       type: string

--- a/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0servicemonitorCustomResourceDefinition.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+    - prometheus-operator
     kind: ServiceMonitor
     listKind: ServiceMonitorList
     plural: servicemonitors

--- a/manifests/setup/prometheus-operator-0thanosrulerCustomResourceDefinition.yaml
+++ b/manifests/setup/prometheus-operator-0thanosrulerCustomResourceDefinition.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   group: monitoring.coreos.com
   names:
+    categories:
+    - prometheus-operator
     kind: ThanosRuler
     listKind: ThanosRulerList
     plural: thanosrulers


### PR DESCRIPTION
Seems like we bumped prometheus-operator binary to 0.46, but forgot about updating CRDs.

I'll try to incorporate this sort of update in my auto updater script, but I don't promise it will work :smile: 