### PR TITLE
legal cleanup

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,0 @@
-CoreOS Project
-Copyright 2018 CoreOS, Inc
-
-This product includes software developed at CoreOS, Inc.
-(http://www.coreos.com/).

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,4 +1,4 @@
-## CoreOS Community Code of Conduct
+## Community Code of Conduct
 
 ### Contributor Code of Conduct
 
@@ -33,29 +33,9 @@ This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting a project maintainer, Brandon Philips
-<brandon.philips@coreos.com>, and/or Rithu John <rithu.john@coreos.com>.
+reported by contacting a project maintainer listed in 
+https://github.com/prometheus-operator/prometheus-operator/blob/master/MAINTAINERS.md. 
 
 This Code of Conduct is adapted from the Contributor Covenant
 (http://contributor-covenant.org), version 1.2.0, available at
 http://contributor-covenant.org/version/1/2/0/
-
-### CoreOS Events Code of Conduct
-
-CoreOS events are working conferences intended for professional networking and
-collaboration in the CoreOS community. Attendees are expected to behave
-according to professional standards and in accordance with their employer’s
-policies on appropriate workplace behavior.
-
-While at CoreOS events or related social networking opportunities, attendees
-should not engage in discriminatory or offensive speech or actions including
-but not limited to gender, sexuality, race, age, disability, or religion.
-Speakers should be especially aware of these concerns.
-
-CoreOS does not condone any statements by speakers contrary to these standards.
-CoreOS reserves the right to deny entrance and/or eject from an event (without
-refund) any individual found to be engaging in discriminatory or offensive
-speech or actions.
-
-Please bring any concerns to the immediate attention of designated on-site
-staff, Brandon Philips <brandon.philips@coreos.com>, and/or Rithu John <rithu.john@coreos.com>.


### PR DESCRIPTION
The project is no longer under CoreOS, let's reflect that in documents.

CoC is copied from prometheus-operator with a minor change of pointing to a GitHub group of maintainers instead of MAINTAINERS.md file. This is because such a file does not exist here.