### PR TITLE
.github/workflows: Update versions schedule to run each Monday

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -2,7 +2,7 @@ name: Upgrade to latest versions
 
 on:
   schedule:
-    - cron: '37 13 * * *'
+    - cron: '37 13 * * 1'
 jobs:
   versions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updates the versions.yaml workflow to run each Monday instead of each day.