### PR TITLE
add grafana ldap support

### DIFF
--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -27,6 +27,7 @@ local defaults = {
   containers: [],
   datasources: [],
   config: {},
+  ldap: null,
   plugins: [],
 };
 
@@ -56,6 +57,7 @@ function(params) {
         folderDashboards: g._config.folderDashboards,
         containers: g._config.containers,
         config+: g._config.config,
+        ldap: g._config.ldap,
         plugins+: g._config.plugins,
       } + (
         // Conditionally overwrite default setting.


### PR DESCRIPTION
Add grafana LDAP support.

Example:

```jsonnet
local kp =
  (import 'kube-prometheus/main.libsonnet') +
  {
    values+:: {
      common+: {
        namespace: 'monitoring',
      },
      grafana+: {
        config+: {
          sections: {
            metrics: { enabled: true },
            'auth.ldap': {
              enabled: true,
              config_file: '/etc/grafana/ldap.toml',
              allow_sign_up: true,
            },
          },
        },
        ldap: |||
          [[servers]]
          host = "127.0.0.1"
          port = 389
          use_ssl = false
          start_tls = false
          ssl_skip_verify = false

          bind_dn = "cn=admins,dc=example,dc=com"
          bind_password = 'grafana'

          search_filter = "(cn=%s)"
          search_base_dns = ["dc=example,dc=com"]
        |||,
      },
    },
  };
```