### PR TITLE
Fix jsonnet extension

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -44,4 +44,4 @@ ports:
     onOpen: open-browser
 vscode:
   extensions:
-    - heptio.jsonnet@0.1.0:woEDU5N62LRdgdz0g/I6sQ==
+    - heptio.jsonnet


### PR DESCRIPTION
Signed-off-by: ArthurSens <arthursens2005@gmail.com>

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Gitpod stopped supporting manually added extensions, this PR adjust the extension to the one [added to OpenVSX Extension Marketplace](https://github.com/open-vsx/publish-extensions/pull/444). 

With this fix, we have better jsonnet support for anyone who uses Gitpod to develop this project

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
