### PR TITLE
1340 kops - set cluster names to match platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,8 @@ A common example is that not all Kubernetes clusters are created exactly the sam
 * bootkube
 * eks
 * gke
-* kops-coredns
+* kops
+* kops_coredns
 * kubeadm
 * kubespray
 


### PR DESCRIPTION
## Description

Issue https://github.com/prometheus-operator/kube-prometheus/issues/1340
Fix README so that kops platform setting matches the list provided

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Fix README so that kops platform setting matches the list provided

```release-note
Fix README so that kops platform setting matches the list provided
```
