### PR TITLE
Fix anti-affinity addon + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,11 +637,11 @@ In order to configure a static etcd cluster to scrape there is a simple [kube-pr
 ### Pod Anti-Affinity
 
 To prevent `Prometheus` and `Alertmanager` instances from being deployed onto the same node when
-possible, one can include the [kube-prometheus-anti-affinity.libsonnet](jsonnet/kube-prometheus/kube-prometheus-anti-affinity.libsonnet) mixin:
+possible, one can include the [kube-prometheus-anti-affinity.libsonnet](jsonnet/kube-prometheus/addons/anti-affinity.libsonnet) mixin:
 
 ```jsonnet
 (import 'kube-prometheus/kube-prometheus.libsonnet') +
-(import 'kube-prometheus/kube-prometheus-anti-affinity.libsonnet')
+(import 'kube-prometheus/addons/anti-affinity.libsonnet')
 ```
 
 ### Stripping container resource limits

--- a/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet
+++ b/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet
@@ -45,7 +45,7 @@
     alertmanager+: {
       spec+:
         antiaffinity(
-          $.alertmanager.config.selectorLabels,
+          $.alertmanager._config.selectorLabels,
           $.values.common.namespace,
           $.values.alertmanager.podAntiAffinity,
           $.values.alertmanager.podAntiAffinityTopologyKey,
@@ -57,7 +57,7 @@
     prometheus+: {
       spec+:
         antiaffinity(
-          $.prometheus.config.selectorLabels,
+          $.prometheus._config.selectorLabels,
           $.values.common.namespace,
           $.values.prometheus.podAntiAffinity,
           $.values.prometheus.podAntiAffinityTopologyKey,
@@ -71,7 +71,7 @@
         template+: {
           spec+:
             antiaffinity(
-              $.blackboxExporter.config.selectorLabels,
+              $.blackboxExporter._config.selectorLabels,
               $.values.common.namespace,
               $.values.blackboxExporter.podAntiAffinity,
               $.values.blackboxExporter.podAntiAffinityTopologyKey,
@@ -87,7 +87,7 @@
         template+: {
           spec+:
             antiaffinity(
-              $.prometheusAdapter.config.selectorLabels,
+              $.prometheusAdapter._config.selectorLabels,
               $.values.common.namespace,
               $.values.prometheusAdapter.podAntiAffinity,
               $.values.prometheusAdapter.podAntiAffinityTopologyKey,


### PR DESCRIPTION
This fixes an issue where using `kube-prometheus/addons/anti-affinity.libsonnet` fails due to unknown field `config`: 
```
➜ ./build.sh
+ rm -rf manifests
+ mkdir -p manifests/setup
+ jsonnet -J vendor -m manifests boarding.jsonnet
+ xargs '-I{}' sh -c 'cat {} | gojsontoyaml > {}.yaml' -- '{}'
RUNTIME ERROR: field does not exist: config
        anti-affinity.libsonnet:74:15-40        thunk <labelSelector>
        anti-affinity.libsonnet:26:22-35        object <anonymous>
        anti-affinity.libsonnet:(25:22)-(27:8)  object <podAffinityTerm>
        anti-affinity.libsonnet:34:28-43        object <anonymous>
        anti-affinity.libsonnet:(32:59)-(35:10) thunk <array_element>
        anti-affinity.libsonnet:(32:58)-(35:11) object <anonymous>
        anti-affinity.libsonnet:(31:24)-(40:69) object <anonymous>
        anti-affinity.libsonnet:(30:15)-(41:6)  object <anonymous>
        anti-affinity.libsonnet:(71:20)-(79:10) object <anonymous>
        anti-affinity.libsonnet:(70:14)-(80:8)  object <anonymous>
        anti-affinity.libsonnet:(69:18)-(81:6)  object <anonymous>
        boarding.jsonnet:201:1-111      object <anonymous>
        During manifestation
```

Also README was updated to use the right import `kube-prometheus/addons/anti-affinity.libsonnet` instead of `kube-prometheus/kube-prometheus-anti-affinity.libsonnet`