### PR TITLE
.github: make version update operation atomic

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -14,7 +14,9 @@ jobs:
     - name: Upgrade versions
       run: |
         export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-        scripts/generate-versions.sh > jsonnet/kube-prometheus/versions.json
+        # Write to temporary file to make update atomic
+        scripts/generate-versions.sh > tmp/versions.json
+        mv tmp/versions.json jsonnet/kube-prometheus/versions.json
         make --always-make generate
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
Fun issues with UNIX shell...

When a command is redirected to a file by using `>`, the file is first cleared. This will result in problems if a script is reading from a file to which its STDOUT is redirected. We've seen this in https://github.com/prometheus-operator/kube-prometheus/pull/1172 where some versions weren't updated and the script put empty strings instead of reading default values from the file.

Everything works fine when outputting to some other file and moving it in a subsequent command.

/cc @lilic @dgrisonnet 