### PR TITLE
examples: add anti-affinity example and include it in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,9 +639,24 @@ In order to configure a static etcd cluster to scrape there is a simple [kube-pr
 To prevent `Prometheus` and `Alertmanager` instances from being deployed onto the same node when
 possible, one can include the [kube-prometheus-anti-affinity.libsonnet](jsonnet/kube-prometheus/addons/anti-affinity.libsonnet) mixin:
 
+[embedmd]:# (examples/anti-affinity.jsonnet)
 ```jsonnet
-(import 'kube-prometheus/kube-prometheus.libsonnet') +
-(import 'kube-prometheus/addons/anti-affinity.libsonnet')
+local kp = (import 'kube-prometheus/main.libsonnet') +
+           (import 'kube-prometheus/addons/anti-affinity.libsonnet') + {
+  values+:: {
+    common+: {
+      namespace: 'monitoring',
+    },
+  },
+};
+
+{ ['00namespace-' + name]: kp.kubePrometheus[name] for name in std.objectFields(kp.kubePrometheus) } +
+{ ['0prometheus-operator-' + name]: kp.prometheusOperator[name] for name in std.objectFields(kp.prometheusOperator) } +
+{ ['node-exporter-' + name]: kp.nodeExporter[name] for name in std.objectFields(kp.nodeExporter) } +
+{ ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
+{ ['alertmanager-' + name]: kp.alertmanager[name] for name in std.objectFields(kp.alertmanager) } +
+{ ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
+{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) }
 ```
 
 ### Stripping container resource limits

--- a/examples/anti-affinity.jsonnet
+++ b/examples/anti-affinity.jsonnet
@@ -1,0 +1,16 @@
+local kp = (import 'kube-prometheus/main.libsonnet') +
+           (import 'kube-prometheus/addons/anti-affinity.libsonnet') + {
+  values+:: {
+    common+: {
+      namespace: 'monitoring',
+    },
+  },
+};
+
+{ ['00namespace-' + name]: kp.kubePrometheus[name] for name in std.objectFields(kp.kubePrometheus) } +
+{ ['0prometheus-operator-' + name]: kp.prometheusOperator[name] for name in std.objectFields(kp.prometheusOperator) } +
+{ ['node-exporter-' + name]: kp.nodeExporter[name] for name in std.objectFields(kp.nodeExporter) } +
+{ ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
+{ ['alertmanager-' + name]: kp.alertmanager[name] for name in std.objectFields(kp.alertmanager) } +
+{ ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
+{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) }


### PR DESCRIPTION
Added an example for anti-affinity addon. Since all jsonnet files in `examples/` are used as a test in CI, this should prevent issues with incorrect addon code being merged.

This is a follow-up to #1095 and #1102. Blocks #1101.

/cc @prometheus-operator/kube-prometheus-reviewers 