### PR TITLE
thanos: bump to latest and add `thanosPrometheusCommonDimensions`

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -59,6 +59,7 @@ function(params) {
       targetGroups: {},
       sidecar: {
         selector: p._config.mixin._config.thanosSelector,
+        thanosPrometheusCommonDimensions: 'namespace, pod',
         dimensions: std.join(', ', ['job', 'instance']),
       },
     },

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -141,8 +141,8 @@
           "subdir": "mixin"
         }
       },
-      "version": "b894fd6537c8b445aa9d907867e492bb26cebcd5",
-      "sum": "X+060DnePPeN/87fgj0SrfxVitywTk8hZA9V4nHxl1g=",
+      "version": "b4b8434ca5a4a873762d73bf22fa4e0e1f43f6f1",
+      "sum": "Og+wEHfgzXBvBLAeeQvGNoiCw3FY4LQHlJdpsG/owj8=",
       "name": "thanos-mixin"
     },
     {


### PR DESCRIPTION

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This commit pulls latest changes from thanos mixins and sets `thanosPrometheusCommonDimensions`
to `namespace, pod` for k8s use case.

Refer https://github.com/thanos-io/thanos/pull/4508 for more details.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>