### PR TITLE
node-exporter: add alerts about file descriptor limits

### DIFF
--- a/manifests/node-exporter-prometheusRule.yaml
+++ b/manifests/node-exporter-prometheusRule.yaml
@@ -223,6 +223,28 @@ spec:
         node_md_disks{state="failed"} > 0
       labels:
         severity: warning
+    - alert: NodeFileDescriptorLimit
+      annotations:
+        description: File descriptors limit at {{ "{{" }} $labels.instance }} is currently at {{ "{{" }} printf "%.2f" $value {{`}}`}}%.
+        summary: Kernel is predicted to exhaust file descriptors limit soon.
+      expr: |
+        (
+          node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} > 70
+        )
+      for: 15m
+      labels:
+        severity: warning
+    - alert: NodeFileDescriptorLimit
+      annotations:
+        description: File descriptors limit at {{ "{{" }} $labels.instance {{`}}`}} is currently at {{ "{{" }} printf "%.2f" $value {{`}}`}}%.
+        summary: Kernel is predicted to exhaust file descriptors limit very soon.
+      expr: |
+        (
+          node_filefd_allocated{job="node-exporter"} * 100 / node_filefd_maximum{job="node-exporter"} > 90
+        )
+      for: 15m
+      labels:
+        severity: critical
   - name: node-exporter.rules
     rules:
     - expr: |


### PR DESCRIPTION
Add 2 new alerts about filesystem descriptors exhaustion.

This alert is useful to track when a node will reach fs.file-max soon