### PR TITLE
s/main/kube-prometheus/

### DIFF
--- a/examples/ingress.jsonnet
+++ b/examples/ingress.jsonnet
@@ -14,7 +14,7 @@ local ingress(name, namespace, rules) = {
 };
 
 local kp =
-  (import 'kube-prometheus/main.libsonnet') +
+  (import 'kube-prometheus/kube-prometheus.libsonnet') +
   {
     values+:: {
       common+: {


### PR DESCRIPTION
the import should be from `kube-prometheus.libsonnet`. there is no `main.libsonnet` ?anymore?