### PR TITLE
reduce KSM cardinality by denylisting unused metrics

### DIFF
--- a/jsonnet/kube-prometheus/addons/ksm-lite.libsonnet
+++ b/jsonnet/kube-prometheus/addons/ksm-lite.libsonnet
@@ -1,0 +1,39 @@
+local addArgs(args, name, containers) = std.map(
+  function(c) if c.name == name then
+    c {
+      args+: args,
+    }
+  else c,
+  containers,
+);
+
+{
+  kubeStateMetrics+: {
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: addArgs(
+              [|||
+                --metric-denylist=
+                kube_*_created,
+                kube_*_metadata_resource_version,
+                kube_replicaset_metadata_generation,
+                kube_replicaset_status_observed_generation,
+                kube_pod_restart_policy,
+                kube_pod_init_container_status_terminated,
+                kube_pod_init_container_status_running,
+                kube_pod_container_status_terminated,
+                kube_pod_container_status_running,
+                kube_pod_completion_time,
+                kube_pod_status_scheduled
+              |||],
+              'kube-state-metrics',
+              super.containers
+            ),
+          },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
In most scenarios KSM ships a lot of metrics and it is one of main sources of cardinality issues in prometheus. This addon allows running KSM in "lite" mode by deny listing metrics that aren't used in mixins and don't have much operational value (mostly because the information they carry is already included in other metrics).

I decided to make this an optional addon as such configuration may be disruptive to end-users and IMHO this should be opt-in.