### PR TITLE
.github: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--
+WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
+-->
+
+## Description
+
+_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
+If it fixes a bug or resolves a feature request, be sure to link to that issue._
+
+
+
+## Type of change
+
+_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._
+
+- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
+- [ ] `FEATURE` (non-breaking change which adds functionality)
+- [ ] `BUGFIX` (non-breaking change which fixes an issue)
+- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
+- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
+
+## Changelog entry
+
+_Please put a one-line changelog entry below. Later this will be copied to the changelog file._
+
+<!-- 
+Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
+the technical details of your PR, so consider what they need to know when you write your release note.
+
+Some brief examples of release notes:
+- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
+- Generate correct scraping configuration for Probes with empty or unset module parameter.
+-->
+
+```release-note
+
+```

--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -33,11 +33,22 @@ jobs:
         commit-message: "[bot] Automated version update"
         title: "[bot] Automated version update"
         body: |
+          ## Description
+
           This is an automated version and jsonnet dependencies update performed from CI on behalf of @paulfantom.
 
           Configuration of the workflow is located in `.github/workflows/versions.yaml`
+
+          ## Type of change
+
+          - [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)
+
+          ## Changelog entry
+          
+          ```release-note
+
+          ```
         team-reviewers: kube-prometheus-reviewers
-        labels: kind/enhancement
         branch: automated-updates
         delete-branch: true
         # GITHUB_TOKEN cannot be used as it won't trigger CI in a created PR


### PR DESCRIPTION
I would like to introduce CHANGELOG to kube-prometheus. For this to happen it would be good to structure PR template.

This PR is aligning PR template with https://github.com/prometheus-operator/prometheus-operator/pull/4147 and modifying automation to create PRs using the new template.

The next step would be to implement some tool that would gather recent PR descriptions, parse them, and present a list of changes in a format known from [prometeus-operator/CHANGELOG.md](https://github.com/prometheus-operator/prometheus-operator/blob/master/CHANGELOG.md).
After that, we can put this into CI and automatically generate CHANGELOG.md in the same workflow as version updater.
I believe such an approach would allow us to have a fairly up-to-date changelog while not increasing toil on new contributors.

The alternative is to require an edition of the changelog file in each PR or generating a changelog only when a new branch is cut. IMHO the former is unnecessarily complicating PR creation process and can cause merge conflicts, while the latter makes new features from `main` branch non-discoverable for a large portion of a year (historically we cut branches for each openshift release).