### PR TITLE
.github: write temporary file to /tmp

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -15,8 +15,8 @@ jobs:
       run: |
         export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
         # Write to temporary file to make update atomic
-        scripts/generate-versions.sh > tmp/versions.json
-        mv tmp/versions.json jsonnet/kube-prometheus/versions.json
+        scripts/generate-versions.sh > /tmp/versions.json
+        mv /tmp/versions.json jsonnet/kube-prometheus/versions.json
         make --always-make generate
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
as in the title.

Version updater couldn't write to tmp/versions.json as `tmp/` doesn't exist. Let's use `/tmp` for the same purpose.

[Version updater was failing for the last 7 days](https://github.com/prometheus-operator/kube-prometheus/actions/workflows/versions.yaml) because of this :shrug: 

/cc @ArthurSens @dgrisonnet 
