### PR TITLE
jsonnet: improve all-namespaces addon

### DIFF
--- a/jsonnet/kube-prometheus/addons/all-namespaces.libsonnet
+++ b/jsonnet/kube-prometheus/addons/all-namespaces.libsonnet
@@ -1,11 +1,22 @@
 {
   prometheus+:: {
     clusterRole+: {
-      rules+: [{
-        apiGroups: [''],
-        resources: ['services', 'endpoints', 'pods'],
-        verbs: ['get', 'list', 'watch'],
-      }],
+      rules+: [
+        {
+          apiGroups: [''],
+          resources: ['services', 'endpoints', 'pods'],
+          verbs: ['get', 'list', 'watch'],
+        },
+        {
+          apiGroups: ['networking.k8s.io'],
+          resources: ['ingresses'],
+          verbs: ['get', 'list', 'watch'],
+        },
+      ],
     },
+    // There is no need for specific namespaces RBAC as this addon grants
+    // all required permissions for every namespace
+    roleBindingSpecificNamespaces:: null,
+    roleSpecificNamespaces:: null,
   },
 }


### PR DESCRIPTION
- Nullify `roleBindingSpecificNamespaces` and `roleSpecificNamespaces` as those are not necessary when granting prometheus access to all namespaces.
- Add RBAC rules to allow prometheus access to ingress resources. Necessary if using Probe CR.

@brancz could you verify RBAC rules?
