### PR TITLE
scripts: move test.sh script into scripts dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ lint: $(JSONNETLINT_BIN) vendor
 .PHONY: test
 test: $(JB_BIN)
 	$(JB_BIN) install
-	./test.sh
+	./scripts/test.sh
 
 .PHONY: test-e2e
 test-e2e:

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,6 +5,8 @@ set -o pipefail
 
 # Make sure to use project tooling
 PATH="$(pwd)/tmp/bin:${PATH}"
+TESTFILE="$(pwd)/tmp/test.jsonnet"
+mkdir -p "$(pwd)/tmp"
 
 for i in examples/jsonnet-snippets/*.jsonnet; do
     [ -f "$i" ] || break
@@ -14,13 +16,13 @@ for i in examples/jsonnet-snippets/*.jsonnet; do
     snippet="local kp = $fileContent;
 
 $(<examples/jsonnet-build-snippet/build-snippet.jsonnet)"
-    echo "${snippet}" > "test.jsonnet"
+    echo "${snippet}" > "${TESTFILE}"
     echo "\`\`\`"
     echo "${snippet}"
     echo "\`\`\`"
     echo ""
-    jsonnet -J vendor "test.jsonnet" > /dev/null
-    rm -rf "test.jsonnet"
+    jsonnet -J vendor "${TESTFILE}" > /dev/null
+    rm -rf "${TESTFILE}"
 done
 
 for i in examples/*.jsonnet; do


### PR DESCRIPTION
Moving from TLD into `scripts/` to cleanup file structure a bit (continuation of https://github.com/prometheus-operator/kube-prometheus/pull/1207 and https://github.com/prometheus-operator/kube-prometheus/pull/1208).

Additionally, a temporary jsonnet file will be created in `tmp/`. This would prevent the accidental addition of the file to git repo without modifying `.gitignore`.

/cc @prometheus-operator/kube-prometheus-reviewers 