### PR TITLE
Adjust dropped metrics from cAdvisor

### DIFF
--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -126,9 +126,7 @@ function(params) {
               action: 'drop',
               regex: '(' + std.join('|',
                                     [
-                                      'container_fs_.*',  // add filesystem read/write data (nodes*disks*services*4)
                                       'container_spec_.*',  // everything related to cgroup specification and thus static data (nodes*services*5)
-                                      'container_blkio_device_usage_total',  // useful for containers, but not for system services (nodes*disks*services*operations*2)
                                       'container_file_descriptors',  // file descriptors limits and global numbers are exposed via (nodes*services)
                                       'container_sockets',  // used sockets in cgroup. Usually not important for system services (nodes*services)
                                       'container_threads_max',  // max number of threads in cgroup. Usually for system services it is not limited (nodes*services)
@@ -136,6 +134,14 @@ function(params) {
                                       'container_start_time_seconds',  // container start. Possibly not needed for system services (nodes*services)
                                       'container_last_seen',  // not needed as system services are always running (nodes*services)
                                     ]) + ');;',
+            },
+            {
+              sourceLabels: ['__name__', 'container'],
+              action: 'drop',
+              regex: '(' + std.join('|',
+                                    [
+                                      'container_blkio_device_usage_total',
+                                    ]) + ');.+',
             },
           ],
         },

--- a/manifests/kubernetes-serviceMonitorKubelet.yaml
+++ b/manifests/kubernetes-serviceMonitorKubelet.yaml
@@ -61,11 +61,16 @@ spec:
       sourceLabels:
       - __name__
     - action: drop
-      regex: (container_fs_.*|container_spec_.*|container_blkio_device_usage_total|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
+      regex: (container_spec_.*|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
       sourceLabels:
       - __name__
       - pod
       - namespace
+    - action: drop
+      regex: (container_blkio_device_usage_total);.+
+      sourceLabels:
+      - __name__
+      - container
     path: /metrics/cadvisor
     port: https-metrics
     relabelings:


### PR DESCRIPTION
This change drops pod-centric metrics without a non-empty 'container' label.

Previously we dropped pod-centric metrics without a (pod, namespace) label set
however these can be critical for debugging.

Backport of https://github.com/prometheus-operator/kube-prometheus/pull/1396

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Drops cAdviosor metrics `container_fs_.*` and `container_blkio_device_usage_total ` with non empty `container` label
```
