### PR TITLE
create dashboardDefinitions if rawDashboards or folderDashboards are …

### DIFF
--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -76,7 +76,9 @@ function(params) {
   dashboardDatasources: glib.grafana.dashboardDatasources,
   dashboardSources: glib.grafana.dashboardSources,
 
-  dashboardDefinitions: if std.length(g._config.dashboards) > 0 then {
+  dashboardDefinitions: if std.length(g._config.dashboards) > 0 || 
+                          std.length(g._config.rawDashboards) > 0 ||
+                          std.length(g._config.folderDashboards) > 0 then {
     apiVersion: 'v1',
     kind: 'ConfigMapList',
     items: glib.grafana.dashboardDefinitions,

--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -77,8 +77,8 @@ function(params) {
   dashboardSources: glib.grafana.dashboardSources,
 
   dashboardDefinitions: if std.length(g._config.dashboards) > 0 || 
-                          std.length(g._config.rawDashboards) > 0 ||
-                          std.length(g._config.folderDashboards) > 0 then {
+                           std.length(g._config.rawDashboards) > 0 ||
+                           std.length(g._config.folderDashboards) > 0 then {
     apiVersion: 'v1',
     kind: 'ConfigMapList',
     items: glib.grafana.dashboardDefinitions,

--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -76,7 +76,7 @@ function(params) {
   dashboardDatasources: glib.grafana.dashboardDatasources,
   dashboardSources: glib.grafana.dashboardSources,
 
-  dashboardDefinitions: if std.length(g._config.dashboards) > 0 || 
+  dashboardDefinitions: if std.length(g._config.dashboards) > 0 ||
                            std.length(g._config.rawDashboards) > 0 ||
                            std.length(g._config.folderDashboards) > 0 then {
     apiVersion: 'v1',


### PR DESCRIPTION
…specified

Signed-off-by: ben.ye <ben.ye@bytedance.com>

`dashboardDefinitions` needs to be created if `rawDashboards` or `folderDashboards` are specified.