### PR TITLE
jsonnet: pin alertmanager to specific commit

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -91,7 +91,7 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "release-0.21",
+      "version": "99f64e944b1043c790784cf5373c8fb349816fc4",
       "name": "alertmanager"
     },
     {

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -120,8 +120,8 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "22ac6dff21901bfce14545da59b37a1aaca0db3a",
-      "sum": "VP1vn/WTGLZaBgGhGMUO81qNTc/fnp5KtzVjcaxad6Q=",
+      "version": "99f64e944b1043c790784cf5373c8fb349816fc4",
+      "sum": "V8jcZQ1Qrlm7AQ6wjbuQQsacPb0NvrcZovKyplmzW5w=",
       "name": "alertmanager"
     },
     {


### PR DESCRIPTION
Pin to commit instead of the branch as there is no release branch with mixin in it.

Fixes #1112 

I wonder why this wasn't picked in CI :thinking: 

/cc @simonpasquier @dgrisonnet @s-urbaniak 