### PR TITLE
Test against Kubernetes v1.21

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   - pull_request
 env:
   golang-version: '1.15'
-  kind-version: 'v0.9.0'
+  kind-version: 'v0.11.0'
 jobs:
   generate:
     runs-on: ${{ matrix.os }}
@@ -53,7 +53,7 @@ jobs:
       matrix:
         kind-image:
           - 'kindest/node:v1.20.0'
-          # - 'kindest/node:v1.21.0' #TODO(paulfantom): enable as soon as image is available
+          - 'kindest/node:v1.21.1'
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
According to the compatibility matrix, the main branch supports both Kubernetes 1.20 and 1.21, so we should run the tests on both versions.