### PR TITLE
Update developing examples to use ExampleAlert instead of Watchdog

### DIFF
--- a/docs/developing-prometheus-rules-and-grafana-dashboards.md
+++ b/docs/developing-prometheus-rules-and-grafana-dashboards.md
@@ -90,13 +90,13 @@ local kp = (import 'kube-prometheus/main.libsonnet') + {
             name: 'example-group',
             rules: [
               {
-                alert: 'Watchdog',
+                alert: 'ExampleAlert',
                 expr: 'vector(1)',
                 labels: {
-                  severity: 'none',
+                  severity: 'warning',
                 },
                 annotations: {
-                  description: 'This is a Watchdog meant to ensure that the entire alerting pipeline is functional.',
+                  description: 'This is an example alert.',
                 },
               },
             ],

--- a/examples/existingrule.json
+++ b/examples/existingrule.json
@@ -1,1 +1,1 @@
-{"groups":[{"name":"example-group","rules":[{"alert":"Watchdog","annotations":{"description":"This is a Watchdog meant to ensure that the entire alerting pipeline is functional."},"expr":"vector(1)","labels":{"severity":"none"}}]}]}
+{"groups":[{"name":"example-group","rules":[{"alert":"ExampleAlert","annotations":{"description":"This is an example alert."},"expr":"vector(1)","labels":{"severity":"warning"}}]}]}

--- a/examples/existingrule.yaml
+++ b/examples/existingrule.yaml
@@ -1,9 +1,9 @@
 groups:
 - name: example-group
   rules:
-  - alert: Watchdog
+  - alert: ExampleAlert
     expr: vector(1)
     labels:
-      severity: "none"
+      severity: "warning"
     annotations:
-      description: This is a Watchdog meant to ensure that the entire alerting pipeline is functional.
+      description: This is an example alert.

--- a/examples/prometheus-additional-alert-rule-example.jsonnet
+++ b/examples/prometheus-additional-alert-rule-example.jsonnet
@@ -18,13 +18,13 @@ local kp = (import 'kube-prometheus/main.libsonnet') + {
             name: 'example-group',
             rules: [
               {
-                alert: 'Watchdog',
+                alert: 'ExampleAlert',
                 expr: 'vector(1)',
                 labels: {
-                  severity: 'none',
+                  severity: 'warning',
                 },
                 annotations: {
-                  description: 'This is a Watchdog meant to ensure that the entire alerting pipeline is functional.',
+                  description: 'This is an example alert.',
                 },
               },
             ],


### PR DESCRIPTION
Replace Watchdog alerts part of the `example-group` in some examples by
ExampleAlert alerts to reinforce the fact that this is just an example.

Fixes #1027 