### PR TITLE
jsonnet: use common to populate options for additional objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ These mixins are selectable via the `platform` field of kubePrometheus:
 (import 'kube-prometheus/main.libsonnet') +
 {
   values+:: {
-    kubePrometheus+: {
+    common+: {
       platform: 'example-platform',
     },
   },

--- a/examples/jsonnet-snippets/platform.jsonnet
+++ b/examples/jsonnet-snippets/platform.jsonnet
@@ -1,7 +1,7 @@
 (import 'kube-prometheus/main.libsonnet') +
 {
   values+:: {
-    kubePrometheus+: {
+    common+: {
       platform: 'example-platform',
     },
   },

--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -16,6 +16,7 @@ local platformPatch = import './platforms/platforms.libsonnet';
   values:: {
     common: {
       namespace: 'default',
+      platform: null,
       ruleLabels: {
         role: 'alert-rules',
         prometheus: $.values.prometheus.name,
@@ -102,20 +103,12 @@ local platformPatch = import './platforms/platforms.libsonnet';
       version: $.values.common.versions.prometheusOperator,
       image: $.values.common.images.prometheusOperator,
       configReloaderImage: $.values.common.images.prometheusOperatorReloader,
-      commonLabels+: {
-        'app.kubernetes.io/part-of': 'kube-prometheus',
-      },
       mixin+: { ruleLabels: $.values.common.ruleLabels },
       kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
     },
     kubernetesControlPlane: {
       namespace: $.values.common.namespace,
       mixin+: { ruleLabels: $.values.common.ruleLabels },
-    },
-    kubePrometheus: {
-      namespace: $.values.common.namespace,
-      mixin+: { ruleLabels: $.values.common.ruleLabels },
-      platform: null,
     },
   },
 
@@ -128,12 +121,17 @@ local platformPatch = import './platforms/platforms.libsonnet';
   prometheusAdapter: prometheusAdapter($.values.prometheusAdapter),
   prometheusOperator: prometheusOperator($.values.prometheusOperator),
   kubernetesControlPlane: kubernetesControlPlane($.values.kubernetesControlPlane),
-  kubePrometheus: customMixin($.values.kubePrometheus) + {
+  kubePrometheus: customMixin(
+    {
+      namespace: $.values.common.namespace,
+      mixin+: { ruleLabels: $.values.common.ruleLabels },
+    }
+  ) + {
     namespace: {
       apiVersion: 'v1',
       kind: 'Namespace',
       metadata: {
-        name: $.values.kubePrometheus.namespace,
+        name: $.values.common.namespace,
       },
     },
   },

--- a/jsonnet/kube-prometheus/platforms/platforms.libsonnet
+++ b/jsonnet/kube-prometheus/platforms/platforms.libsonnet
@@ -26,7 +26,7 @@ local platformPatch(p) = if p != null && std.objectHas(platforms, p) then platfo
     prometheusOperator: {},
     kubernetesControlPlane: {},
     kubePrometheus: {},
-  } + platformPatch($.values.kubePrometheus.platform),
+  } + platformPatch($.values.common.platform),
 
   alertmanager+: p.alertmanager,
   blackboxExporter+: p.blackboxExporter,


### PR DESCRIPTION
Remove `$.values.kubePrometheus` and use `$.values.common` instead.

Next step would be to move `jsonnet/kube-prometheus/components/mixin` into separate mixin at `jsonnet/mixin` and use `jsonnet/kube-prometheus/lib/mixin.libsonnet` instead of `jsonnet/kube-prometheus/components/mixin/custom.libsonnet`

All this would increase code reusability and allow easier configuration.