### PR TITLE
jsonnet: kube-prometheus adapt to changes to veth interfaces names

### DIFF
--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -175,8 +175,11 @@ function(params) {
         '--no-collector.wifi',
         '--no-collector.hwmon',
         '--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)',
-        '--collector.netclass.ignored-devices=^(veth.*)$',
-        '--collector.netdev.device-exclude=^(veth.*)$',
+        // NOTE: ignore veth network interface associated with containers.
+        // OVN renames veth.* to <rand-hex>@if<X> where X is /sys/class/net/<if>/ifindex
+        // thus [a-z0-9] regex below
+        '--collector.netclass.ignored-devices=^(veth.*|[a-z0-9]+@if\\d+)$',
+        '--collector.netdev.device-exclude=^(veth.*|[a-z0-9]+@if\\d+)$',
       ],
       volumeMounts: [
         { name: 'sys', mountPath: '/host/sys', mountPropagation: 'HostToContainer', readOnly: true },

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -30,8 +30,8 @@ spec:
         - --no-collector.wifi
         - --no-collector.hwmon
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
-        - --collector.netclass.ignored-devices=^(veth.*)$
-        - --collector.netdev.device-exclude=^(veth.*)$
+        - --collector.netclass.ignored-devices=^(veth.*|[a-z0-9]+@if\d+)$
+        - --collector.netdev.device-exclude=^(veth.*|[a-z0-9]+@if\d+)$
         image: quay.io/prometheus/node-exporter:v1.1.2
         name: node-exporter
         resources:


### PR DESCRIPTION

With OVN, the container veth network interface names that used to start
with `veth` has now changed to `<rand-hex>{15}@if<number>`(see Related
Links below).

This patch adapts to the new change introduced in ovn and ignores the network
interfaces that match `[a-z0-9]{15}@if\d+` in addition to those starting
with `veth`

Related Links:
  - https://github.com/openshift/ovn-kubernetes/blob/master/go-controller/vendor/github.com/containernetworking/plugins/pkg/ip/link_linux.go#L107
  - https://github.com/openshift/ovn-kubernetes/blob/master/go-controller/pkg/cni/helper_linux.go#L148

Signed-off-by: Sunil Thaha <sthaha@redhat.com>
