### PR TITLE
add cluster role to list and watch ingresses in "networking.k8s.io"

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -229,6 +229,11 @@ function(params) {
           resources: ['ingresses'],
           verbs: ['get', 'list', 'watch'],
         },
+        {
+          apiGroups: ['networking.k8s.io'],
+          resources: ['ingresses'],
+          verbs: ['get', 'list', 'watch'],
+        },
       ],
     };
     {

--- a/manifests/prometheus-roleSpecificNamespaces.yaml
+++ b/manifests/prometheus-roleSpecificNamespaces.yaml
@@ -29,6 +29,14 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - ingresses
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
@@ -58,6 +66,14 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - networking.k8s.io
+    resources:
+    - ingresses
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:
@@ -81,6 +97,14 @@ items:
     - watch
   - apiGroups:
     - extensions
+    resources:
+    - ingresses
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - networking.k8s.io
     resources:
     - ingresses
     verbs:


### PR DESCRIPTION
I found the prometheus cannot list and watch ingresses in api group "networking.k8s.io".

The Ingress I created is:
```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: prometheus
  namespace: monitoring
spec:
  rules:
  - host: prometheus.minikube
    http:
      paths:
      - pathType: Prefix
        path: "/"
        backend:
          service: 
            name: prometheus-k8s
            port: 
              number: 9090
```

And error log is:
```
level=error ts=2021-03-26T15:58:34.357Z caller=klog.go:96 component=k8s_client_runtime func=ErrorDepth msg="pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.Ingress: failed to list *v1beta1.Ingress: ingresses.networking.k8s.io is forbidden: User \"system:serviceaccount:monitoring:prometheus-k8s\" cannot list resource \"ingresses\" in API group \"networking.k8s.io\" in the namespace \"monitoring\""
```

After I add proper role for the prometheus manually, it works.

So I update the jsonnet file and generate all yaml files in "manifests".