### PR TITLE
jsonnet: Add windows_exporter queries for adapter

### DIFF
--- a/jsonnet/kube-prometheus/addons/windows.libsonnet
+++ b/jsonnet/kube-prometheus/addons/windows.libsonnet
@@ -10,6 +10,17 @@ local windowsrules = import 'kubernetes-mixin/rules/windows.libsonnet';
           targets: [error 'must provide targets array'],
         },
       ],
+      relabel_configs: [
+        {
+          action: 'replace',
+          regex: '(.*)',
+          replacement: '$1',
+          sourceLabels: [
+            '__meta_kubernetes_endpoint_address_target_name',
+          ],
+          targetLabel: 'instance',
+        },
+      ],
     },
 
     grafana+:: {

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -27,7 +27,7 @@ local defaults = {
     resourceRules: {
       cpu: {
         containerQuery: 'sum(irate(container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!="",pod!=""}[5m])) by (<<.GroupBy>>)',
-        nodeQuery: 'sum(1 - irate(node_cpu_seconds_total{mode="idle"}[5m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>)',
+        nodeQuery: 'sum(1 - irate(node_cpu_seconds_total{mode="idle"}[5m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>) or sum (1- irate(windows_cpu_time_total{mode="idle", job="windows-exporter",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)',
         resources: {
           overrides: {
             node: { resource: 'node' },
@@ -39,7 +39,7 @@ local defaults = {
       },
       memory: {
         containerQuery: 'sum(container_memory_working_set_bytes{<<.LabelMatchers>>,container!="",pod!=""}) by (<<.GroupBy>>)',
-        nodeQuery: 'sum(node_memory_MemTotal_bytes{job="node-exporter",<<.LabelMatchers>>} - node_memory_MemAvailable_bytes{job="node-exporter",<<.LabelMatchers>>}) by (<<.GroupBy>>)',
+        nodeQuery: 'sum(node_memory_MemTotal_bytes{job="node-exporter",<<.LabelMatchers>>} - node_memory_MemAvailable_bytes{job="node-exporter",<<.LabelMatchers>>}) by (<<.GroupBy>>) or sum(windows_cs_physical_memory_bytes{job="windows-exporter",<<.LabelMatchers>>} - windows_memory_available_bytes{job="windows-exporter",<<.LabelMatchers>>}) by (<<.GroupBy>>)',
         resources: {
           overrides: {
             instance: { resource: 'node' },

--- a/manifests/prometheus-adapter-configMap.yaml
+++ b/manifests/prometheus-adapter-configMap.yaml
@@ -5,7 +5,7 @@ data:
       "cpu":
         "containerLabel": "container"
         "containerQuery": "sum(irate(container_cpu_usage_seconds_total{<<.LabelMatchers>>,container!=\"\",pod!=\"\"}[5m])) by (<<.GroupBy>>)"
-        "nodeQuery": "sum(1 - irate(node_cpu_seconds_total{mode=\"idle\"}[5m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>)"
+        "nodeQuery": "sum(1 - irate(node_cpu_seconds_total{mode=\"idle\"}[5m]) * on(namespace, pod) group_left(node) node_namespace_pod:kube_pod_info:{<<.LabelMatchers>>}) by (<<.GroupBy>>) or sum (1- irate(windows_cpu_time_total{mode=\"idle\", job=\"windows-exporter\",<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)"
         "resources":
           "overrides":
             "namespace":
@@ -17,7 +17,7 @@ data:
       "memory":
         "containerLabel": "container"
         "containerQuery": "sum(container_memory_working_set_bytes{<<.LabelMatchers>>,container!=\"\",pod!=\"\"}) by (<<.GroupBy>>)"
-        "nodeQuery": "sum(node_memory_MemTotal_bytes{job=\"node-exporter\",<<.LabelMatchers>>} - node_memory_MemAvailable_bytes{job=\"node-exporter\",<<.LabelMatchers>>}) by (<<.GroupBy>>)"
+        "nodeQuery": "sum(node_memory_MemTotal_bytes{job=\"node-exporter\",<<.LabelMatchers>>} - node_memory_MemAvailable_bytes{job=\"node-exporter\",<<.LabelMatchers>>}) by (<<.GroupBy>>) or sum(windows_cs_physical_memory_bytes{job=\"windows-exporter\",<<.LabelMatchers>>} - windows_memory_available_bytes{job=\"windows-exporter\",<<.LabelMatchers>>}) by (<<.GroupBy>>)"
         "resources":
           "overrides":
             "instance":


### PR DESCRIPTION
This PR includes [windows_exporter](https://github.com/prometheus-community/windows_exporter) targeting metrics in the node queries for the prometheus adapter configuration. The windows_exporter runs as a Windows service on Windows nodes.
This will help obtain the resource metrics: memory and CPU for Windows nodes. This change will also help in
displaying metrics reported through the 'kubectl top' command which currently reports 'unknown' status for Windows nodes that use prometheus adapter configuration for metrics reporting. 
Additionally this PR adds a relabeling config to the scrape config of windows-exporter in the Windows add-on using the 'replace' action field to replace the node endpoint address with node name. The windows_exporter returns endpoint target as node IP but we need it to be node name to use the prometheus adapter queries.

Ran commands:
```
make generate
```

Would like to get feedback and will add documentation if it looks good. The prometheus queries have been manually tested for the results.
