### PR TITLE
Add resource requests and limits to prometheus-adapter container

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -206,6 +206,7 @@ function(params) {
         '--secure-port=6443',
         '--tls-cipher-suites=' + std.join(',', pa._config.tlsCipherSuites),
       ],
+      resources: pa._config.resources,
       ports: [{ containerPort: 6443 }],
       volumeMounts: [
         { name: 'tmpfs', mountPath: '/tmp', readOnly: false },

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -38,7 +38,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "a20c679492aae363414dce23bc63da09cf8a7287",
+      "version": "4c6f9dabceb944ce894d79eeb516c98694f5759f",
       "sum": "GRf2GvwEU4jhXV+JOonXSZ4wdDv8mnHBPCQ6TUVd+g8="
     },
     {
@@ -130,7 +130,7 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "79d354ad2e7c3d510a7811176d5ffcd1b29c8b77",
+      "version": "507d61fdeb4540c34102f41b7286895ecec19324",
       "sum": "G3mFWvwIrrhG6hlPz/hQdE6ZNSim88DlbSDJN7enkhY=",
       "name": "prometheus"
     },
@@ -141,7 +141,7 @@
           "subdir": "mixin"
         }
       },
-      "version": "0f5223beb7e9cb7e62f0227bf5649deb851e6112",
+      "version": "83419bc5e3c5f667410a04c1c9920e27c3779162",
       "sum": "cajthvLKDjYgYHCKQU2g/pTMRkxcbuJEvTnCyJOihl8=",
       "name": "thanos-mixin"
     },

--- a/manifests/prometheus-adapter-deployment.yaml
+++ b/manifests/prometheus-adapter-deployment.yaml
@@ -40,6 +40,13 @@ spec:
         name: prometheus-adapter
         ports:
         - containerPort: 6443
+        resources:
+          limits:
+            cpu: 250m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
         volumeMounts:
         - mountPath: /tmp
           name: tmpfs


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description
While testing out release 0.8 I noticed there were no container requests/limits for prometheus-adapter. Looking at the jsonnet file, I saw that resources were defined in the default values, but not added to the container. By adding the line in the PR, resource limits are now attached to the container.
I have to note that the resource requests and limits are a lot higher than the usage I'm seeing in my cluster, but I'm running a small cluster. Still, if anyone could verify that the actual resources defined are reasonable, that would be great!



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Add resource requests and limits to prometheus-adapter container
```
