### PR TITLE
.github: automatic version upgrader v2

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -1,0 +1,35 @@
+name: Upgrade to latest versions
+
+on:
+  schedule:
+    - cron: '37 13 * * *'
+jobs:
+  versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+    - name: Upgrade versions
+      run: |
+        export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+        scripts/generate-versions.sh > jsonnet/kube-prometheus/versions.json
+        make --always-make generate
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3
+      with:
+        commit-message: "[bot] Automated version update"
+        title: "[bot] Automated version update"
+        body: |
+          This is an automated version update performed from CI on behalf of @paulfantom.
+
+          Configuration of the workflow is located in `.github/workflows/versions.yaml`
+        team-reviewers: kube-prometheus-reviewers
+        labels: kind/enhancement
+        branch: automated-updates
+        delete-branch: true
+        # GITHUB_TOKEN cannot be used as it won't trigger CI in a created PR
+        # More in https://github.com/peter-evans/create-pull-request/issues/155
+        # TODO(paulfantom) Consider running this from a special bot account.
+        token: ${{ secrets.PAT }}


### PR DESCRIPTION
Reintroducing version upgrader.

The previous attempt from https://github.com/prometheus-operator/kube-prometheus/pull/983 and https://github.com/prometheus-operator/kube-prometheus/pull/1002 was correctly creating PRs, but it had issues with triggering CI pipelines. The solution from this PR was tested in https://github.com/thaum-xyz/ankhmorpork and consistently created PRs which were correctly triggering CI (examples: https://github.com/thaum-xyz/ankhmorpork/pull/79 and https://github.com/thaum-xyz/ankhmorpork/pull/81).

Sadly [every solution for automated upgrades needs a Personal Access Token from an active Github Account with repo-access](https://github.com/peter-evans/create-pull-request/issues/155). For the time being, I will use my account for this purpose (PRs will appear as if they are created by me), but in the long run, we might want to create a special bot account.

PRs created by this CI workflow will be labeled as `kind/enhancement` and `kube-prometheus-reviewers` team will be assigned as reviewers for easier discovery.
PRs will be created on `automated-updates` branch in this repository and the branch should be deleted automatically when PR is merged.

Manual reproduction of the workflow is also entirely possible on developer machine by running following commands:

```bash
scripts/generate-versions.sh > jsonnet/kube-prometheus/versions.json
make --always-make generate
``` 

Pinging directly whole @prometheus-operator/prometheus-operator-reviewers for feedback as I feel this is something whole team should be aware of - @s-urbaniak @kakkoyun @metalmatze @paulfantom @brancz @lilic @dgrisonnet @ArthurSens