### PR TITLE
Fix make manifests not building every time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ generate: manifests **.md
 **.md: $(EMBEDMD_BIN) $(shell find examples) build.sh example.jsonnet
 	$(EMBEDMD_BIN) -w `find . -name "*.md" | grep -v vendor`
 
-manifests: examples/kustomize.jsonnet $(GOJSONTOYAML_BIN) vendor build.sh
+manifests: examples/kustomize.jsonnet $(GOJSONTOYAML_BIN) vendor
 	./build.sh $<
 
 vendor: $(JB_BIN) jsonnetfile.json jsonnetfile.lock.json
@@ -36,7 +36,7 @@ vendor: $(JB_BIN) jsonnetfile.json jsonnetfile.lock.json
 	$(JB_BIN) install
 
 crdschemas: vendor
-	./scripts/generate-schemas.sh	
+	./scripts/generate-schemas.sh
 
 .PHONY: validate
 validate: crdschemas manifests $(KUBECONFORM_BIN)


### PR DESCRIPTION
Make target `manifests` has a dependency on build.sh which if untouched
wouldn't generate the manifests after the first run. This patch fixes it
by removing the `build.sh` dependency