### PR TITLE
jsonnet: Support scraping the config-reloader for AlertManager and Pr…

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -19,6 +19,7 @@ local defaults = {
     if !std.setMember(labelName, ['app.kubernetes.io/version'])
   },
   name: error 'must provide name',
+  reloaderPort: 8080,
   config: {
     global: {
       resolve_timeout: '5m',
@@ -136,6 +137,7 @@ function(params) {
     spec: {
       ports: [
         { name: 'web', targetPort: 'web', port: 9093 },
+        { name: 'reloader-web', port: am._config.reloaderPort, targetPort: 'reloader-web' },
       ],
       selector: {
         app: 'alertmanager',
@@ -161,6 +163,7 @@ function(params) {
       },
       endpoints: [
         { port: 'web', interval: '30s' },
+        { port: 'reloader-web', interval: '30s' },
       ],
     },
   },

--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -35,6 +35,7 @@ local defaults = {
     },
   },
   thanos: null,
+  reloaderPort: 8080,
 };
 
 
@@ -98,6 +99,7 @@ function(params) {
     spec: {
       ports: [
                { name: 'web', targetPort: 'web', port: 9090 },
+               { name: 'reloader-web', port: p._config.reloaderPort, targetPort: 'reloader-web' },
              ] +
              (
                if p._config.thanos != null then
@@ -317,10 +319,10 @@ function(params) {
       selector: {
         matchLabels: p._config.selectorLabels,
       },
-      endpoints: [{
-        port: 'web',
-        interval: '30s',
-      }],
+      endpoints: [
+        { port: 'web', interval: '30s' },
+        { port: 'reloader-web', interval: '30s' },
+      ],
     },
   },
 

--- a/manifests/alertmanager-service.yaml
+++ b/manifests/alertmanager-service.yaml
@@ -14,6 +14,9 @@ spec:
   - name: web
     port: 9093
     targetPort: web
+  - name: reloader-web
+    port: 8080
+    targetPort: reloader-web
   selector:
     alertmanager: main
     app: alertmanager

--- a/manifests/alertmanager-serviceMonitor.yaml
+++ b/manifests/alertmanager-serviceMonitor.yaml
@@ -12,6 +12,8 @@ spec:
   endpoints:
   - interval: 30s
     port: web
+  - interval: 30s
+    port: reloader-web
   selector:
     matchLabels:
       alertmanager: main

--- a/manifests/prometheus-service.yaml
+++ b/manifests/prometheus-service.yaml
@@ -14,6 +14,9 @@ spec:
   - name: web
     port: 9090
     targetPort: web
+  - name: reloader-web
+    port: 8080
+    targetPort: reloader-web
   selector:
     app: prometheus
     app.kubernetes.io/component: prometheus

--- a/manifests/prometheus-serviceMonitor.yaml
+++ b/manifests/prometheus-serviceMonitor.yaml
@@ -12,6 +12,8 @@ spec:
   endpoints:
   - interval: 30s
     port: web
+  - interval: 30s
+    port: reloader-web
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus


### PR DESCRIPTION
…ometheus

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This change updates the ServiceMonitor to scrape the reloader sidecar for Promtheus and AlertManager via the service when the components are not set to listen on localhost.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry
<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Support scraping config-reloader sidecar for Prometheus and AlertManager StatefulSets
```
