### PR TITLE
*: cut release-0.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,8 +52,8 @@ jobs:
     strategy:
       matrix:
         kind-image:
-          - 'kindest/node:v1.19.0'
           - 'kindest/node:v1.20.0'
+          # - 'kindest/node:v1.21.0' #TODO(paulfantom): enable as soon as image is available
     steps:
     - uses: actions/checkout@v2
       with:

--- a/README.md
+++ b/README.md
@@ -105,15 +105,13 @@ $ minikube addons disable metrics-server
 
 The following versions are supported and work as we test against these versions in their respective branches. But note that other versions might work!
 
-| kube-prometheus stack | Kubernetes 1.16 | Kubernetes 1.17 | Kubernetes 1.18 | Kubernetes 1.19 | Kubernetes 1.20 |
-|-----------------------|-----------------|-----------------|-----------------|-----------------|-----------------|
-| `release-0.4`         | ✔ (v1.16.5+)    | ✔               | ✗               | ✗               | ✗               |
-| `release-0.5`         | ✗               | ✗               | ✔               | ✗               | ✗               |
-| `release-0.6`         | ✗               | ✗               | ✗               | ✔               | ✗               |
-| `release-0.7`         | ✗               | ✗               | ✗               | ✔               | ✔               |
-| `HEAD`                | ✗               | ✗               | ✗               | ✔               | ✔               |
-
-Note: Due to [two](https://github.com/kubernetes/kubernetes/issues/83778) [bugs](https://github.com/kubernetes/kubernetes/issues/86359) in Kubernetes v1.16.1, and prior to Kubernetes v1.16.5 the kube-prometheus release-0.4 branch only supports v1.16.5 and higher.  The `extension-apiserver-authentication-reader` role in the kube-system namespace can be manually edited to include list and watch permissions in order to workaround the second issue with Kubernetes v1.16.2 through v1.16.4.
+| kube-prometheus stack | Kubernetes 1.18 | Kubernetes 1.19 | Kubernetes 1.20 | Kubernetes 1.21 |
+|-----------------------|-----------------|-----------------|-----------------|-----------------|
+| `release-0.5`         | ✔               | ✗               | ✗               | ✗               |
+| `release-0.6`         | ✗               | ✔               | ✗               | ✗               |
+| `release-0.7`         | ✗               | ✔               | ✔               | ✗               |
+| `release-0.8`         | ✗               | ✗               | ✔               | ✔               |
+| `HEAD`                | ✗               | ✗               | ✔               | ✔               |
 
 ## Quickstart
 

--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -8,7 +8,7 @@
           "subdir": "grafana"
         }
       },
