### PR TITLE
remove "app" label selector deprecated by prometheus-operator

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -140,7 +140,6 @@ function(params) {
         { name: 'reloader-web', port: am._config.reloaderPort, targetPort: 'reloader-web' },
       ],
       selector: {
-        app: 'alertmanager',
         alertmanager: am._config.name,
       } + am._config.selectorLabels,
       sessionAffinity: 'ClientIP',

--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -107,7 +107,7 @@ function(params) {
                  [{ name: 'grpc', port: 10901, targetPort: 10901 }]
                else []
              ),
-      selector: { app: 'prometheus' } + p._config.selectorLabels,
+      selector: p._config.selectorLabels,
       sessionAffinity: 'ClientIP',
     },
   },

--- a/manifests/alertmanager-service.yaml
+++ b/manifests/alertmanager-service.yaml
@@ -19,7 +19,6 @@ spec:
     targetPort: reloader-web
   selector:
     alertmanager: main
-    app: alertmanager
     app.kubernetes.io/component: alert-router
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus

--- a/manifests/prometheus-service.yaml
+++ b/manifests/prometheus-service.yaml
@@ -18,7 +18,6 @@ spec:
     port: 8080
     targetPort: reloader-web
   selector:
-    app: prometheus
     app.kubernetes.io/component: prometheus
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Prometheus-operator has [deprecated the "app" selector in favor of "app.kubernetes.io/name"](https://github.com/prometheus-operator/prometheus-operator/blob/master/CHANGELOG.md#0480--2021-05-19). This pull request replaces the "app" selector with "app.kubernetes.io/name" when applicable.



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Remove "app" label selector deprecated by Prometheus-operator.
```
