### PR TITLE
jsonnet/addons: simplify managed-cluster addon

### DIFF
--- a/jsonnet/kube-prometheus/addons/managed-cluster.libsonnet
+++ b/jsonnet/kube-prometheus/addons/managed-cluster.libsonnet
@@ -2,12 +2,9 @@
 // Disable scrape jobs, service monitors, and alert groups for these components by overwriting 'main.libsonnet' defaults
 
 {
-  local k = super.kubernetesControlPlane,
-
   kubernetesControlPlane+: {
-    [q]: null
-    for q in std.objectFields(k)
-    if std.setMember(q, ['serviceMonitorKubeControllerManager', 'serviceMonitorKubeScheduler'])
+    serviceMonitorKubeControllerManager:: null,
+    serviceMonitorKubeScheduler:: null,
   } + {
     prometheusRule+: {
       spec+: {


### PR DESCRIPTION
Instead of looping over all objects to select 2 we can force them to be present but hidden and null. This would simplify the codebase a bit and allow better downstream usage possibilities.

Related to https://github.com/prometheus-operator/kube-prometheus/issues/1051

/cc @prometheus-operator/kube-prometheus-reviewers 