### PR TITLE
[Gitpod] Deploy kube-prometheus on k3s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ vendor/
 ./auth
 .swp
 crdschemas/
+
+.gitpod/_output/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,5 @@
-
+image: gitpod/workspace-full
+checkoutLocation: gitpod-k3s
 tasks: 
   - init: |
       make --always-make
@@ -21,6 +22,26 @@ tasks:
       fi
       EOF
       chmod +x ${PWD}/.git/hooks/pre-commit
+  - name: run kube-prometheus
+    command: |
+      .gitpod/prepare-k3s.sh
+      .gitpod/deploy-kube-prometheus.sh
+  - name: kernel dev environment
+    init: |
+      sudo apt update -y
+      sudo apt install qemu qemu-system-x86 linux-image-$(uname -r) libguestfs-tools sshpass netcat -y
+      sudo curl -o /usr/bin/kubectl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+      sudo chmod +x /usr/bin/kubectl
+      .gitpod/prepare-rootfs.sh
+    command: |
+      .gitpod/qemu.sh
+ports:
+  - port: 3000
+    onOpen: open-browser
+  - port: 9090
+    onOpen: open-browser
+  - port: 9093
+    onOpen: open-browser
 vscode:
   extensions:
     - heptio.jsonnet@0.1.0:woEDU5N62LRdgdz0g/I6sQ==

--- a/.gitpod/deploy-kube-prometheus.sh
+++ b/.gitpod/deploy-kube-prometheus.sh
@@ -1,0 +1,16 @@
+kubectl apply -f manifests/setup
+
+# Safety wait for CRDs to be working
+sleep 30
+
+kubectl apply -f manifests/
+
+kubectl rollout status -n monitoring daemonset node-exporter
+kubectl rollout status -n monitoring statefulset alertmanager-main
+kubectl rollout status -n monitoring statefulset prometheus-k8s
+kubectl rollout status -n monitoring deployment grafana
+kubectl rollout status -n monitoring deployment kube-state-metrics
+
+kubectl port-forward -n monitoring svc/grafana 3000 > /dev/null 2>&1 &
+kubectl port-forward -n monitoring svc/alertmanager-main 9093 > /dev/null 2>&1 &
+kubectl port-forward -n monitoring svc/prometheus-k8s 9090 > /dev/null 2>&1 &

--- a/.gitpod/prepare-k3s.sh
+++ b/.gitpod/prepare-k3s.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+script_dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+rootfslock="${script_dirname}/_output/rootfs/rootfs-ready.lock"
+k3sreadylock="${script_dirname}/_output/rootfs/k3s-ready.lock"
+
+if test -f "${k3sreadylock}"; then
+    exit 0
+fi
+
+cd $script_dirname
+
+function waitssh() {
+  while ! nc -z 127.0.0.1 2222; do   
+    sleep 0.1
+  done
+  ./ssh.sh "whoami" &>/dev/null
+  if [ $? -ne 0 ]; then
+    sleep 1
+    waitssh
+  fi
+}
+
+function waitrootfs() {
+  while ! test -f "${rootfslock}"; do
+    sleep 0.1
+  done
+}
+
+echo "🔥 Installing everything, this will be done only one time per workspace."
+
+echo "Waiting for the rootfs to become available, it can take a while, open the terminal #2 for progress"
+waitrootfs
+echo "✅ rootfs available"
+
+echo "Waiting for the ssh server to become available, it can take a while, after this k3s is getting installed"
+waitssh
+echo "✅ ssh server available"
+
+./ssh.sh "curl -sfL https://get.k3s.io | sh -"
+
+mkdir -p ~/.kube
+./scp.sh root@127.0.0.1:/etc/rancher/k3s/k3s.yaml ~/.kube/config
+
+echo "✅ k3s server is ready"
+touch "${k3sreadylock}"
+
+# safety wait for cluster availability
+sleep 30s

