### PR TITLE
jsonnet: set thanos config to null by default

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -34,7 +34,7 @@ local defaults = {
       runbookURLPattern: 'https://runbooks.prometheus-operator.dev/runbooks/prometheus/%s',
     },
   },
-  thanos: {},
+  thanos: null,
 };
 
 
@@ -100,7 +100,7 @@ function(params) {
                { name: 'web', targetPort: 'web', port: 9090 },
              ] +
              (
-               if p._config.thanos != {} then
+               if p._config.thanos != null then
                  [{ name: 'grpc', port: 10901, targetPort: 10901 }]
                else []
              ),
@@ -325,7 +325,7 @@ function(params) {
   },
 
   // Include thanos sidecar PrometheusRule only if thanos config was passed by user
-  [if std.objectHas(params, 'thanos') && std.length(params.thanos) > 0 then 'prometheusRuleThanosSidecar']: {
+  [if std.objectHas(params, 'thanos') && params.thanos != null then 'prometheusRuleThanosSidecar']: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'PrometheusRule',
     metadata: {
@@ -341,7 +341,7 @@ function(params) {
   },
 
   // Include thanos sidecar Service only if thanos config was passed by user
-  [if std.objectHas(params, 'thanos') && std.length(params.thanos) > 0 then 'serviceThanosSidecar']: {
+  [if std.objectHas(params, 'thanos') && params.thanos != null then 'serviceThanosSidecar']: {
     apiVersion: 'v1',
     kind: 'Service',
     metadata+: {
@@ -366,7 +366,7 @@ function(params) {
   },
 
   // Include thanos sidecar ServiceMonitor only if thanos config was passed by user
-  [if std.objectHas(params, 'thanos') && std.length(params.thanos) > 0 then 'serviceMonitorThanosSidecar']: {
+  [if std.objectHas(params, 'thanos') && params.thanos != null then 'serviceMonitorThanosSidecar']: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'ServiceMonitor',
     metadata+: {


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Fixes #1324

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
prometheus: allow passing `thanos: {}` to prometheus configuration
```
