### PR TITLE
jsonnet: fix windows addon

### DIFF
--- a/jsonnet/kube-prometheus/addons/windows.libsonnet
+++ b/jsonnet/kube-prometheus/addons/windows.libsonnet
@@ -48,7 +48,7 @@ local windowsrules = import 'kubernetes-mixin/rules/windows.libsonnet';
     prometheus+: {
       spec+: {
         additionalScrapeConfigs: {
-          name: 'prometheus-' + p.config.name + '-additional-scrape-config',
+          name: 'prometheus-' + p._config.name + '-additional-scrape-config',
           key: 'prometheus-additional.yaml',
         },
       },
@@ -58,8 +58,8 @@ local windowsrules = import 'kubernetes-mixin/rules/windows.libsonnet';
       apiVersion: 'v1',
       kind: 'Secret',
       metadata: {
-        name: 'prometheus-' + p.config.name + '-additional-scrape-config',
-        namespace: p.config.namespace,
+        name: 'prometheus-' + p._config.name + '-additional-scrape-config',
+        namespace: p._config.namespace,
       },
       stringData: {
         'prometheus-additional.yaml': std.manifestYamlDoc(sc),


### PR DESCRIPTION
This is a follow-up to #1039 as merging it caused `main` branch to fail unit tests.

How did this happen?
- #1039 was last updated 25 days ago and this is when CI was run last time (it was green)
- #1058 was merged 9 days ago and added new `addon`, which wasn't tested in #1039
- #1039 should have been tested again before merging as `main` was stale at the point of merging.


Up for discussion:
Should we enable [`Require branches to be up to date before merging` checkbox in branch protection rules](https://docs.github.com/en/github/administering-a-repository/about-protected-branches#require-status-checks-before-merging) for `main` branch? This should prevent issues as one we just experienced, but at the same time will require much more frequent rebases of PRs.
/cc @prometheus-operator/prometheus-operator-reviewers 
