### PR TITLE
jsonnet: fix label selector for coredns ServiceMonitor

### DIFF
--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -245,7 +245,7 @@ function(params) {
     spec: {
       jobLabel: 'app.kubernetes.io/name',
       selector: {
-        matchLabels: { 'app.kubernetes.io/name': 'kube-dns' },
+        matchLabels: { 'k8s-app': 'kube-dns' },
       },
       namespaceSelector: {
         matchNames: ['kube-system'],

--- a/manifests/kubernetes-serviceMonitorCoreDNS.yaml
+++ b/manifests/kubernetes-serviceMonitorCoreDNS.yaml
@@ -16,4 +16,4 @@ spec:
     - kube-system
   selector:
     matchLabels:
-      app.kubernetes.io/name: kube-dns
+      k8s-app: kube-dns


### PR DESCRIPTION
Revert label selector responsible for choosing CoreDNS SVC.

Sadly not all kubernetes distributions ship CoreDNS SVC with `app.kubernetes.io/name` label, but all ship older `k8s-app` label.

I'll backport it to `release-0.8` after it is merged

/cc @prometheus-operator/kube-prometheus-reviewers 