### PR TITLE
jsonnet: add default container annotation for KSM and blackbox exporter

### DIFF
--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -218,7 +218,12 @@ function(params) {
         replicas: bb._config.replicas,
         selector: { matchLabels: bb._config.selectorLabels },
         template: {
-          metadata: { labels: bb._config.commonLabels },
+          metadata: {
+            labels: bb._config.commonLabels,
+            annotations: {
+              'kubectl.kubernetes.io/default-container': blackboxExporter.name,
+            },
+          },
           spec: {
             containers: [blackboxExporter, reloader, kubeRbacProxy],
             nodeSelector: { 'kubernetes.io/os': 'linux' },

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -109,6 +109,11 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
   deployment+: {
     spec+: {
       template+: {
+        metadata+: {
+          annotations+: {
+            'kubectl.kubernetes.io/default-container': 'kube-state-metrics',
+          },
+        },
         spec+: {
           containers: std.map(function(c) c {
             ports:: null,

--- a/manifests/blackbox-exporter-deployment.yaml
+++ b/manifests/blackbox-exporter-deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app.kubernetes.io/part-of: kube-prometheus
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: blackbox-exporter
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: blackbox-exporter

--- a/manifests/kube-state-metrics-deployment.yaml
+++ b/manifests/kube-state-metrics-deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app.kubernetes.io/part-of: kube-prometheus
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: kube-state-metrics
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics


### PR DESCRIPTION
Idea from https://github.com/prometheus-operator/prometheus-operator/pull/3971

More in https://kubernetes.io/docs/reference/labels-annotations-taints/#kubectl-kubernetes-io-default-container

Tested with https://github.com/thaum-xyz/ankhmorpork/commit/4f4ecd9c4ed367ee2ea3e7cf2b5ae3cc0968396d

Requires kubectl >= 1.21, on previous versions, this doesn't have any impact.

/cc @prometheus-operator/prometheus-operator-reviewers 