### PR TITLE
Fix ingress path rules for networking.k8s.io/v1

### DIFF
--- a/examples/ingress.jsonnet
+++ b/examples/ingress.jsonnet
@@ -54,10 +54,14 @@ local kp =
           host: 'alertmanager.example.com',
           http: {
             paths: [{
+              path: '/',
+              pathType: 'Prefix',
               backend: {
                 service: {
                   name: 'alertmanager-main',
-                  port: 'web',
+                  port: {
+                    name: 'web'
+                  },
                 },
               },
             }],
@@ -71,10 +75,14 @@ local kp =
           host: 'grafana.example.com',
           http: {
             paths: [{
+              path: '/',
+              pathType: 'Prefix',
               backend: {
                 service: {
                   name: 'grafana',
-                  port: 'http',
+                  port: {
+                    name: 'http'
+                  },
                 },
               },
             }],
@@ -88,10 +96,14 @@ local kp =
           host: 'prometheus.example.com',
           http: {
             paths: [{
+              path: '/',
+              pathType: 'Prefix',
               backend: {
                 service: {
                   name: 'prometheus-k8s',
-                  port: 'web',
+                  port: {
+                    name: 'web'
+                  },
                 },
               },
             }],

--- a/examples/ingress.jsonnet
+++ b/examples/ingress.jsonnet
@@ -60,7 +60,7 @@ local kp =
                 service: {
                   name: 'alertmanager-main',
                   port: {
-                    name: 'web'
+                    name: 'web',
                   },
                 },
               },
@@ -81,7 +81,7 @@ local kp =
                 service: {
                   name: 'grafana',
                   port: {
-                    name: 'http'
+                    name: 'http',
                   },
                 },
               },
@@ -102,7 +102,7 @@ local kp =
                 service: {
                   name: 'prometheus-k8s',
                   port: {
-                    name: 'web'
+                    name: 'web',
                   },
                 },
               },


### PR DESCRIPTION
Current ingress path rules are not working. This PR update the path rules to make sure it working with apiVersion networking.k8s.io/v1.