### PR TITLE
Fix name for blackbox-exporter PodSecurityPolicy

### DIFF
--- a/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
+++ b/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
@@ -117,7 +117,11 @@ local restrictedPodSecurityPolicy = {
             },
           }
         else
-          {};
+          {
+            metadata+: {
+              name: 'blackbox-exporter-psp',
+            },
+          };
 
       restrictedPodSecurityPolicy + blackboxExporterPspPrivileged,
   },


### PR DESCRIPTION
After updating and enabling PSP we got alerted that the blackbox probes were failing. It turned out that the blackbox exporter couldn't even start. This was caused by the PSP preventing the Pod creation.
```
PodSecurityPolicy: unable to admit pod: []
```

I finally found out that the name of the PodSecurityPolicy for the blackbox exporter was wrong.
This is the fix:
```diff
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: kube-prometheus-restricted
+  name: blackbox-exporter-psp
 spec:
   allowPrivilegeEscalation: false
   fsGroup:
```

