### PR TITLE
jsonnet: The node exporter should not export data about veth interfaces.

### DIFF
--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -177,8 +177,8 @@ function(params) {
         // NOTE: ignore veth network interface associated with containers.
         // OVN renames veth.* to <rand-hex>@if<X> where X is /sys/class/net/<if>/ifindex
         // thus [a-z0-9] regex below
-        '--collector.netclass.ignored-devices=^(veth.*|[a-z0-9]+@if\\d+)$',
-        '--collector.netdev.device-exclude=^(veth.*|[a-z0-9]+@if\\d+)$',
+        '--collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$',
+        '--collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$',
       ],
       volumeMounts: [
         { name: 'sys', mountPath: '/host/sys', mountPropagation: 'HostToContainer', readOnly: true },

--- a/manifests/node-exporter-daemonset.yaml
+++ b/manifests/node-exporter-daemonset.yaml
@@ -30,8 +30,8 @@ spec:
         - --no-collector.wifi
         - --no-collector.hwmon
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)
-        - --collector.netclass.ignored-devices=^(veth.*|[a-z0-9]+@if\d+)$
-        - --collector.netdev.device-exclude=^(veth.*|[a-z0-9]+@if\d+)$
+        - --collector.netclass.ignored-devices=^(veth.*|[a-f0-9]{15})$
+        - --collector.netdev.device-exclude=^(veth.*|[a-f0-9]{15})$
         image: quay.io/prometheus/node-exporter:v1.1.2
         name: node-exporter
         resources:


### PR DESCRIPTION
In case of the OVN, the regex was incorrect and was exporting veth metrics.

## Description

Backport of #1283 


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

