### PR TITLE
jsonnet: Add External mixin lib

### DIFF
--- a/jsonnet/kube-prometheus/lib/mixin.libsonnet
+++ b/jsonnet/kube-prometheus/lib/mixin.libsonnet
@@ -1,0 +1,38 @@
+local defaults = {
+  name: error 'provide name',
+  namespace: 'monitoring',
+  labels: {
+    prometheus: 'k8s',
+  },
+  mixin: error 'provide a mixin',
+};
+
+function(params) {
+  config:: defaults + params,
+
+  local m = self,
+
+  local prometheusRules = if std.objectHasAll(m.config.mixin, 'prometheusRules') || std.objectHasAll(m.config.mixin, 'prometheusAlerts') then {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'PrometheusRule',
+    metadata: {
+      labels: m.config.labels,
+      name: m.config.name,
+      namespace: m.config.namespace,
+    },
+    spec: {
+      local r = if std.objectHasAll(m.config.mixin, 'prometheusRules') then m.config.mixin.prometheusRules.groups else [],
+      local a = if std.objectHasAll(m.config.mixin, 'prometheusAlerts') then m.config.mixin.prometheusAlerts.groups else [],
+      groups: a + r,
+    },
+  },
+
+  local grafanaDashboards = if std.objectHasAll(m.config.mixin, 'grafanaDashboards') then (
+    if std.objectHas(m.config, 'dashboardFolder') then {
+      [m.config.dashboardFolder]+: m.config.mixin.grafanaDashboards,
+    } else (m.config.mixin.grafanaDashboards)
+  ),
+
+  prometheusRules: prometheusRules,
+  grafanaDashboards: grafanaDashboards,
+}


### PR DESCRIPTION
Not sure if this is the correct approach but it's a feature I need since the 0.7 upgrade. 

Maybe it should not be a component but did not know where it should fit otherwise and the current project setup made it easy to implement this way.

Usage:

```jsonnet
{ ['external-mixins-' + name]: kp.externalMixins[name] for name in std.objectFields(kp.externalMixins) } +
```

```jsonnet
      externalMixins+: {
        mixins: [
          {
            name: 'sample', // Alerting rule name and dashboard Configmap name
            namespace: 'abc', // Can be omitted
            dashboardFolder: 'Misc', // Can be omitted
            mixin: import 'blackbox-exporter-mixin/mixin.libsonnet', // Add your custom configuration when importing the mixin
          },
        ],
      },
```

Would add documentation if the approach is fine. Pointers/hints are appreciated :)