### PR TITLE
jsonnet: Drop cAdvisor metrics with no (pod, namespace) labels while …

### DIFF
--- a/jsonnet/kube-prometheus/kube-prometheus-insecure-kubelet.libsonnet
+++ b/jsonnet/kube-prometheus/kube-prometheus-insecure-kubelet.libsonnet
@@ -31,6 +31,23 @@
                   regex: 'container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)',
                   action: 'drop',
                 },
+                // Drop cAdvisor metrics with no (pod, namespace) labels while preserving ability to monitor system services resource usage (cardinality estimation)
+                {
+                  sourceLabels: ['__name__', 'pod', 'namespace'],
+                  action: 'drop',
+                  regex: '(' + std.join('|',
+                                        [
+                                          'container_fs_.*',  // add filesystem read/write data (nodes*disks*services*4)
+                                          'container_spec_.*',  // everything related to cgroup specification and thus static data (nodes*services*5)
+                                          'container_blkio_device_usage_total',  // useful for containers, but not for system services (nodes*disks*services*operations*2)
+                                          'container_file_descriptors',  // file descriptors limits and global numbers are exposed via (nodes*services)
+                                          'container_sockets',  // used sockets in cgroup. Usually not important for system services (nodes*services)
+                                          'container_threads_max',  // max number of threads in cgroup. Usually for system services it is not limited (nodes*services)
+                                          'container_threads',  // used threads in cgroup. Usually not important for system services (nodes*services)
+                                          'container_start_time_seconds',  // container start. Possibly not needed for system services (nodes*services)
+                                          'container_last_seen',  // not needed as system services are always running (nodes*services)
+                                        ]) + ');;',
+                },
               ],
             },
           ],

--- a/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/prometheus/prometheus.libsonnet
@@ -322,6 +322,23 @@ local relabelings = import 'kube-prometheus/dropping-deprecated-metrics-relabeli
                 regex: 'container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)',
                 action: 'drop',
               },
+              // Drop cAdvisor metrics with no (pod, namespace) labels while preserving ability to monitor system services resource usage (cardinality estimation)
+              {
+                sourceLabels: ['__name__', 'pod', 'namespace'],
+                action: 'drop',
+                regex: '(' + std.join('|',
+                                      [
+                                        'container_fs_.*',  // add filesystem read/write data (nodes*disks*services*4)
+                                        'container_spec_.*',  // everything related to cgroup specification and thus static data (nodes*services*5)
+                                        'container_blkio_device_usage_total',  // useful for containers, but not for system services (nodes*disks*services*operations*2)
+                                        'container_file_descriptors',  // file descriptors limits and global numbers are exposed via (nodes*services)
+                                        'container_sockets',  // used sockets in cgroup. Usually not important for system services (nodes*services)
+                                        'container_threads_max',  // max number of threads in cgroup. Usually for system services it is not limited (nodes*services)
+                                        'container_threads',  // used threads in cgroup. Usually not important for system services (nodes*services)
+                                        'container_start_time_seconds',  // container start. Possibly not needed for system services (nodes*services)
+                                        'container_last_seen',  // not needed as system services are always running (nodes*services)
+                                      ]) + ');;',
+              },
             ],
           },
           {

--- a/manifests/prometheus-serviceMonitorKubelet.yaml
+++ b/manifests/prometheus-serviceMonitorKubelet.yaml
@@ -60,6 +60,12 @@ spec:
       regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
       sourceLabels:
       - __name__
+    - action: drop
+      regex: (container_fs_.*|container_spec_.*|container_blkio_device_usage_total|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
+      sourceLabels:
+      - __name__
+      - pod
+      - namespace
     path: /metrics/cadvisor
     port: https-metrics
     relabelings:


### PR DESCRIPTION
…preserving ability to monitor system services resource usage

The following provides a description and cardinality estimation based on the tests in a local cluster:

container_blkio_device_usage_total - useful for containers, but not for system services (nodes*disks*services*operations*2)
container_fs_.*                    - add filesystem read/write data (nodes*disks*services*4)
container_file_descriptors         - file descriptors limits and global numbers are exposed via (nodes*services)
container_threads_max              - max number of threads in cgroup. Usually for system services it is not limited (nodes*services)
container_threads                  - used threads in cgroup. Usually not important for system services (nodes*services)
container_sockets                  - used sockets in cgroup. Usually not important for system services (nodes*services)
container_start_time_seconds       - container start. Possibly not needed for system services (nodes*services)
container_last_seen                - Not needed as system services are always running (nodes*services)
container_spec_.*                  - Everything related to cgroup specification and thus static data (nodes*services*5)

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Backport of #1250

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Drop high cardinality metrics from cAdvisor
```
