### PR TITLE
Add changelogs to automated version updates

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -23,11 +23,15 @@ jobs:
       with:
         go-version: 1.16
     - name: Upgrade versions
+      id: versions
       run: |
         export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
         # Write to temporary file to make update atomic
         scripts/generate-versions.sh > /tmp/versions.json
         mv /tmp/versions.json jsonnet/kube-prometheus/versions.json
+        # Get the links to the changelogs of the updated versions and make them
+        # available to the reviewers
+        echo ::set-output name=new_changelogs::$(scripts/get-new-changelogs.sh)
       if: matrix.branch == 'main'
     - name: Update jsonnet dependencies
       run: |
@@ -49,7 +53,12 @@ jobs:
 
           This is an automated version and jsonnet dependencies update performed from CI.
 
-          Configuration of the workflow is located in `.github/workflows/versions.yaml`
+          Please review the following changelogs to make sure that we don't miss any important
+          changes before merging this PR.
+
+          ${{ steps.versions.outputs.new_changelogs }}
+
+          Configuration of the workflow is located in `.github/workflows/versions.yaml`.
 
           ## Type of change
 

--- a/scripts/get-new-changelogs.sh
+++ b/scripts/get-new-changelogs.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Get the freshly updated components versions.
+# Should be only used after running ./scripts/generate-versions and before
+# committing any changes.
+get_updated_versions() {
+  # Get only the newly updated versions from the versions file.
+  echo "$(git diff -U0 -- "${VERSION_FILE}" | grep '^[+]' | grep -Ev '^(--- a/|\+\+\+ b/)' | tr -d '",:+' | awk -F'"' '{print $1}')"
+}
+
+# Returns github changelog url based on a given repository url and tag.
+get_changelog_url() {
+  echo "https://github.com/${1}/releases/tag/v${2}"
+}
+
+# Gets all the new changelogs from the updated components version.
+get_changelog_urls() {
+  while IFS= read -r updated_version; do
+    read -r component version <<< "${updated_version}"
+    case "${component}" in
+      alertmanager)
+        get_changelog_url "prometheus/alertmanager" "${version}"
+        ;;
+      blackboxExporter)
+        get_changelog_url "prometheus/blackbox_exporter" "${version}"
+        ;;
+      grafana)
+        get_changelog_url "grafana/grafana" "${version}"
+        ;;
+      kubeStateMetrics)
+        get_changelog_url "kubernetes/kube-state-metrics" "${version}"
+        ;;
+      nodeExporter)
+        get_changelog_url "prometheus/node_exporter" "${version}"
+        ;;
+      prometheus)
+        get_changelog_url "prometheus/prometheus" "${version}"
+        ;;
+      prometheusAdapter)
+        get_changelog_url "kubernetes-sigs/prometheus-adapter" "${version}"
+        ;;
+      prometheusOperator)
+        get_changelog_url "prometheus-operator/prometheus-operator" "${version}"
+        ;;
+      kubeRbacProxy)
+        get_changelog_url "brancz/kube-rbac-proxy" "${version}"
+        ;;
+      configmapReload)
+        get_changelog_url "jimmidyson/configmap-reload" "${version}"
+        ;;
+      *)
+        echo "Unknown component ${component} updated"
+        exit 1
+        ;;
+    esac
+  done <<< "$(get_updated_versions)"
+}
+
+# File is used to read current versions
+VERSION_FILE="$(pwd)/jsonnet/kube-prometheus/versions.json"
+
+get_changelog_urls


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Add the links to the changelogs of the freshly updated components to the
automated PR that does the update. This allow verifying that we are not
missing any important changes before merging the update. This happened
recently with node-exporter 1.2 which changed some flag names that we
took 3 months to update. https://github.com/prometheus-operator/kube-prometheus/pull/1407


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
