### PR TITLE
*: add "update" target to makefile and use it in automatic updater

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -17,13 +17,10 @@ jobs:
         # Write to temporary file to make update atomic
         scripts/generate-versions.sh > /tmp/versions.json
         mv /tmp/versions.json jsonnet/kube-prometheus/versions.json
-    - name: Install jsonnet bundler
-      run: |
-        go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
     - name: Update jsonnet dependencies
       run: |
-        jb update
-        make --always-make generate
+        make update
+        make generate
 
         # Reset jsonnetfile.lock.json if no dependencies were updated
         changedFiles=$(git diff --name-only | grep -v 'jsonnetfile.lock.json')

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,10 @@ vendor: $(JB_BIN) jsonnetfile.json jsonnetfile.lock.json
 crdschemas: vendor
 	./scripts/generate-schemas.sh
 
+.PHONY: update
+update: $(JB_BIN)
+	$(JB_BIN) update
+
 .PHONY: validate
 validate: crdschemas manifests $(KUBECONFORM_BIN)
 	$(KUBECONFORM_BIN) -kubernetes-version $(KUBE_VERSION) -schema-location 'default' -schema-location 'crdschemas/{{ .ResourceKind }}.json' -skip CustomResourceDefinition manifests/


### PR DESCRIPTION
PR #1241 showed that CI is updating go.{mod,sum} files which shouldn't be the case. It is happening because `jb` was downloaded not using `scripts/go.mod` file. This PR changes this state by introducing `make update` and using it in CI.