### PR TITLE
Keep 'container_fs_.*' metrics from cAdvisor

### DIFF
--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -140,8 +140,7 @@ function(params) {
               sourceLabels: ['__name__', 'container'],
               action: 'drop',
               regex: '(' + std.join('|',
-                                    [  // metrics are available at slice level
-                                      'container_fs_.*',
+                                    [
                                       'container_blkio_device_usage_total',
                                     ]) + ');.+',
             },

--- a/manifests/kubernetes-serviceMonitorKubelet.yaml
+++ b/manifests/kubernetes-serviceMonitorKubelet.yaml
@@ -67,7 +67,7 @@ spec:
       - pod
       - namespace
     - action: drop
-      regex: (container_fs_.*|container_blkio_device_usage_total);.+
+      regex: (container_blkio_device_usage_total);.+
       sourceLabels:
       - __name__
       - container


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Based on the discussion and investigation in https://github.com/prometheus-operator/kube-prometheus/pull/1396, it has become apparent that dropping these particular metrics might become problamatic for users of certain environments who have come to depend on them.

We believed when making the change, that the info provided by these metrics would still be available at a slice level. However in some cases (docker driver?) this appears not to be the case.

As per https://github.com/prometheus-operator/kube-prometheus/pull/1396#issuecomment-927887623 the original change should have been valid but given that it can cause issues, this change reverts the drop.

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
