### PR TITLE
jsonnet/components: fix missing resource config in blackbox exporter

### DIFF
--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -201,6 +201,7 @@ function(params) {
     local kubeRbacProxy = krp({
       name: 'kube-rbac-proxy',
       upstream: 'http://127.0.0.1:' + bb._config.internalPort + '/',
+      resources: bb._config.resources,
       secureListenAddress: ':' + bb._config.port,
       ports: [
         { name: 'https', containerPort: bb._config.port },


### PR DESCRIPTION
There was missing resources configuration for kubeRbacProxy container in blackbox exporter deployment.
Because of that, I wasn't able to change all resource limits using config value override.