### PR TITLE
Turn AWS VPC CNI into a control plane add-on

### DIFF
--- a/jsonnet/kube-prometheus/addons/aws-vpc-cni.libsonnet
+++ b/jsonnet/kube-prometheus/addons/aws-vpc-cni.libsonnet
@@ -1,0 +1,110 @@
+{
+  values+:: {
+    awsVpcCni: {
+      // `minimumWarmIPs` should be inferior or equal to `WARM_IP_TARGET`.
+      //
+      // References:
+      // https://github.com/aws/amazon-vpc-cni-k8s/blob/v1.9.0/docs/eni-and-ip-target.md
+      // https://github.com/aws/amazon-vpc-cni-k8s/blob/v1.9.0/pkg/ipamd/ipamd.go#L61-L71
+      minimumWarmIPs: 10,
+      minimumWarmIPsTime: '10m',
+    },
+  },
+  kubernetesControlPlane+: {
+    serviceAwsVpcCni: {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: {
+        name: 'aws-node',
+        namespace: 'kube-system',
+        labels: { 'app.kubernetes.io/name': 'aws-node' },
+      },
+      spec: {
+        ports: [
+          {
+            name: 'cni-metrics-port',
+            port: 61678,
+            targetPort: 61678,
+          },
+        ],
+        selector: { 'app.kubernetes.io/name': 'aws-node' },
+        clusterIP: 'None',
+      },
+    },
+
+    serviceMonitorAwsVpcCni: {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'ServiceMonitor',
+      metadata: {
+        name: 'aws-node',
+        namespace: $.values.common.namespace,
+        labels: {
+          'app.kubernetes.io/name': 'aws-node',
+        },
+      },
+      spec: {
+        jobLabel: 'app.kubernetes.io/name',
+        selector: {
+          matchLabels: {
+            'app.kubernetes.io/name': 'aws-node',
+          },
+        },
+        namespaceSelector: {
+          matchNames: [
+            'kube-system',
+          ],
+        },
+        endpoints: [
+          {
+            port: 'cni-metrics-port',
+            interval: '30s',
+            path: '/metrics',
+            relabelings: [
+              {
+                action: 'replace',
+                regex: '(.*)',
+                replacement: '$1',
+                sourceLabels: ['__meta_kubernetes_pod_node_name'],
+                targetLabel: 'instance',
+              },
+            ],
+          },
+        ],
+      },
+    },
+
+    prometheusRuleAwsVpcCni: {
+      apiVersion: 'monitoring.coreos.com/v1',
+      kind: 'PrometheusRule',
+      metadata: {
+        labels: $.prometheus._config.commonLabels + $.prometheus._config.mixin.ruleLabels,
+        name: 'aws-vpc-cni-rules',
+        namespace: $.prometheus._config.namespace,
+      },
+      spec: {
+        groups: [
+          {
+            name: 'aws-vpc-cni.rules',
+            rules: [
+              {
+                expr: 'sum by(instance) (awscni_total_ip_addresses) - sum by(instance) (awscni_assigned_ip_addresses) < %s' % $.values.awsVpcCni.minimumWarmIPs,
+                labels: {
+                  severity: 'critical',
+                },
+                annotations: {
+                  summary: 'AWS VPC CNI has a low warm IP pool',
+                  description: |||
+                    Instance {{ $labels.instance }} has only {{ $value }} warm IPs which is lower than set threshold of %s.
+                    It could mean the current subnet is out of available IP addresses or the CNI is unable to request them from the EC2 API.
+                  ||| % $.values.awsVpcCni.minimumWarmIPs,
+                },
+                'for': $.values.awsVpcCni.minimumWarmIPsTime,
+                alert: 'AwsVpcCniWarmIPsLow',
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+}

--- a/jsonnet/kube-prometheus/platforms/eks.libsonnet
+++ b/jsonnet/kube-prometheus/platforms/eks.libsonnet
@@ -1,15 +1,5 @@
+(import '../addons/aws-vpc-cni.libsonnet') +
 (import '../addons/managed-cluster.libsonnet') + {
-  values+:: {
-    awsVpcCni: {
-      // `minimumWarmIPs` should be inferior or equal to `WARM_IP_TARGET`.
-      //
-      // References:
-      // https://github.com/aws/amazon-vpc-cni-k8s/blob/v1.9.0/docs/eni-and-ip-target.md
-      // https://github.com/aws/amazon-vpc-cni-k8s/blob/v1.9.0/pkg/ipamd/ipamd.go#L61-L71
-      minimumWarmIPs: 10,
-      minimumWarmIPsTime: '10m',
-    },
-  },
   kubernetesControlPlane+: {
     serviceMonitorCoreDNS+: {
       spec+: {
@@ -18,102 +8,6 @@
             bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
             interval: '15s',
             targetPort: 9153,
-          },
-        ],
-      },
-    },
-
-    serviceAwsVpcCniMetrics: {
-      apiVersion: 'v1',
-      kind: 'Service',
-      metadata: {
-        name: 'aws-node',
-        namespace: 'kube-system',
-        labels: { 'app.kubernetes.io/name': 'aws-node' },
-      },
-      spec: {
-        ports: [
-          {
-            name: 'cni-metrics-port',
-            port: 61678,
-            targetPort: 61678,
-          },
-        ],
-        selector: { 'app.kubernetes.io/name': 'aws-node' },
-        clusterIP: 'None',
-      },
-    },
-
-    serviceMonitorAwsVpcCni: {
-      apiVersion: 'monitoring.coreos.com/v1',
-      kind: 'ServiceMonitor',
-      metadata: {
-        name: 'aws-node',
-        namespace: $.values.common.namespace,
-        labels: {
-          'app.kubernetes.io/name': 'aws-node',
-        },
-      },
-      spec: {
-        jobLabel: 'app.kubernetes.io/name',
-        selector: {
-          matchLabels: {
-            'app.kubernetes.io/name': 'aws-node',
-          },
-        },
-        namespaceSelector: {
-          matchNames: [
-            'kube-system',
-          ],
-        },
-        endpoints: [
-          {
-            port: 'cni-metrics-port',
-            interval: '30s',
-            path: '/metrics',
-            relabelings: [
-              {
-                action: 'replace',
-                regex: '(.*)',
-                replacement: '$1',
-                sourceLabels: ['__meta_kubernetes_pod_node_name'],
-                targetLabel: 'instance',
-              },
-            ],
-          },
-        ],
-      },
-    },
-
-    prometheusRuleAwsVpcCni: {
-      apiVersion: 'monitoring.coreos.com/v1',
-      kind: 'PrometheusRule',
-      metadata: {
-        labels: $.prometheus._config.commonLabels + $.prometheus._config.mixin.ruleLabels,
-        name: 'aws-vpc-cni-rules',
-        namespace: $.prometheus._config.namespace,
-      },
-      spec: {
-        groups: [
-          {
-            name: 'kube-prometheus-aws-vpc-cni.rules',
-            rules: [
-              {
-                expr: 'sum by(instance) (awscni_total_ip_addresses) - sum by(instance) (awscni_assigned_ip_addresses) < %s' % $.values.awsVpcCni.minimumWarmIPs,
-                labels: {
-                  severity: 'critical',
-                },
-                annotations: {
-                  summary: 'AWS VPC CNI has a low warm IP pool',
-                  description: |||
-                    Instance {{ $labels.instance }} has only {{ $value }} warm IPs which is lower than set threshold of %s.
-                    It could mean the current subnet is out of available IP addresses or the CNI is unable to request them from the EC2 API.
-                  ||| % $.values.awsVpcCni.minimumWarmIPs,
-                },
-                'for': $.values.awsVpcCni.minimumWarmIPsTime,
-                alert: 'AwsVpcCniWarmIPsLow',
-              },
-            ],
           },
         ],
       },


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Move configuration related to the AWS VPC CNI to its own add-on file, and import it in the EKS platform file, this way it can be used for self-managed clusters on AWS too.

kOps for example: https://kops.sigs.k8s.io/networking/aws-vpc/

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Turn AWS VPC CNI into a control plane add-on
```
