### PR TITLE
release-0.7: ci: Harden action to wait for kind cluster readiness

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   - pull_request
 env:
   golang-version: '1.15'
-  kind-version: 'v0.9.0'
+  kind-version: 'v0.11.1'
 jobs:
   generate:
     runs-on: ${{ matrix.os }}
@@ -32,8 +32,8 @@ jobs:
     strategy:
       matrix:
         kind-image:
-          - 'kindest/node:v1.19.0'
-          - 'kindest/node:v1.20.0'
+          - 'kindest/node:v1.19.11'
+          - 'kindest/node:v1.20.7'
     steps:
     - uses: actions/checkout@v2
     - name: Start KinD

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,13 +41,9 @@ jobs:
       with:
         version: ${{ env.kind-version }}
         image: ${{ matrix.kind-image }}
+        wait: 300s
     - name: Wait for cluster to finish bootstraping
-      run: |
-        until [ "$(kubectl get pods --all-namespaces --no-headers | grep -cEv '([0-9]+)/\1')" -eq 0 ]; do
-            sleep 5s
-        done
-        kubectl cluster-info
-        kubectl get pods -A
+      run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
     - name: Create kube-prometheus stack
       run: |
         kubectl create -f manifests/setup


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Backport https://github.com/prometheus-operator/kube-prometheus/pull/1237 to release-0.7 for https://github.com/prometheus-operator/kube-prometheus/pull/1295.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
