### PR TITLE
Allow configuring the platform used directly instead of having to use a patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,57 +360,28 @@ Jsonnet is a turing complete language, any logic can be reflected in it. It also
 
 ### Cluster Creation Tools
 
-A common example is that not all Kubernetes clusters are created exactly the same way, meaning the configuration to monitor them may be slightly different. For [kubeadm](examples/jsonnet-snippets/kubeadm.jsonnet), [bootkube](examples/jsonnet-snippets/bootkube.jsonnet), [kops](examples/jsonnet-snippets/kops.jsonnet) and [kubespray](examples/jsonnet-snippets/kubespray.jsonnet) clusters there are mixins available to easily configure these:
+A common example is that not all Kubernetes clusters are created exactly the same way, meaning the configuration to monitor them may be slightly different. For the following clusters there are mixins available to easily configure them:
 
-kubeadm:
+* aws
+* bootkube
+* eks
+* gke
+* kops-coredns
+* kubeadm
+* kubespray
 
-[embedmd]:# (examples/jsonnet-snippets/kubeadm.jsonnet)
+These mixins are selectable via the `platform` field of kubePrometheus:
+
+[embedmd]:# (examples/jsonnet-snippets/platform.jsonnet)
 ```jsonnet
 (import 'kube-prometheus/main.libsonnet') +
-(import 'kube-prometheus/platforms/kubeadm.libsonnet')
-```
-
-bootkube:
-
-[embedmd]:# (examples/jsonnet-snippets/bootkube.jsonnet)
-```jsonnet
-(import 'kube-prometheus/main.libsonnet') +
-(import 'kube-prometheus/platforms/bootkube.libsonnet')
-```
-
-kops:
-
-[embedmd]:# (examples/jsonnet-snippets/kops.jsonnet)
-```jsonnet
-(import 'kube-prometheus/main.libsonnet') +
-(import 'kube-prometheus/platforms/kops.libsonnet')
-```
-
-kops with CoreDNS:
-
-If your kops cluster is using CoreDNS, there is an additional mixin to import.
-
-[embedmd]:# (examples/jsonnet-snippets/kops-coredns.jsonnet)
-```jsonnet
-(import 'kube-prometheus/main.libsonnet') +
-(import 'kube-prometheus/platforms/kops.libsonnet') +
-(import 'kube-prometheus/platforms/kops-coredns.libsonnet')
-```
-
-kubespray:
-
-[embedmd]:# (examples/jsonnet-snippets/kubespray.jsonnet)
-```jsonnet
-(import 'kube-prometheus/main.libsonnet') +
-(import 'kube-prometheus/platforms/kubespray.libsonnet')
-```
-
-aws:
-
-[embedmd]:# (examples/jsonnet-snippets/aws.jsonnet)
-```jsonnet
-(import 'kube-prometheus/main.libsonnet') +
-(import 'kube-prometheus/platforms/aws.libsonnet')
+{
+  values+:: {
+    kubePrometheus+: {
+      platform: 'example-platform',
+    },
+  },
+}
 ```
 
 ### Internal Registry