-      "version": "master"
+      "version": "8ea4e7bc04b1bf5e9bd99918ca28c6271b42be0e"
     },
     {
       "source": {
@@ -17,7 +17,7 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "master"
+      "version": "562d645ac923388ff5b8d270b0536764d34b0e0f"
     },
     {
       "source": {
@@ -35,7 +35,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "master",
+      "version": "release-0.47",
       "name": "prometheus-operator-mixin"
     },
     {
@@ -45,7 +45,7 @@
           "subdir": ""
         }
       },
-      "version": "master"
+      "version": "release-0.8"
     },
     {
       "source": {
@@ -72,7 +72,7 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "master"
+      "version": "release-1.1"
     },
     {
       "source": {
@@ -91,7 +91,7 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "master",
+      "version": "release-0.21",
       "name": "alertmanager"
     },
     {

--- a/jsonnet/kube-prometheus/versions.json
+++ b/jsonnet/kube-prometheus/versions.json
@@ -1,7 +1,7 @@
 {
   "alertmanager": "0.21.0",
   "blackboxExporter": "0.18.0",
-  "grafana": "7.5.3",
+  "grafana": "7.5.4",
   "kubeStateMetrics": "2.0.0",
   "nodeExporter": "1.1.2",
   "prometheus": "2.26.0",

--- a/manifests/grafana-dashboardDatasources.yaml
+++ b/manifests/grafana-dashboardDatasources.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 7.5.3
+    app.kubernetes.io/version: 7.5.4
   name: grafana-datasources
   namespace: monitoring
 type: Opaque

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -1733,7 +1733,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-apiserver
     namespace: monitoring
 - apiVersion: v1
@@ -3604,7 +3604,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-cluster-total
     namespace: monitoring
 - apiVersion: v1
@@ -4770,7 +4770,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-controller-manager
     namespace: monitoring
 - apiVersion: v1
@@ -7293,7 +7293,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-k8s-resources-cluster
     namespace: monitoring
 - apiVersion: v1
@@ -9536,7 +9536,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-k8s-resources-namespace
     namespace: monitoring
 - apiVersion: v1
@@ -10503,7 +10503,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-k8s-resources-node
     namespace: monitoring
 - apiVersion: v1
@@ -12228,7 +12228,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-k8s-resources-pod
     namespace: monitoring
 - apiVersion: v1
@@ -14203,7 +14203,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-k8s-resources-workload
     namespace: monitoring
 - apiVersion: v1
@@ -16343,7 +16343,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-k8s-resources-workloads-namespace
     namespace: monitoring
 - apiVersion: v1
@@ -18865,7 +18865,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-kubelet
     namespace: monitoring
 - apiVersion: v1
@@ -20318,7 +20318,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-namespace-by-pod
     namespace: monitoring
 - apiVersion: v1
@@ -22043,7 +22043,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-namespace-by-workload
     namespace: monitoring
 - apiVersion: v1
@@ -22996,7 +22996,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-node-cluster-rsrc-use
     namespace: monitoring
 - apiVersion: v1
@@ -23976,7 +23976,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-node-rsrc-use
     namespace: monitoring
 - apiVersion: v1
@@ -24962,7 +24962,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-nodes
     namespace: monitoring
 - apiVersion: v1
@@ -25528,7 +25528,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-persistentvolumesusage
     namespace: monitoring
 - apiVersion: v1
@@ -26745,7 +26745,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-pod-total
     namespace: monitoring
 - apiVersion: v1
@@ -28404,7 +28404,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-prometheus-remote-write
     namespace: monitoring
 - apiVersion: v1
@@ -29620,7 +29620,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-prometheus
     namespace: monitoring
 - apiVersion: v1
@@ -30866,7 +30866,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-proxy
     namespace: monitoring
 - apiVersion: v1
@@ -31955,7 +31955,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-scheduler
     namespace: monitoring
 - apiVersion: v1
@@ -32872,7 +32872,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-statefulset
     namespace: monitoring
 - apiVersion: v1
@@ -34299,7 +34299,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 7.5.3
+      app.kubernetes.io/version: 7.5.4
     name: grafana-dashboard-workload-total
     namespace: monitoring
 kind: ConfigMapList

--- a/manifests/grafana-dashboardSources.yaml
+++ b/manifests/grafana-dashboardSources.yaml
@@ -21,6 +21,6 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 7.5.3
+    app.kubernetes.io/version: 7.5.4
   name: grafana-dashboards
   namespace: monitoring

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 7.5.3
+    app.kubernetes.io/version: 7.5.4
   name: grafana
   namespace: monitoring
 spec:
@@ -18,16 +18,16 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/grafana-datasources: d118a0f812be10bddbea6fdd25543bb1
+        checksum/grafana-datasources: bff02b6fd55e414ce7cf08a5ea2a85e3
       labels:
         app.kubernetes.io/component: grafana
         app.kubernetes.io/name: grafana
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 7.5.3
+        app.kubernetes.io/version: 7.5.4
     spec:
       containers:
       - env: []
-        image: grafana/grafana:7.5.3
+        image: grafana/grafana:7.5.4
         name: grafana
         ports:
         - containerPort: 3000

--- a/manifests/grafana-service.yaml
+++ b/manifests/grafana-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 7.5.3
+    app.kubernetes.io/version: 7.5.4
   name: grafana
   namespace: monitoring
 spec:

--- a/manifests/grafana-serviceMonitor.yaml
+++ b/manifests/grafana-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 7.5.3
+    app.kubernetes.io/version: 7.5.4
   name: grafana
   namespace: monitoring
 spec:


### PR DESCRIPTION
Preparing to cut release-0.8.

This PR also updates grafana to 7.5.4, which is the last available version with Apache 2.0 License. After the branch is cut I will create a follow-up PR to unlock jsonnet dependencies.

Setting WIP in hope kind images for k8s 1.21 will be released soon. Plus I would like to merge or close those PR before having 0.8 release:
- https://github.com/prometheus-operator/kube-prometheus/pull/1091
- https://github.com/prometheus-operator/kube-prometheus/pull/1050
- possibly https://github.com/prometheus-operator/kube-prometheus/pull/1095 (ping @dgrisonnet)