### PR TITLE
grafana: Do not define timezone in dashboard

### DIFF
--- a/examples/example-grafana-dashboard.json
+++ b/examples/example-grafana-dashboard.json
@@ -171,7 +171,6 @@
             "30d"
         ]
     },
-    "timezone": "browser",
     "title": "my dashboard",
     "version": 0
 }

--- a/jsonnet/kube-prometheus/addons/weave-net/grafana-weave-net-cluster.json
+++ b/jsonnet/kube-prometheus/addons/weave-net/grafana-weave-net-cluster.json
@@ -3340,7 +3340,6 @@
       "30d"
     ]
   },
-  "timezone": "",
   "title": "WeaveNet (Cluster)",
   "uid": "voS3tW_Zk",
   "version": 9

--- a/jsonnet/kube-prometheus/addons/weave-net/grafana-weave-net.json
+++ b/jsonnet/kube-prometheus/addons/weave-net/grafana-weave-net.json
@@ -2598,7 +2598,6 @@
       "30d"
     ]
   },
-  "timezone": "",
   "title": "WeaveNet",
   "uid": "GzIXGqwZz",
   "version": 5

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -1722,7 +1722,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / API server",
           "uid": "09ec8aa1e996d6ffcd6817bbaff4db1b",
           "version": 0
@@ -3593,7 +3592,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Networking / Cluster",
           "uid": "ff635a025bcfea7bc3dd4f508990a3e9",
           "version": 0
@@ -4759,7 +4757,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Controller Manager",
           "uid": "72e0e05bef5099e5f049b05fdc429ed4",
           "version": 0
@@ -7282,7 +7279,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Compute Resources / Cluster",
           "uid": "efa86fd1d0c121a26444b636a3f509a8",
           "version": 0
@@ -9525,7 +9521,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Compute Resources / Namespace (Pods)",
           "uid": "85a562078cdf77779eaa1add43ccec1e",
           "version": 0
@@ -10492,7 +10487,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Compute Resources / Node (Pods)",
           "uid": "200ac8fdbfbb74b39aff88118e4d1c2c",
           "version": 0
@@ -12217,7 +12211,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Compute Resources / Pod",
           "uid": "6581e46e4e5c7ba40a07646395ef7b23",
           "version": 0
@@ -14192,7 +14185,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Compute Resources / Workload",
           "uid": "a164a7f0339f99e89cea5cb47e9be617",
           "version": 0
@@ -16332,7 +16324,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Compute Resources / Namespace (Workloads)",
           "uid": "a87fb0d919ec0ea5f6543124e16c42a5",
           "version": 0
@@ -18854,7 +18845,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Kubelet",
           "uid": "3138fa155d5915769fbded898ac09fd9",
           "version": 0
@@ -20307,7 +20297,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Networking / Namespace (Pods)",
           "uid": "8b7a8b326d7a6f1f04244066368c67af",
           "version": 0
@@ -22032,7 +22021,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Networking / Namespace (Workload)",
           "uid": "bbb2a765a623ae38130206c7d94a160f",
           "version": 0
@@ -22985,7 +22973,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "utc",
           "title": "USE Method / Cluster",
           "uid": "",
           "version": 0
@@ -23965,7 +23952,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "utc",
           "title": "USE Method / Node",
           "uid": "",
           "version": 0
@@ -24952,7 +24938,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "browser",
           "title": "Nodes",
           "version": 0
       }
@@ -25517,7 +25502,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Persistent Volumes",
           "uid": "919b92a8e8041bd567af9edab12c840c",
           "version": 0
@@ -26734,7 +26718,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Networking / Pod",
           "uid": "7a18067ce943a40ae25454675c19ff5c",
           "version": 0
@@ -28394,7 +28377,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "browser",
           "title": "Prometheus / Remote Write",
           "version": 0
       }
@@ -29609,7 +29591,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "utc",
           "title": "Prometheus / Overview",
           "uid": "",
           "version": 0
@@ -30855,7 +30836,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Proxy",
           "uid": "632e265de029684c40b21cb76bca4f94",
           "version": 0
@@ -31944,7 +31924,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Scheduler",
           "uid": "2e6b6a3b4bddf1427b3a55aa1311c656",
           "version": 0
@@ -32861,7 +32840,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / StatefulSets",
           "uid": "a31c1f46e6f727cb37c0d731a7245005",
           "version": 0
@@ -34288,7 +34266,6 @@ items:
                   "30d"
               ]
           },
-          "timezone": "UTC",
           "title": "Kubernetes / Networking / Workload",
           "uid": "728bf77cc1166d2f3133bf25846876cc",
           "version": 0


### PR DESCRIPTION
When dashboard timezone is not defined, grafana will use default
timezone, which can be set per server/organization/team/personal, make
it more flexible.

See https://grafana.com/docs/grafana/latest/administration/preferences/change-grafana-timezone/