--- a/docs/EKS-cni-support.md
+++ b/docs/EKS-cni-support.md
@@ -7,11 +7,13 @@ One fatal issue that can occur is that you run out of IP addresses in your eks c
 You can monitor the `awscni` using kube-promethus with : 
 [embedmd]:# (../examples/eks-cni-example.jsonnet)
 ```jsonnet
-local kp = (import 'kube-prometheus/main.libsonnet') +
-           (import 'kube-prometheus/platforms/eks.libsonnet') + {
+local kp = (import 'kube-prometheus/main.libsonnet') + {
   values+:: {
     common+: {
       namespace: 'monitoring',
+    },
+    kubePrometheus+: {
+      platform: 'eks',
     },
   },
   kubernetesControlPlane+: {

--- a/examples/eks-cni-example.jsonnet
+++ b/examples/eks-cni-example.jsonnet
@@ -1,8 +1,10 @@
-local kp = (import 'kube-prometheus/main.libsonnet') +
-           (import 'kube-prometheus/platforms/eks.libsonnet') + {
+local kp = (import 'kube-prometheus/main.libsonnet') + {
   values+:: {
     common+: {
       namespace: 'monitoring',
+    },
+    kubePrometheus+: {
+      platform: 'eks',
     },
   },
   kubernetesControlPlane+: {

--- a/examples/jsonnet-snippets/aws.jsonnet
+++ b/examples/jsonnet-snippets/aws.jsonnet
@@ -1,2 +1,0 @@
-(import 'kube-prometheus/main.libsonnet') +
-(import 'kube-prometheus/platforms/aws.libsonnet')

--- a/examples/jsonnet-snippets/bootkube.jsonnet
+++ b/examples/jsonnet-snippets/bootkube.jsonnet
@@ -1,2 +1,0 @@
-(import 'kube-prometheus/main.libsonnet') +
-(import 'kube-prometheus/platforms/bootkube.libsonnet')

--- a/examples/jsonnet-snippets/kops-coredns.jsonnet
+++ b/examples/jsonnet-snippets/kops-coredns.jsonnet
@@ -1,3 +1,0 @@
-(import 'kube-prometheus/main.libsonnet') +
-(import 'kube-prometheus/platforms/kops.libsonnet') +
-(import 'kube-prometheus/platforms/kops-coredns.libsonnet')

--- a/examples/jsonnet-snippets/kops.jsonnet
+++ b/examples/jsonnet-snippets/kops.jsonnet
@@ -1,2 +1,0 @@
-(import 'kube-prometheus/main.libsonnet') +
-(import 'kube-prometheus/platforms/kops.libsonnet')

--- a/examples/jsonnet-snippets/kubeadm.jsonnet
+++ b/examples/jsonnet-snippets/kubeadm.jsonnet
@@ -1,2 +1,0 @@
-(import 'kube-prometheus/main.libsonnet') +
-(import 'kube-prometheus/platforms/kubeadm.libsonnet')

--- a/examples/jsonnet-snippets/kubespray.jsonnet
+++ b/examples/jsonnet-snippets/kubespray.jsonnet
@@ -1,2 +1,0 @@
-(import 'kube-prometheus/main.libsonnet') +
-(import 'kube-prometheus/platforms/kubespray.libsonnet')

--- a/examples/jsonnet-snippets/platform.jsonnet
+++ b/examples/jsonnet-snippets/platform.jsonnet
@@ -1,0 +1,8 @@
+(import 'kube-prometheus/main.libsonnet') +
+{
+  values+:: {
+    kubePrometheus+: {
+      platform: 'example-platform',
+    },
+  },
+}

--- a/examples/minikube.jsonnet
+++ b/examples/minikube.jsonnet
@@ -1,6 +1,5 @@
 local kp =
   (import 'kube-prometheus/main.libsonnet') +
-  (import 'kube-prometheus/platforms/kubeadm.libsonnet') +
   // Note that NodePort type services is likely not a good idea for your production use case, it is only used for demonstration purposes here.
   (import 'kube-prometheus/addons/node-ports.libsonnet') +
   {
@@ -18,6 +17,9 @@ local kp =
             'auth.anonymous': { enabled: true },
           },
         },
+      },
+      kubePrometheus+: {
+        platform: 'kubeadm',
       },
     },
 

--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -9,7 +9,7 @@ local prometheusAdapter = import './components/prometheus-adapter.libsonnet';
 local prometheusOperator = import './components/prometheus-operator.libsonnet';
 local prometheus = import './components/prometheus.libsonnet';
 
-local platformPatch = (import './platforms/platforms.libsonnet').platformPatch;
+local platformPatch = import './platforms/platforms.libsonnet';
 
 {
   // using `values` as this is similar to helm
@@ -127,5 +127,5 @@ local platformPatch = (import './platforms/platforms.libsonnet').platformPatch;
         name: $.values.kubePrometheus.namespace,
       },
     },
-  } + platformPatch($.values.kubePrometheus.platform),
-}
+  },
+} + platformPatch

--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -9,6 +9,8 @@ local prometheusAdapter = import './components/prometheus-adapter.libsonnet';
 local prometheusOperator = import './components/prometheus-operator.libsonnet';
 local prometheus = import './components/prometheus.libsonnet';
 
+local platformPatch = (import './platforms/platforms.libsonnet').platformPatch;
+
 {
   // using `values` as this is similar to helm
   values:: {
@@ -104,6 +106,7 @@ local prometheus = import './components/prometheus.libsonnet';
     kubePrometheus: {
       namespace: $.values.common.namespace,
       mixin+: { ruleLabels: $.values.common.ruleLabels },
+      platform: null,
     },
   },
 
@@ -124,5 +127,5 @@ local prometheus = import './components/prometheus.libsonnet';
         name: $.values.kubePrometheus.namespace,
       },
     },
-  },
+  } + platformPatch($.values.kubePrometheus.platform),
 }

--- a/jsonnet/kube-prometheus/platforms/README.md
+++ b/jsonnet/kube-prometheus/platforms/README.md
@@ -1,0 +1,18 @@
+# Adding a new platform specific configuration
+
+Adding a new platform specific configuration requires to update the
+[platforms.jsonnet](./platform.jsonnet) file by adding the platform to the list
+of existing ones.
+
+This allow configuring the new platform in the following way:
+
+```jsonnet
+(import 'kube-prometheus/main.libsonnet') +
+  {
+    values+:: {
+      kubePrometheus+: {
+        platform: 'example-platform',
+      }
+    }
+  }
+```

--- a/jsonnet/kube-prometheus/platforms/README.md
+++ b/jsonnet/kube-prometheus/platforms/README.md
@@ -1,18 +1,3 @@
 # Adding a new platform specific configuration
 
-Adding a new platform specific configuration requires to update the
-[platforms.jsonnet](./platform.jsonnet) file by adding the platform to the list
-of existing ones.
-
-This allow configuring the new platform in the following way:
-
-```jsonnet
-(import 'kube-prometheus/main.libsonnet') +
-  {
-    values+:: {
-      kubePrometheus+: {
-        platform: 'example-platform',
-      }
-    }
-  }
-```
+Adding a new platform specific configuration requires to update the [README](../../../README.md#cluster-creation-tools) and the [platforms.jsonnet](./platform.jsonnet) file by adding the platform to the list of existing ones. This allow the new platform to be discoverable and easily configurable by the users.

--- a/jsonnet/kube-prometheus/platforms/platforms.libsonnet
+++ b/jsonnet/kube-prometheus/platforms/platforms.libsonnet
@@ -1,0 +1,16 @@
+local platforms = {
+  aws: import './aws.libsonnet',
+  bootkube: import './bootkube.libsonnet',
+  gke: import './gke.libsonnet',
+  eks: import './eks.libsonnet',
+  kops: import './kops.libsonnet',
+  kops_coredns: (import './kops.libsonnet') + (import './kops-coredns.libsonnet'),
+  kubeadm: import './kubeadm.libsonnet',
+  kubespray: import './kubespray.libsonnet',
+};
+
+{
+  // platformPatch returns the platform specific patch associated to the given
+  // platform.
+  platformPatch(p): if p != null && std.objectHas(platforms, p) then platforms[p] else {},
+}

--- a/jsonnet/kube-prometheus/platforms/platforms.libsonnet
+++ b/jsonnet/kube-prometheus/platforms/platforms.libsonnet
@@ -9,8 +9,33 @@ local platforms = {
   kubespray: import './kubespray.libsonnet',
 };
 
+// platformPatch returns the platform specific patch associated to the given
+// platform.
+local platformPatch(p) = if p != null && std.objectHas(platforms, p) then platforms[p] else {};
+
 {
-  // platformPatch returns the platform specific patch associated to the given
-  // platform.
-  platformPatch(p): if p != null && std.objectHas(platforms, p) then platforms[p] else {},
+  // initialize the object to prevent "Indexed object has no field" lint errors
+  local p = {
+    alertmanager: {},
+    blackboxExporter: {},
+    grafana: {},
+    kubeStateMetrics: {},
+    nodeExporter: {},
+    prometheus: {},
+    prometheusAdapter: {},
+    prometheusOperator: {},
+    kubernetesControlPlane: {},
+    kubePrometheus: {},
+  } + platformPatch($.values.kubePrometheus.platform),
+
+  alertmanager+: p.alertmanager,
+  blackboxExporter+: p.blackboxExporter,
+  grafana+: p.grafana,
+  kubeStateMetrics+: p.kubeStateMetrics,
+  nodeExporter+: p.nodeExporter,
+  prometheus+: p.prometheus,
+  prometheusAdapter+: p.prometheusAdapter,
+  prometheusOperator+: p.prometheusOperator,
+  kubernetesControlPlane+: p.kubernetesControlPlane,
+  kubePrometheus+: p.kubePrometheus,
 }


### PR DESCRIPTION
This PR makes it easier to configure the platform specific configuration of kube-prometheus.

Currently users have to manually apply the patches corresponding to their needs. This requires them to have some knowledge of jsonnet in order to tweak the default configuration to match their needs. For example with `aws`, it results in the following jsonnet configuration:

```jsonnet
(import 'kube-prometheus/main.libsonnet') +
(import 'kube-prometheus/platforms/aws.libsonnet)
```

With this PR, they would only have to customize the `platform` field of `kubePrometheus` to match their needs.

```jsonnet
(import 'kube-prometheus/main.libsonnet') +
  {
    values+:: {
      kubePrometheus+: {
        platform: 'aws',
      }
    }
  }
```

Note that by default, `platform` is set to `null` which means that no patches are applied.

Fixes #1029 