### PR TITLE
Setup gitpod config for ephemeral dev-environments

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,8 @@
+
+tasks: 
+  - init: |
+      make --always-make
+      export PATH="$(pwd)/tmp/bin:${PATH}"
+vscode:
+  extensions:
+    - heptio.jsonnet@0.1.0:woEDU5N62LRdgdz0g/I6sQ==

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/prometheus-operator/kube-prometheus/workflows/ci/badge.svg)](https://github.com/prometheus-operator/kube-prometheus/actions)
 [![Slack](https://img.shields.io/badge/join%20slack-%23prometheus--operator-brightgreen.svg)](http://slack.k8s.io/)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/prometheus-operator/kube-prometheus)
 
 > Note that everything is experimental and may change significantly at any time.
 


### PR DESCRIPTION
This PR adds configuration that makes life easier if you want to develop this project on [Gitpod](https://www.gitpod.io/) like myself 😛.

It installs all the necessary tooling using the Makefile script then adds `./tmp/bin` to `PATH` so we can use all those binaries.

It also installs a jsonnet extension with syntax highlighting and autocompletion:

![image](https://user-images.githubusercontent.com/24193764/113370866-539bb900-933b-11eb-9282-8aa4748c8c9e.png)


You can test the difference by accessing how things are today on main:
https://gitpod.io/#https://github.com/prometheus-operator/kube-prometheus

And then compare with how things are on this branch:
https://gitpod.io/#https://github.com/ArthurSens/kube-prometheus/tree/as/gitpodfy
