### PR TITLE
Fix automated update in CI

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -35,8 +35,8 @@ jobs:
         make generate
 
         # Reset jsonnetfile.lock.json if no dependencies were updated
-        changedFiles=$(git diff --name-only | grep -v 'jsonnetfile.lock.json')
-        if [[ $changedFiles == "" ]]; then
+        changedFiles=$(git diff --name-only | grep -v 'jsonnetfile.lock.json' | wc -l)
+        if [[ "$changedFiles" -eq 0 ]]; then
           git checkout -- jsonnetfile.lock.json;
         fi
     - name: Create Pull Request


### PR DESCRIPTION
Automated dependencies update in CI was failing whenever no new changes
were detected since git diff was returning 1.

Recent failures caused by this issue:
- https://github.com/prometheus-operator/kube-prometheus/actions/runs/1136036797
- https://github.com/prometheus-operator/kube-prometheus/actions/runs/1134649290

The CI failures aren't very self explanatory, but after checking on my fork, the issue was actually in the subshell.