### PR TITLE
eks: Relabel instance with node name for CNI DaemonSet

### DIFF
--- a/jsonnet/kube-prometheus/platforms/eks.libsonnet
+++ b/jsonnet/kube-prometheus/platforms/eks.libsonnet
@@ -27,7 +27,20 @@
       },
       spec: {
         ports: [
-          { name: 'cni-metrics-port', port: 61678, targetPort: 61678 },
+          {
+            name: 'cni-metrics-port',
+            port: 61678,
+            targetPort: 61678,
+            relabelings: [
+              {
+                action: 'replace',
+                regex: '(.*)',
+                replacement: '$1',
+                sourceLabels: ['__meta_kubernetes_pod_node_name'],
+                targetLabel: 'instance',
+              },
+            ],
+          },
         ],
         selector: { 'app.kubernetes.io/name': 'aws-node' },
         clusterIP: 'None',


### PR DESCRIPTION
It is convenient to have node name as the value of the `instance` label for DaemonSets