--- a/.gitpod/prepare-rootfs.sh
+++ b/.gitpod/prepare-rootfs.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+img_url="https://cloud-images.ubuntu.com/hirsute/current/hirsute-server-cloudimg-amd64.tar.gz"
+
+script_dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+outdir="${script_dirname}/_output/rootfs"
+
+rm -Rf $outdir
+mkdir -p $outdir
+
+curl -L -o "${outdir}/rootfs.tar.gz" $img_url
+
+cd $outdir
+
+tar -xvf rootfs.tar.gz
+
+qemu-img resize hirsute-server-cloudimg-amd64.img +20G
+
+sudo virt-customize -a hirsute-server-cloudimg-amd64.img --run-command 'resize2fs /dev/sda'
+
+sudo virt-customize -a hirsute-server-cloudimg-amd64.img --root-password password:root
+
+netconf="
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    enp0s3:
+      dhcp4: yes
+"
+
+# networking setup
+sudo virt-customize -a hirsute-server-cloudimg-amd64.img --run-command "echo '${netconf}' > /etc/netplan/01-net.yaml"
+
+# copy kernel modules
+sudo virt-customize -a hirsute-server-cloudimg-amd64.img --copy-in /lib/modules/$(uname -r):/lib/modules
+
+# ssh
+sudo virt-customize -a hirsute-server-cloudimg-amd64.img --run-command 'apt remove openssh-server -y && apt install openssh-server -y'
+sudo virt-customize -a hirsute-server-cloudimg-amd64.img --run-command "sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config"
+sudo virt-customize -a hirsute-server-cloudimg-amd64.img --run-command "sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config"
+
+# mark as ready
+touch rootfs-ready.lock
+
+echo "k3s development environment is ready"

--- a/.gitpod/qemu.sh
+++ b/.gitpod/qemu.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+script_dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+outdir="${script_dirname}/_output"
+
+sudo qemu-system-x86_64 -kernel "/boot/vmlinuz" \
+-boot c -m 3073M -hda "${outdir}/rootfs/hirsute-server-cloudimg-amd64.img" \
+-net user \
+-smp 8 \
+-append "root=/dev/sda rw console=ttyS0,115200 acpi=off nokaslr" \
+-nic user,hostfwd=tcp::2222-:22,hostfwd=tcp::6443-:6443 \
+-serial mon:stdio -display none

--- a/.gitpod/scp.sh
+++ b/.gitpod/scp.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sshpass -p 'root' scp -o StrictHostKeychecking=no -P 2222 $@

--- a/.gitpod/ssh.sh
+++ b/.gitpod/ssh.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sshpass  -p 'root' ssh -o StrictHostKeychecking=no -p 2222 root@127.0.0.1 "$@"


### PR DESCRIPTION
Based on this awesome example: https://github.com/fntlnz/gitpod-k3s

---

This PR automates the deployment of kube-prometheus into a k3s cluster, running inside a VM, running inside a Gitpod Workspace.

The aim of this PR is to enable easy visualization of dashboards and alerts when updating upstream dependencies,  without requiring the reviewer to start a cluster locally. 

The experience right now is not great, Gitpod limits CPU for Workspaces that consume huge amounts, and running a VM that is able to support a k3s cluster is not exactly the lightest thing 😅. After opening the workspace, it takes around 20~30 mins to spin up VM, k3s and deploy kube-prometheus. Navigating through Grafana dashboards can be quite sluggish and I see a couple of alerts firing due to that same sluggishness 😞.


While waiting 20mins to be able to see a Grafana dashboard is not the best, this whole process can be further automated with [Gitpod Prebuilds](https://www.gitpod.io/docs/prebuilds/), unfortunately, I wasn't able to make k3s work with Prebuilds for our own internal repositories. You can expect another PR in the future to eliminate this 20~30min wait time once I get that working 🙂.


Quick video explaining how to visualize dashboards and alerts:
https://www.loom.com/share/0a4a6ceca9cb450d889811e3ec41192e