### PR TITLE
ci: Use wait command to ensure cluster readiness

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,13 +63,9 @@ jobs:
       with:
         version: ${{ env.kind-version }}
         image: ${{ matrix.kind-image }}
+        wait: 300s
     - name: Wait for cluster to finish bootstraping
-      run: |
-        until [ "$(kubectl get pods --all-namespaces --no-headers | grep -cEv '([0-9]+)/\1')" -eq 0 ]; do
-            sleep 5s
-        done
-        kubectl cluster-info
-        kubectl get pods -A
+      run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
     - name: Create kube-prometheus stack
       run: |
         kubectl create -f manifests/setup


### PR DESCRIPTION
The underlying GH action allows us to wait for the control plane to become ready. We can use the kubectl wait command to wait for pod readiness