### PR TITLE
fix sync-to-internal-registry.jsonnet

### DIFF
--- a/jsonnet/kube-prometheus/addons/config-mixins.libsonnet
+++ b/jsonnet/kube-prometheus/addons/config-mixins.libsonnet
@@ -32,5 +32,9 @@ local withImageRepository(repository) = {
 };
 
 {
+  imageName:: imageName,
+}
+
+{
   withImageRepository:: withImageRepository,
 }

--- a/sync-to-internal-registry.jsonnet
+++ b/sync-to-internal-registry.jsonnet
@@ -1,17 +1,16 @@
-local kp = import 'kube-prometheus/kube-prometheus.libsonnet';
-local l = import 'kube-prometheus/lib/lib.libsonnet';
-local config = kp._config;
+local kp = import 'kube-prometheus/main.libsonnet';
+local l = import 'kube-prometheus/addons/config-mixins.libsonnet';
+local config = kp.values.common;
 
 local makeImages(config) = [
   {
-    name: config.imageRepos[image],
-    tag: config.versions[image],
+    name: config.images[image],
   }
-  for image in std.objectFields(config.imageRepos)
+  for image in std.objectFields(config.images)
 ];
 
-local upstreamImage(image) = '%s:%s' % [image.name, image.tag];
-local downstreamImage(registry, image) = '%s/%s:%s' % [registry, l.imageName(image.name), image.tag];
+local upstreamImage(image) = '%s' % [image.name];
+local downstreamImage(registry, image) = '%s/%s' % [registry, l.imageName(image.name)];
 
 local pullPush(image, newRegistry) = [
   'docker pull %s' % upstreamImage(image),


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

### Expected:
```jsonnet -J vendor -S --tla-str repository=internal-registry.com/organization sync-to-internal-registry.jsonnet``` to work

### Actual:

```
RUNTIME ERROR: couldn't open import "kube-prometheus/kube-prometheus.libsonnet": no match locally or in the Jsonnet library paths.
        sync-to-internal-registry.jsonnet:1:12-62       thunk <kp>
        sync-to-internal-registry.jsonnet:3:16-18       thunk <config>
        sync-to-internal-registry.jsonnet:22:27-33      thunk <config>
        sync-to-internal-registry.jsonnet:10:33-39      thunk <o>
        std.jsonnet:1293:24     
        std.jsonnet:1293:5-33   function <anonymous>
        sync-to-internal-registry.jsonnet:10:16-51      thunk <a>
        sync-to-internal-registry.jsonnet:(5:28)-(11:2) function <anonymous>
        sync-to-internal-registry.jsonnet:(5:28)-(11:2) function <makeImages>
        sync-to-internal-registry.jsonnet:22:16-34      thunk <images>
        ...
        std.jsonnet:847:37-41   thunk <arr>
        std.jsonnet:790:15-18   thunk <arr>
        std.jsonnet:786:28-31   
        std.jsonnet:786:17-32   function <aux>
        std.jsonnet:790:5-28    function <anonymous>
        std.jsonnet:847:5-46    function <anonymous>
        sync-to-internal-registry.jsonnet:(24:28)-(27:3)        function <output>
        sync-to-internal-registry.jsonnet:30:18-36      
        sync-to-internal-registry.jsonnet:30:3-37       function <top_level>
        Top-level function      
```

### Notes: 
```Broken since release-0.8```

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
fixes sync-to-internal-registry.jsonnet which is broken since release-0.8
```
