### PR TITLE
jsonnet: unify internal configuration field name

### DIFF
--- a/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
+++ b/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
@@ -101,7 +101,7 @@ local restrictedPodSecurityPolicy = {
 
     podSecurityPolicy:
       local blackboxExporterPspPrivileged =
-        if $.blackboxExporter.config.privileged then
+        if $.blackboxExporter._config.privileged then
           {
             metadata+: {
               name: 'blackbox-exporter-psp',
@@ -209,8 +209,8 @@ local restrictedPodSecurityPolicy = {
         hostPID: true,
         hostPorts: [
           {
-            max: $.nodeExporter.config.port,
-            min: $.nodeExporter.config.port,
+            max: $.nodeExporter._config.port,
+            min: $.nodeExporter._config.port,
           },
         ],
         readOnlyRootFilesystem: true,

--- a/jsonnet/kube-prometheus/addons/weave-net/weave-net.libsonnet
+++ b/jsonnet/kube-prometheus/addons/weave-net/weave-net.libsonnet
@@ -52,9 +52,9 @@
       apiVersion: 'monitoring.coreos.com/v1',
       kind: 'PrometheusRule',
       metadata: {
-        labels: p.config.mixin.ruleLabels,
+        labels: p._config.mixin.ruleLabels,
         name: 'weave-net-rules',
-        namespace: p.config.namespace,
+        namespace: p._config.namespace,
       },
       spec: {
         groups: [{

--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -72,23 +72,23 @@ local defaults = {
 
 function(params) {
   local am = self,
-  config:: defaults + params,
+  _config:: defaults + params,
   // Safety check
-  assert std.isObject(am.config.resources),
-  assert std.isObject(am.config.mixin._config),
+  assert std.isObject(am._config.resources),
+  assert std.isObject(am._config.mixin._config),
 
   mixin:: (import 'github.com/prometheus/alertmanager/doc/alertmanager-mixin/mixin.libsonnet') +
           (import 'github.com/kubernetes-monitoring/kubernetes-mixin/alerts/add-runbook-links.libsonnet') {
-            _config+:: am.config.mixin._config,
+            _config+:: am._config.mixin._config,
           },
 
   prometheusRule: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'PrometheusRule',
     metadata: {
-      labels: am.config.commonLabels + am.config.mixin.ruleLabels,
-      name: 'alertmanager-' + am.config.name + '-rules',
-      namespace: am.config.namespace,
+      labels: am._config.commonLabels + am._config.mixin.ruleLabels,
+      name: 'alertmanager-' + am._config.name + '-rules',
+      namespace: am._config.namespace,
     },
     spec: {
       local r = if std.objectHasAll(am.mixin, 'prometheusRules') then am.mixin.prometheusRules.groups else [],
@@ -102,16 +102,16 @@ function(params) {
     kind: 'Secret',
     type: 'Opaque',
     metadata: {
-      name: 'alertmanager-' + am.config.name,
-      namespace: am.config.namespace,
-      labels: { alertmanager: am.config.name } + am.config.commonLabels,
+      name: 'alertmanager-' + am._config.name,
+      namespace: am._config.namespace,
+      labels: { alertmanager: am._config.name } + am._config.commonLabels,
     },
     stringData: {
-      'alertmanager.yaml': if std.type(am.config.config) == 'object'
+      'alertmanager.yaml': if std.type(am._config.config) == 'object'
       then
-        std.manifestYamlDoc(am.config.config)
+        std.manifestYamlDoc(am._config.config)
       else
-        am.config.config,
+        am._config.config,
     },
   },
 
@@ -119,9 +119,9 @@ function(params) {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
     metadata: {
-      name: 'alertmanager-' + am.config.name,
-      namespace: am.config.namespace,
-      labels: { alertmanager: am.config.name } + am.config.commonLabels,
+      name: 'alertmanager-' + am._config.name,
+      namespace: am._config.namespace,
+      labels: { alertmanager: am._config.name } + am._config.commonLabels,
     },
   },
 
@@ -129,9 +129,9 @@ function(params) {
     apiVersion: 'v1',
     kind: 'Service',
     metadata: {
-      name: 'alertmanager-' + am.config.name,
-      namespace: am.config.namespace,
-      labels: { alertmanager: am.config.name } + am.config.commonLabels,
+      name: 'alertmanager-' + am._config.name,
+      namespace: am._config.namespace,
+      labels: { alertmanager: am._config.name } + am._config.commonLabels,
     },
     spec: {
       ports: [
@@ -139,8 +139,8 @@ function(params) {
       ],
       selector: {
         app: 'alertmanager',
-        alertmanager: am.config.name,
-      } + am.config.selectorLabels,
+        alertmanager: am._config.name,
+      } + am._config.selectorLabels,
       sessionAffinity: 'ClientIP',
     },
   },
@@ -150,14 +150,14 @@ function(params) {
     kind: 'ServiceMonitor',
     metadata: {
       name: 'alertmanager',
-      namespace: am.config.namespace,
-      labels: am.config.commonLabels,
+      namespace: am._config.namespace,
+      labels: am._config.commonLabels,
     },
     spec: {
       selector: {
         matchLabels: {
-          alertmanager: am.config.name,
-        } + am.config.selectorLabels,
+          alertmanager: am._config.name,
+        } + am._config.selectorLabels,
       },
       endpoints: [
         { port: 'web', interval: '30s' },
@@ -169,16 +169,16 @@ function(params) {
     apiVersion: 'policy/v1beta1',
     kind: 'PodDisruptionBudget',
     metadata: {
-      name: 'alertmanager-' + am.config.name,
-      namespace: am.config.namespace,
-      labels: am.config.commonLabels,
+      name: 'alertmanager-' + am._config.name,
+      namespace: am._config.namespace,
+      labels: am._config.commonLabels,
     },
     spec: {
       maxUnavailable: 1,
       selector: {
         matchLabels: {
-          alertmanager: am.config.name,
-        } + am.config.selectorLabels,
+          alertmanager: am._config.name,
+        } + am._config.selectorLabels,
       },
     },
   },
@@ -187,22 +187,22 @@ function(params) {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'Alertmanager',
     metadata: {
-      name: am.config.name,
-      namespace: am.config.namespace,
+      name: am._config.name,
+      namespace: am._config.namespace,
       labels: {
-        alertmanager: am.config.name,
-      } + am.config.commonLabels,
+        alertmanager: am._config.name,
+      } + am._config.commonLabels,
     },
     spec: {
-      replicas: am.config.replicas,
-      version: am.config.version,
-      image: am.config.image,
+      replicas: am._config.replicas,
+      version: am._config.version,
+      image: am._config.image,
       podMetadata: {
-        labels: am.config.commonLabels,
+        labels: am._config.commonLabels,
       },
-      resources: am.config.resources,
+      resources: am._config.resources,
       nodeSelector: { 'kubernetes.io/os': 'linux' },
-      serviceAccountName: 'alertmanager-' + am.config.name,
+      serviceAccountName: 'alertmanager-' + am._config.name,
       securityContext: {
         runAsUser: 1000,
         runAsNonRoot: true,

--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -33,35 +33,35 @@ local defaults = {
 
 function(params) {
   local g = self,
-  cfg:: defaults + params,
+  _config:: defaults + params,
   // Safety check
-  assert std.isObject(g.cfg.resources),
+  assert std.isObject(g._config.resources),
 
   local glib = (import 'github.com/brancz/kubernetes-grafana/grafana/grafana.libsonnet') + {
     _config+:: {
-      namespace: g.cfg.namespace,
+      namespace: g._config.namespace,
       versions+:: {
-        grafana: g.cfg.version,
+        grafana: g._config.version,
       },
       imageRepos+:: {
-        grafana: g.cfg.imageRepos,
+        grafana: g._config.imageRepos,
       },
       prometheus+:: {
-        name: g.cfg.prometheusName,
+        name: g._config.prometheusName,
       },
       grafana+:: {
-        labels: g.cfg.commonLabels,
-        dashboards: g.cfg.dashboards,
-        resources: g.cfg.resources,
-        rawDashboards: g.cfg.rawDashboards,
-        folderDashboards: g.cfg.folderDashboards,
-        containers: g.cfg.containers,
-        config+: g.cfg.config,
-        plugins+: g.cfg.plugins,
+        labels: g._config.commonLabels,
+        dashboards: g._config.dashboards,
+        resources: g._config.resources,
+        rawDashboards: g._config.rawDashboards,
+        folderDashboards: g._config.folderDashboards,
+        containers: g._config.containers,
+        config+: g._config.config,
+        plugins+: g._config.plugins,
       } + (
         // Conditionally overwrite default setting.
-        if std.length(g.cfg.datasources) > 0 then
-          { datasources: g.cfg.datasources }
+        if std.length(g._config.datasources) > 0 then
+          { datasources: g._config.datasources }
         else {}
       ),
     },
@@ -75,7 +75,7 @@ function(params) {
   dashboardDatasources: glib.grafana.dashboardDatasources,
   dashboardSources: glib.grafana.dashboardSources,
 
-  dashboardDefinitions: if std.length(g.cfg.dashboards) > 0 then {
+  dashboardDefinitions: if std.length(g._config.dashboards) > 0 then {
     apiVersion: 'v1',
     kind: 'ConfigMapList',
     items: glib.grafana.dashboardDefinitions,
@@ -85,8 +85,8 @@ function(params) {
     kind: 'ServiceMonitor',
     metadata: {
       name: 'grafana',
-      namespace: g.cfg.namespace,
-      labels: g.cfg.commonLabels,
+      namespace: g._config.namespace,
+      labels: g._config.commonLabels,
     },
     spec: {
       selector: {

--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -26,19 +26,19 @@ local defaults = {
 
 function(params) {
   local k8s = self,
-  config:: defaults + params,
+  _config:: defaults + params,
 
   mixin:: (import 'github.com/kubernetes-monitoring/kubernetes-mixin/mixin.libsonnet') {
-    _config+:: k8s.config.mixin._config,
+    _config+:: k8s._config.mixin._config,
   },
 
   prometheusRule: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'PrometheusRule',
     metadata: {
-      labels: k8s.config.commonLabels + k8s.config.mixin.ruleLabels,
+      labels: k8s._config.commonLabels + k8s._config.mixin.ruleLabels,
       name: 'kubernetes-monitoring-rules',
-      namespace: k8s.config.namespace,
+      namespace: k8s._config.namespace,
     },
     spec: {
       local r = if std.objectHasAll(k8s.mixin, 'prometheusRules') then k8s.mixin.prometheusRules.groups else {},
@@ -52,7 +52,7 @@ function(params) {
     kind: 'ServiceMonitor',
     metadata: {
       name: 'kube-scheduler',
-      namespace: k8s.config.namespace,
+      namespace: k8s._config.namespace,
       labels: { 'app.kubernetes.io/name': 'kube-scheduler' },
     },
     spec: {
@@ -78,7 +78,7 @@ function(params) {
     kind: 'ServiceMonitor',
     metadata: {
       name: 'kubelet',
-      namespace: k8s.config.namespace,
+      namespace: k8s._config.namespace,
       labels: { 'app.kubernetes.io/name': 'kubelet' },
     },
     spec: {
@@ -150,7 +150,7 @@ function(params) {
     kind: 'ServiceMonitor',
     metadata: {
       name: 'kube-controller-manager',
-      namespace: k8s.config.namespace,
+      namespace: k8s._config.namespace,
       labels: { 'app.kubernetes.io/name': 'kube-controller-manager' },
     },
     spec: {
@@ -185,7 +185,7 @@ function(params) {
     kind: 'ServiceMonitor',
     metadata: {
       name: 'kube-apiserver',
-      namespace: k8s.config.namespace,
+      namespace: k8s._config.namespace,
       labels: { 'app.kubernetes.io/name': 'apiserver' },
     },
     spec: {
@@ -239,7 +239,7 @@ function(params) {
     kind: 'ServiceMonitor',
     metadata: {
       name: 'coredns',
-      namespace: k8s.config.namespace,
+      namespace: k8s._config.namespace,
       labels: { 'app.kubernetes.io/name': 'coredns' },
     },
     spec: {

--- a/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet
@@ -41,20 +41,20 @@ local defaults = {
 
 function(params) {
   local krp = self,
-  config:: defaults + params,
+  _config:: defaults + params,
   // Safety check
-  assert std.isObject(krp.config.resources),
+  assert std.isObject(krp._config.resources),
 
-  name: krp.config.name,
-  image: krp.config.image,
+  name: krp._config.name,
+  image: krp._config.image,
   args: [
     '--logtostderr',
-    '--secure-listen-address=' + krp.config.secureListenAddress,
-    '--tls-cipher-suites=' + std.join(',', krp.config.tlsCipherSuites),
-    '--upstream=' + krp.config.upstream,
+    '--secure-listen-address=' + krp._config.secureListenAddress,
+    '--tls-cipher-suites=' + std.join(',', krp._config.tlsCipherSuites),
+    '--upstream=' + krp._config.upstream,
   ],
-  resources: krp.config.resources,
-  ports: krp.config.ports,
+  resources: krp._config.resources,
+  ports: krp._config.ports,
   securityContext: {
     runAsUser: 65532,
     runAsGroup: 65532,

--- a/jsonnet/kube-prometheus/components/mixin/custom.libsonnet
+++ b/jsonnet/kube-prometheus/components/mixin/custom.libsonnet
@@ -18,22 +18,22 @@ local defaults = {
 
 function(params) {
   local m = self,
-  config:: defaults + params,
+  _config:: defaults + params,
 
   local alertsandrules = (import './alerts/alerts.libsonnet') + (import './rules/rules.libsonnet'),
 
   mixin:: alertsandrules +
           (import 'github.com/kubernetes-monitoring/kubernetes-mixin/alerts/add-runbook-links.libsonnet') {
-            _config+:: m.config.mixin._config,
+            _config+:: m._config.mixin._config,
           },
 
   prometheusRule: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'PrometheusRule',
     metadata: {
-      labels: m.config.commonLabels + m.config.mixin.ruleLabels,
-      name: m.config.name + '-rules',
-      namespace: m.config.namespace,
+      labels: m._config.commonLabels + m._config.mixin.ruleLabels,
+      name: m._config.name + '-rules',
+      namespace: m._config.namespace,
     },
     spec: {
       local r = if std.objectHasAll(m.mixin, 'prometheusRules') then m.mixin.prometheusRules.groups else [],

--- a/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
@@ -42,18 +42,20 @@ function(params)
 
   prometheusOperator(config) {
     local po = self,
+    // declare variable as a field to allow overriding options and to have unified API across all components
+    _config:: config,
     mixin:: (import 'github.com/prometheus-operator/prometheus-operator/jsonnet/mixin/mixin.libsonnet') +
             (import 'github.com/kubernetes-monitoring/kubernetes-mixin/alerts/add-runbook-links.libsonnet') {
-              _config+:: config.mixin._config,
+              _config+:: po._config.mixin._config,
             },
 
     prometheusRule: {
       apiVersion: 'monitoring.coreos.com/v1',
       kind: 'PrometheusRule',
       metadata: {
-        labels: config.commonLabels + config.mixin.ruleLabels,
-        name: config.name + '-rules',
-        namespace: config.namespace,
+        labels: po._config.commonLabels + po._config.mixin.ruleLabels,
+        name: po._config.name + '-rules',
+        namespace: po._config.namespace,
       },
       spec: {
         local r = if std.objectHasAll(po.mixin, 'prometheusRules') then po.mixin.prometheusRules.groups else [],

--- a/jsonnet/kube-prometheus/platforms/eks.libsonnet
+++ b/jsonnet/kube-prometheus/platforms/eks.libsonnet
@@ -69,9 +69,9 @@
       apiVersion: 'monitoring.coreos.com/v1',
       kind: 'PrometheusRule',
       metadata: {
-        labels: $.prometheus.config.commonLabels + $.prometheus.config.mixin.ruleLabels,
+        labels: $.prometheus._config.commonLabels + $.prometheus._config.mixin.ruleLabels,
         name: 'eks-rules',
-        namespace: $.prometheus.config.namespace,
+        namespace: $.prometheus._config.namespace,
       },
       spec: {
         groups: [


### PR DESCRIPTION
Before this PR we were merging default configuration and user-provided configuration into a field or a variable with name `config` or `cfg`. This PR provides a unified way to store configuration in the form of hidden `_config` field. Such field is a de-facto standard for this particular case and should prevent name collision (we had it in grafana component).

Changes:
- exposed `_config` for prometheus-operator component
- renamed `cfg` to `_config` for grafana.libsonnet
- renamed `config` to `_config` for other components
- adjusted `platforms/eks.libsonnet`
- adjusted `addons/weave-net/weave-net.libsonnet`