### PR TITLE
jsonnet: Drop cAdvisor metrics without (pod, namespace) label pairs.

### DIFF
--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -120,6 +120,23 @@ function(params) {
               regex: 'container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)',
               action: 'drop',
             },
+            // Drop cAdvisor metrics with no (pod, namespace) labels while preserving ability to monitor system services resource usage (cardinality estimation)
+            {
+              sourceLabels: ['__name__', 'pod', 'namespace'],
+              action: 'drop',
+              regex: '(' + std.join('|',
+                                    [
+                                      'container_fs_.*',  // add filesystem read/write data (nodes*disks*services*4)
+                                      'container_spec_.*',  // everything related to cgroup specification and thus static data (nodes*services*5)
+                                      'container_blkio_device_usage_total',  // useful for containers, but not for system services (nodes*disks*services*operations*2)
+                                      'container_file_descriptors',  // file descriptors limits and global numbers are exposed via (nodes*services)
+                                      'container_sockets',  // used sockets in cgroup. Usually not important for system services (nodes*services)
+                                      'container_threads_max',  // max number of threads in cgroup. Usually for system services it is not limited (nodes*services)
+                                      'container_threads',  // used threads in cgroup. Usually not important for system services (nodes*services)
+                                      'container_start_time_seconds',  // container start. Possibly not needed for system services (nodes*services)
+                                      'container_last_seen',  // not needed as system services are always running (nodes*services)
+                                    ]) + ');;',
+            },
           ],
         },
         {

--- a/manifests/kubernetes-serviceMonitorKubelet.yaml
+++ b/manifests/kubernetes-serviceMonitorKubelet.yaml
@@ -60,6 +60,12 @@ spec:
       regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
       sourceLabels:
       - __name__
+    - action: drop
+      regex: (container_fs_.*|container_spec_.*|container_blkio_device_usage_total|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
+      sourceLabels:
+      - __name__
+      - pod
+      - namespace
     path: /metrics/cadvisor
     port: https-metrics
     relabelings:


### PR DESCRIPTION
This change intends to reduce cardinality by dropping cAdvisor metrics without (pod, namespace) label pairs.


EDIT: The initial implementation dropped excessive metrics and cost us the ability to effectively query system service resource usage ~Tested in minikube and the change drops 540 metrics. The list that is dropped can be seen here https://gist.github.com/PhilipGough/72c3a3f5f8b6676e6c09fc0dc9e9b033~