### PR TITLE
Add e2e tests for Grafana deployment

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -277,3 +277,18 @@ func TestFailedRuleEvaluations(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestGrafana(t *testing.T){
+	kClient := promClient.kubeClient
+	
+	err := wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
+		grafanaDeployment, err := kClient.AppsV1().Deployments("monitoring").Get(context.Background(), "grafana", metav1.GetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return grafanaDeployment.Status.ReadyReplicas == *grafanaDeployment.Spec.Replicas, nil
+	})
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "Timeout while waiting for deployment ready condition."))
+	}
+}


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Recently, we've been hit by a [change upstream](https://github.com/brancz/kubernetes-grafana/pull/115) that [broke our Grafana deployment](https://github.com/prometheus-operator/kube-prometheus/issues/1372). 

This bug has been fixed by https://github.com/prometheus-operator/kube-prometheus/pull/1373, however, I think that we could add an e2e test to prevent that from happening again.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
NONE
```
