### PR TITLE
jsonnet/kube-prometheus: fix jb warning message

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -35,7 +35,8 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "master"
+      "version": "master",
+      "name": "prometheus-operator-mixin"
     },
     {
       "source": {
@@ -100,7 +101,8 @@
           "subdir": "mixin"
         }
       },
-      "version": "release-0.19"
+      "version": "release-0.19",
+      "name": "thanos-mixin"
     }
   ],
   "legacyImports": true

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -100,7 +100,8 @@
         }
       },
       "version": "a4f5928b074e75addb76a27c5ebfe78314fcd6d1",
-      "sum": "6reUygVmQrLEWQzTKcH8ceDbvM+2ztK3z2VBR2K2l+U="
+      "sum": "6reUygVmQrLEWQzTKcH8ceDbvM+2ztK3z2VBR2K2l+U=",
+      "name": "prometheus-operator-mixin"
     },
     {
       "source": {
@@ -152,7 +153,8 @@
         }
       },
       "version": "ba6c5c4726ff52807c7383c68f2159b1af7980bb",
-      "sum": "XP3uq7xcfKHsnWsz1v992csZhhZR3jQma6hFOfSViTs="
+      "sum": "XP3uq7xcfKHsnWsz1v992csZhhZR3jQma6hFOfSViTs=",
+      "name": "thanos-mixin"
     },
     {
       "source": {


### PR DESCRIPTION
Fixes #827 by assigning prometheus-operator and thanos mixins a dedicated name.