### PR TITLE
examples: add example of running without grafana deployment

### DIFF
--- a/examples/grafana-only-dashboards.jsonnet
+++ b/examples/grafana-only-dashboards.jsonnet
@@ -1,0 +1,25 @@
+local kp =
+  (import 'kube-prometheus/main.libsonnet') +
+  {
+    values+:: {
+      common+: {
+        namespace: 'monitoring',
+      },
+    },
+
+    // Disable all grafana-related objects apart from dashboards and datasource
+    grafana: {
+      dashboardSources:: {},
+      deployment:: {},
+      serviceAccount:: {},
+      serviceMonitor:: {},
+      service:: {},
+    },
+  };
+
+// Manifestation
+{
+  [component + '-' + resource + '.json']: kp[component][resource]
+  for component in std.objectFields(kp)
+  for resource in std.objectFields(kp[component])
+}


### PR DESCRIPTION
Simple example of how to include grafana dashboards and datasources, but not grafana itself.

May be useful for folks who don't want to run grafana (for example due to licensing issues).