### PR TITLE
Fix adding private repository

### DIFF
--- a/jsonnet/kube-prometheus/addons/config-mixins.libsonnet
+++ b/jsonnet/kube-prometheus/addons/config-mixins.libsonnet
@@ -18,13 +18,15 @@ local imageName(image) =
 // quay.io/coreos/addon-resizer -> $repository/addon-resizer
 // grafana/grafana -> grafana $repository/grafana
 local withImageRepository(repository) = {
-  local oldRepos = super._config.imageRepos,
+  local oldRepos = super.values.common.images,
   local substituteRepository(image, repository) =
     if repository == null then image else repository + '/' + imageName(image),
   values+:: {
-    imageRepos:: {
-      [field]: substituteRepository(oldRepos[field], repository)
-      for field in std.objectFields(oldRepos)
+    common+:: {
+      images:: {
+        [field]: substituteRepository(oldRepos[field], repository)
+        for field in std.objectFields(oldRepos)
+      },
     },
   },
 };


### PR DESCRIPTION
`imageRepos` field was removed and the project no longer tries to compose image strings. Now the libraries use `$.values.common.images` to override default images.