### PR TITLE
Create Thanos Sidecar rules separately from Prometheus ones

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -59,6 +59,7 @@ function(params) {
   mixinThanos::
     (import 'github.com/thanos-io/thanos/mixin/alerts/sidecar.libsonnet') +
     (import 'github.com/kubernetes-monitoring/kubernetes-mixin/lib/add-runbook-links.libsonnet') + {
+      _config+:: p._config.mixin._config,
       targetGroups: {},
       sidecar: {
         selector: p._config.mixin._config.thanosSelector,

--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -50,20 +50,21 @@ function(params) {
   assert std.isObject(p._config.resources),
   assert std.isObject(p._config.mixin._config),
 
-  mixin:: (import 'github.com/prometheus/prometheus/documentation/prometheus-mixin/mixin.libsonnet') +
-          (import 'github.com/kubernetes-monitoring/kubernetes-mixin/lib/add-runbook-links.libsonnet') + (
-    if p._config.thanos != {} then
-      (import 'github.com/thanos-io/thanos/mixin/alerts/sidecar.libsonnet') + {
-        targetGroups: {},
-        sidecar: {
-          selector: p._config.mixin._config.thanosSelector,
-          dimensions: std.join(', ', ['job', 'instance']),
-        },
-      }
-    else {}
-  ) {
-    _config+:: p._config.mixin._config,
-  },
+  mixin::
+    (import 'github.com/prometheus/prometheus/documentation/prometheus-mixin/mixin.libsonnet') +
+    (import 'github.com/kubernetes-monitoring/kubernetes-mixin/lib/add-runbook-links.libsonnet') + {
+      _config+:: p._config.mixin._config,
+    },
+
+  mixinThanos::
+    (import 'github.com/thanos-io/thanos/mixin/alerts/sidecar.libsonnet') +
+    (import 'github.com/kubernetes-monitoring/kubernetes-mixin/lib/add-runbook-links.libsonnet') + {
+      targetGroups: {},
+      sidecar: {
+        selector: p._config.mixin._config.thanosSelector,
+        dimensions: std.join(', ', ['job', 'instance']),
+      },
+    },
 
   prometheusRule: {
     apiVersion: 'monitoring.coreos.com/v1',
@@ -324,6 +325,22 @@ function(params) {
         port: 'web',
         interval: '30s',
       }],
+    },
+  },
+
+  // Include thanos sidecar PrometheusRule only if thanos config was passed by user
+  [if std.objectHas(params, 'thanos') && std.length(params.thanos) > 0 then 'prometheusRuleThanosSidecar']: {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'PrometheusRule',
+    metadata: {
+      labels: p._config.commonLabels + p._config.mixin.ruleLabels,
+      name: 'prometheus-' + p._config.name + '-thanos-sidecar-rules',
+      namespace: p._config.namespace,
+    },
+    spec: {
+      local r = if std.objectHasAll(p.mixinThanos, 'prometheusRules') then p.mixinThanos.prometheusRules.groups else [],
+      local a = if std.objectHasAll(p.mixinThanos, 'prometheusAlerts') then p.mixinThanos.prometheusAlerts.groups else [],
+      groups: a + r,
     },
   },
 


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

I want to be able to hide these resources easily:

```jsonnet
    prometheusRuleThanosSidecar:: {},
    serviceThanosSidecar:: {},
    serviceMonitorThanosSidecar:: {},
```

I prefer to manage them with https://github.com/thanos-io/kube-thanos/blob/main/jsonnet/kube-thanos/kube-thanos-sidecar.libsonnet instead, it can be used to create a single set of resources for all Prometheus pairs, which avoids updating Thanos Query for each of them.

I also think PrometheusRule could create duplicated rules between Prometheus pairs, as the Prometheus query selector does not exclusively select the sidecar metrics it has been deployed for.

(And it happens to be a bit more readable too)

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Create Thanos Sidecar rules separately from Prometheus ones
```
