### PR TITLE
Add support for Grafana 8 notifier channels configuration as "notifie…

### DIFF
--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -21,6 +21,7 @@ local defaults = {
   },
   prometheusName: error 'must provide prometheus name',
   dashboards: {},
+  notifiers: [],
   // TODO(paulfantom): expose those to have a stable API. After kubernetes-grafana refactor those could probably be removed.
   rawDashboards: {},
   folderDashboards: {},
@@ -52,6 +53,7 @@ function(params) {
       grafana+:: {
         labels: g._config.commonLabels,
         dashboards: g._config.dashboards,
+        notifiers: g._config.notifiers,
         resources: g._config.resources,
         rawDashboards: g._config.rawDashboards,
         folderDashboards: g._config.folderDashboards,
@@ -74,6 +76,7 @@ function(params) {
   deployment: glib.grafana.deployment,
   dashboardDatasources: glib.grafana.dashboardDatasources,
   dashboardSources: glib.grafana.dashboardSources,
+  notifierSources: glib.grafana.notifierSources,
 
   dashboardDefinitions: if std.length(g._config.dashboards) > 0 ||
                            std.length(g._config.rawDashboards) > 0 ||


### PR DESCRIPTION

## Description
Grafana 8 introduced notifications. For the notifications to work we need to configure Grafana Notifiers (aka notification channels). I created a pull request here https://github.com/brancz/kubernetes-grafana/pull/121 that adds this support on the kubernetes-grafana project.
However, we need to add support on this project as well, so we can configure the notifiers via `values: grafana: notifiers` in the libsonnet files.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [X] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Add `notifiers` field to `values:grafana` section to allow configuration of Grafana 8 notification channels (notifiers).

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```Add "notifiers" field to "values:grafana" section to allow configuration of Grafana 8 notification channels (notifiers).

```
