### PR TITLE
can change grafanaImage over $.values.common.images

### DIFF
--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -3,8 +3,7 @@ local defaults = {
   name: 'grafana',
   namespace: error 'must provide namespace',
   version: error 'must provide version',
-  // image: error 'must provide image',
-  imageRepos: 'grafana/grafana',
+  image: error 'must provide image',
   resources: {
     requests: { cpu: '100m', memory: '100Mi' },
     limits: { cpu: '200m', memory: '200Mi' },
@@ -44,7 +43,7 @@ function(params) {
         grafana: g._config.version,
       },
       imageRepos+:: {
-        grafana: g._config.imageRepos,
+        grafana: std.split(g._config.image, ":")[0],
       },
       prometheus+:: {
         name: g._config.prometheusName,

--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -43,7 +43,7 @@ function(params) {
         grafana: g._config.version,
       },
       imageRepos+:: {
-        grafana: std.split(g._config.image, ":")[0],
+        grafana: std.split(g._config.image, ':')[0],
       },
       prometheus+:: {
         name: g._config.prometheusName,


### PR DESCRIPTION
#1110
Point 1
I split the repo out of the image string. This works perfekt for grafana, because it do not use a 'v' before the version number. Best solution would be if the grafanalib also support a whole image string.