### PR TITLE
[HOLD] Update kube-state-metrics version to v2.0.0-rc.0

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -53,7 +53,7 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "release-1.9"
+      "version": "release-2.0"
     },
     {
       "source": {
@@ -62,7 +62,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "master"
+      "version": "release-2.0"
     },
     {
       "source": {

--- a/jsonnet/kube-prometheus/versions.json
+++ b/jsonnet/kube-prometheus/versions.json
@@ -2,7 +2,7 @@
   "alertmanager": "0.21.0",
   "blackboxExporter": "0.18.0",
   "grafana": "7.4.3",
-  "kubeStateMetrics": "1.9.8",
+  "kubeStateMetrics": "2.0.0-rc.0",
   "nodeExporter": "1.1.1",
   "prometheus": "2.25.0",
   "prometheusAdapter": "0.8.3",

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -79,8 +79,8 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "89aaf6c524ee891140c4c8f2a05b1b16f5847309",
-      "sum": "zD/pbQLnQq+5hegEelaheHS8mn1h09GTktFO74iwlBI="
+      "version": "8fb9b23f7376be9014f110b83a83fe930e027726",
+      "sum": "aE6e4P6NiMf5eQMv0w4hy+oSeLBzwCrjUSkP+DSgrro="
     },
     {
       "source": {
@@ -89,7 +89,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "72d6d3106861f992b7d6ecc0a88abe9b12ad5427",
+      "version": "8fb9b23f7376be9014f110b83a83fe930e027726",
       "sum": "Yf8mNAHrV1YWzrdV8Ry5dJ8YblepTGw3C0Zp10XIYLo="
     },
     {

--- a/manifests/kube-state-metrics-clusterRole.yaml
+++ b/manifests/kube-state-metrics-clusterRole.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.8
+    app.kubernetes.io/version: 2.0.0-rc.0
   name: kube-state-metrics
 rules:
 - apiGroups:
@@ -32,7 +32,6 @@ rules:
   - daemonsets
   - deployments
   - replicasets
-  - ingresses
   verbs:
   - list
   - watch
@@ -107,6 +106,14 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
+  - ingresses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
   verbs:
   - list
   - watch

--- a/manifests/kube-state-metrics-clusterRoleBinding.yaml
+++ b/manifests/kube-state-metrics-clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.8
+    app.kubernetes.io/version: 2.0.0-rc.0
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/kube-state-metrics-deployment.yaml
+++ b/manifests/kube-state-metrics-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.8
+    app.kubernetes.io/version: 2.0.0-rc.0
   name: kube-state-metrics
   namespace: monitoring
 spec:
@@ -21,7 +21,7 @@ spec:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 1.9.8
+        app.kubernetes.io/version: 2.0.0-rc.0
     spec:
       containers:
       - args:
@@ -29,7 +29,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0-rc.0
         name: kube-state-metrics
         resources:
           limits:
@@ -38,6 +38,8 @@ spec:
           requests:
             cpu: 10m
             memory: 190Mi
+        securityContext:
+          runAsUser: 65534
       - args:
         - --logtostderr
         - --secure-listen-address=:8443

--- a/manifests/kube-state-metrics-prometheusRule.yaml
+++ b/manifests/kube-state-metrics-prometheusRule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.8
+    app.kubernetes.io/version: 2.0.0-rc.0
     prometheus: k8s
     role: alert-rules
   name: kube-state-metrics-rules

--- a/manifests/kube-state-metrics-service.yaml
+++ b/manifests/kube-state-metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.8
+    app.kubernetes.io/version: 2.0.0-rc.0
   name: kube-state-metrics
   namespace: monitoring
 spec:

--- a/manifests/kube-state-metrics-serviceAccount.yaml
+++ b/manifests/kube-state-metrics-serviceAccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.8
+    app.kubernetes.io/version: 2.0.0-rc.0
   name: kube-state-metrics
   namespace: monitoring

--- a/manifests/kube-state-metrics-serviceMonitor.yaml
+++ b/manifests/kube-state-metrics-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 1.9.8
+    app.kubernetes.io/version: 2.0.0-rc.0
   name: kube-state-metrics
   namespace: monitoring
 spec:


### PR DESCRIPTION
We need https://github.com/kubernetes-monitoring/kubernetes-mixin/pull/534 to merge before this gets merged.