### PR TITLE
Add PodDisruptionBudget to prometheus-adapter

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -300,4 +300,20 @@ function(params) {
       namespace: pa._config.namespace,
     }],
   },
+
+  [if (defaults + params).replicas > 1 then 'podDisruptionBudget']: {
+    apiVersion: 'policy/v1beta1',
+    kind: 'PodDisruptionBudget',
+    metadata: {
+      name: pa._config.name,
+      namespace: pa._config.namespace,
+      labels: pa._config.commonLabels,
+    },
+    spec: {
+      minAvailable: 1,
+      selector: {
+        matchLabels: pa._config.selectorLabels,
+      },
+    },
+  },
 }

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -51,6 +51,7 @@ resources:
 - ./manifests/prometheus-adapter-clusterRoleServerResources.yaml
 - ./manifests/prometheus-adapter-configMap.yaml
 - ./manifests/prometheus-adapter-deployment.yaml
+- ./manifests/prometheus-adapter-podDisruptionBudget.yaml
 - ./manifests/prometheus-adapter-roleBindingAuthReader.yaml
 - ./manifests/prometheus-adapter-service.yaml
 - ./manifests/prometheus-adapter-serviceAccount.yaml

--- a/manifests/prometheus-adapter-podDisruptionBudget.yaml
+++ b/manifests/prometheus-adapter-podDisruptionBudget.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.8.4
+  name: prometheus-adapter
+  namespace: monitoring
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: metrics-adapter
+      app.kubernetes.io/name: prometheus-adapter
+      app.kubernetes.io/part-of: kube-prometheus


### PR DESCRIPTION
Adding a PodDisruptionBudget to prometheus-adapter ensure that at least
one replica of the adapter is always available. This make sure that even
during disruption the aggregated API is available and thus does not
impact the availability of the apiserver.