### PR TITLE
Adds default ruleSelector in developing rules & dashboards documentation

### DIFF
--- a/docs/developing-prometheus-rules-and-grafana-dashboards.md
+++ b/docs/developing-prometheus-rules-and-grafana-dashboards.md
@@ -83,6 +83,10 @@ local kp = (import 'kube-prometheus/main.libsonnet') + {
       metadata: {
         name: 'my-prometheus-rule',
         namespace: $.values.common.namespace,
+        labels: {
+          prometheus: 'k8s',
+          role: 'alert-rules',
+        }
       },
       spec: {
         groups: [
@@ -139,6 +143,10 @@ local kp = (import 'kube-prometheus/main.libsonnet') + {
       metadata: {
         name: 'my-prometheus-rule',
         namespace: $.values.common.namespace,
+        labels: {
+          prometheus: 'k8s',
+          role: 'alert-rules',
+        }
       },
       spec: {
         groups: [
@@ -199,6 +207,10 @@ local kp = (import 'kube-prometheus/main.libsonnet') + {
       metadata: {
         name: 'my-prometheus-rule',
         namespace: $.values.common.namespace,
+        labels: {
+          prometheus: 'k8s',
+          role: 'alert-rules',
+        }
       },
       spec: {
         groups: (import 'existingrule.json').groups,
@@ -292,6 +304,10 @@ local add = {
       metadata: {
         name: 'example-application-rules',
         namespace: $.values.common.namespace,
+        labels: {
+          prometheus: 'k8s',
+          role: 'alert-rules',
+        }
       },
       spec: (import 'existingrule.json'),
     },


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

The examples provided do not include the default `ruleSelector` labels and therefore will not be added to the `rulefiles` configmap



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Adds default ruleSelector in developing rules & dashboards documentation

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Adds default ruleSelector in developing rules & dashboards documentation
```
