### PR TITLE
addons: hide antiaffinity function

### DIFF
--- a/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet
+++ b/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet
@@ -18,7 +18,7 @@
     },
   },
 
-  antiaffinity(labelSelector, namespace, type, topologyKey): {
+  antiaffinity(labelSelector, namespace, type, topologyKey):: {
     local podAffinityTerm = {
       namespaces: [namespace],
       topologyKey: topologyKey,


### PR DESCRIPTION
Currently, the function is not hidden which can cause various issues in manifestation as all other fields on this level are simple strings.

For example using following example fails but it worked earlier:
```jsonnet
local kp =
  (import 'kube-prometheus/main.libsonnet') +
  (import 'kube-prometheus/addons/anti-affinity.libsonnet');

{
  [component + '/' + resource + '.yaml']: std.manifestYamlDoc(kp[component][resource])
  for component in std.objectFields(kp)
  for resource in std.objectFields(kp[component])
}
```

It works again with the change from this PR.

/cc @dgrisonnet
