### PR TITLE
Fix import path in 'monitoring other namespaces' docs

### DIFF
--- a/docs/monitoring-other-namespaces.md
+++ b/docs/monitoring-other-namespaces.md
@@ -20,7 +20,7 @@ This is done in the variable `prometheus.roleSpecificNamespaces`. You usually se
 
 Example to create the needed `Role` and `RoleBinding` for the Namespace `foo` : 
 ```
-local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') + {
+local kp = (import 'kube-prometheus/main.libsonnet') + {
   _config+:: {
     namespace: 'monitoring',
 


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

I was following https://prometheus-operator.dev/docs/kube/monitoring-other-namespaces/ to monitor an additional namespace by default, and ran through the jsonnet steps. 

```
➜ ./build.sh customize.jsonnet

+ set -o pipefail
++ pwd
+ PATH=/Users/mfriedrich/dev/everyonecancontribute/observability/my-kube-prometheus/tmp/bin:/Users/mfriedrich/.rbenv/shims:/Users/mfriedrich/.pyenv/shims:/usr/local/opt/grep/libexec/gnubin:/usr/local/opt/gnu-tar/libexec/gnubin:/usr/local/opt/gnu-sed/libexec/gnubin:/usr/local/opt/gnu-indent/libexec/gnubin:/usr/local/opt/gawk/libexec/gnubin:/usr/local/opt/findutils/libexec/gnubin:/usr/local/opt/coreutils/libexec/gnubin:/Users/mfriedrich/.nvm/versions/node/v12.4.0/bin:/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Wireshark.app/Contents/MacOS
+ rm -rf manifests
+ mkdir -p manifests/setup
+ jsonnet -J vendor -m manifests customize.jsonnet
+ xargs '-I{}' sh -c 'cat {} | gojsontoyaml > {}.yaml' -- '{}'
RUNTIME ERROR: couldn't open import "kube-prometheus/kube-prometheus.libsonnet": no match locally or in the Jsonnet library paths.
	customize.jsonnet:1:13-63	thunk <kp>
	customize.jsonnet:11:81-83	thunk <o>
	std.jsonnet:1293:24
	std.jsonnet:1293:5-33	function <anonymous>
	customize.jsonnet:11:64-99	thunk <a>
	customize.jsonnet:11:1-101	function <anonymous>
	customize.jsonnet:11:1-101
```

Changed in https://github.com/prometheus-operator/kube-prometheus/commit/42a3ac0606818541e66a111693d3ff98c642f7a8 from `kube-prometheus` to `main`

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix kube-prometheus jsonnet include path in 'Monitoring other Namespaces' docs
```
