### PR TITLE
Add description and summary to custom alerts

### DIFF
--- a/jsonnet/kube-prometheus/components/mixin/alerts/general.libsonnet
+++ b/jsonnet/kube-prometheus/components/mixin/alerts/general.libsonnet
@@ -7,6 +7,7 @@
           {
             alert: 'TargetDown',
             annotations: {
+              summary: 'One or more targets are unreachable.',
               description: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace are down.',
             },
             expr: '100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) > 10',
@@ -18,6 +19,7 @@
           {
             alert: 'Watchdog',
             annotations: {
+              summary: 'An alert that should always be firing to certify that Alertmanager is working properly.',
               description: |||
                 This is an alert meant to ensure that the entire alerting pipeline is functional.
                 This alert is always firing, therefore it should always be firing in Alertmanager

--- a/jsonnet/kube-prometheus/components/mixin/alerts/general.libsonnet
+++ b/jsonnet/kube-prometheus/components/mixin/alerts/general.libsonnet
@@ -7,7 +7,7 @@
           {
             alert: 'TargetDown',
             annotations: {
-              message: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace are down.',
+              description: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace are down.',
             },
             expr: '100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) > 10',
             'for': '10m',
@@ -18,7 +18,7 @@
           {
             alert: 'Watchdog',
             annotations: {
-              message: |||
+              description: |||
                 This is an alert meant to ensure that the entire alerting pipeline is functional.
                 This alert is always firing, therefore it should always be firing in Alertmanager
                 and always fire against a receiver. There are integrations with various notification

--- a/manifests/kube-prometheus-prometheusRule.yaml
+++ b/manifests/kube-prometheus-prometheusRule.yaml
@@ -15,21 +15,23 @@ spec:
     rules:
     - alert: TargetDown
       annotations:
-        message: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace are down.'
+        description: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace are down.'
         runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/targetdown
+        summary: One or more targets are unreachable.
       expr: 100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) > 10
       for: 10m
       labels:
         severity: warning
     - alert: Watchdog
       annotations:
-        message: |
+        description: |
           This is an alert meant to ensure that the entire alerting pipeline is functional.
           This alert is always firing, therefore it should always be firing in Alertmanager
           and always fire against a receiver. There are integrations with various notification
           mechanisms that send a notification when this alert is not firing. For example the
           "DeadMansSnitch" integration in PagerDuty.
         runbook_url: https://github.com/prometheus-operator/kube-prometheus/wiki/watchdog
+        summary: An alert that should always be firing to certify that Alertmanager is working properly.
       expr: vector(1)
       labels:
         severity: none


### PR DESCRIPTION
The pattern used by all other mixins is to use `description` as the annotation used to describe the alert. The custom alerts created by kube-prometheus are the only ones with `message` instead.

This PR changes `message` to `description` while also adding a short summary to them