### PR TITLE
Parallelize e2e tests

### DIFF
--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -60,235 +60,267 @@ func testMain(m *testing.M) int {
 	return m.Run()
 }
 
-func TestQueryPrometheus(t *testing.T) {
-	queries := []struct {
-		query   string
-		expectN int
+func TestSuite(t *testing.T) {
+	type testFunc func(t *testing.T)
+
+	testCases := []struct {
+		name string
+		test testFunc
 	}{
 		{
-			query:   `up{job="node-exporter"} == 1`,
-			expectN: 1,
+			name: "TestQueryPrometheus",
+			test: func(t *testing.T) {
+				// TestQueryPrometheus is not run in parallel with the rest since
+				// we want to ensure we have metrics before running other tests.
+				queries := []struct {
+					query   string
+					expectN int
+				}{
+					{
+						query:   `up{job="node-exporter"} == 1`,
+						expectN: 1,
+					}, {
+						// 	query:   `up{job="kubelet"} == 1`,
+						// 	expectN: 1,
+						// }, {
+						query:   `up{job="apiserver"} == 1`,
+						expectN: 1,
+					}, {
+						query:   `up{job="kube-state-metrics"} == 1`,
+						expectN: 1,
+					}, {
+						query:   `up{job="prometheus-k8s"} == 1`,
+						expectN: 1,
+					}, {
+						query:   `up{job="prometheus-operator"} == 1`,
+						expectN: 1,
+					}, {
+						query:   `up{job="alertmanager-main"} == 1`,
+						expectN: 2,
+					},
+				}
+
+				// Wait for pod to respond at queries at all. Then start verifying their results.
+				err := wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
+					_, err := promClient.query("up")
+					return err == nil, nil
+				})
+				if err != nil {
+					t.Fatal(errors.Wrap(err, "wait for prometheus-k8s"))
+				}
+
+				err = wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
+					defer t.Log("---------------------------\n")
+
+					for _, q := range queries {
+
+						n, err := promClient.query(q.query)
+						if err != nil {
+							return false, err
+						}
+						if n < q.expectN {
+							// Don't return an error as targets may only become visible after a while.
+							t.Logf("expected at least %d results for %q but got %d", q.expectN, q.query, n)
+							return false, nil
+						}
+						t.Logf("query %q succeeded", q.query)
+					}
+					return true, nil
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
 		}, {
-			// 	query:   `up{job="kubelet"} == 1`,
-			// 	expectN: 1,
-			// }, {
-			query:   `up{job="apiserver"} == 1`,
-			expectN: 1,
+			name: "TestDroppedMetrics",
+			test: func(t *testing.T) {
+				t.Parallel()
+				// query metadata for all metrics and their metadata
+				md, err := promClient.metadata("{job=~\".+\"}")
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, k := range md {
+					// check if the metric' help text contains Deprecated
+					if strings.Contains(k.Help, "Deprecated") {
+						// query prometheus for the Deprecated metric
+						n, err := promClient.query(k.Metric)
+						if err != nil {
+							t.Fatal(err)
+						}
+						if n > 0 {
+							t.Fatalf("deprecated metric with name: %s and help text: %s exists.", k.Metric, k.Help)
+						}
+					}
+				}
+			},
 		}, {
-			query:   `up{job="kube-state-metrics"} == 1`,
-			expectN: 1,
+			name: "TestTargetScheme",
+			test: func(t *testing.T) {
+				t.Parallel()
+				// query targets for all endpoints
+				tgs, err := promClient.targets()
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// exclude jobs from checking for http endpoints
+				// TODO(paulfantom): This should be reduced as we secure connections for those components
+				exclude := map[string]bool{
+					"alertmanager-main": true,
+					"prometheus-k8s":    true,
+					"kube-dns":          true,
+					"grafana":           true,
+				}
+
+				for _, k := range tgs.Active {
+					job := k.Labels["job"]
+					if k.DiscoveredLabels["__scheme__"] == "http" && !exclude[string(job)] {
+						t.Fatalf("target exposing metrics over HTTP instead of HTTPS: %+v", k)
+					}
+				}
+			},
 		}, {
-			query:   `up{job="prometheus-k8s"} == 1`,
-			expectN: 1,
+			name: "TestFailedRuleEvaluations",
+			test: func(t *testing.T) {
+				// TestFailedRuleEvaluations detects recording and alerting rules that may
+				// trigger "many-to-many" evaluation errors when multiple kube-state-metrics
+				// instances are running.
+				t.Parallel()
+
+				// Scale kube-state-metrics to 2 replicas.
+				kClient := promClient.kubeClient
+
+				scale, err := kClient.AppsV1().Deployments("monitoring").GetScale(context.Background(), "kube-state-metrics", metav1.GetOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				scale.Spec.Replicas = 2
+				scale, err = kClient.AppsV1().Deployments("monitoring").UpdateScale(context.Background(), "kube-state-metrics", scale, metav1.UpdateOptions{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Rollback to 1 replica at the end of the test.
+				defer func() {
+					scale, err := kClient.AppsV1().Deployments("monitoring").GetScale(context.Background(), "kube-state-metrics", metav1.GetOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					scale.Spec.Replicas = 1
+					_, err = kClient.AppsV1().Deployments("monitoring").UpdateScale(context.Background(), "kube-state-metrics", scale, metav1.UpdateOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+				}()
+
+				// Wait for the 2 replicas of kube-state-metrics to be successfully scraped.
+				err = wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
+					n, err := promClient.query(`up{job="kube-state-metrics"} == 1`)
+					if err != nil {
+						return false, err
+					}
+
+					if n != 2 {
+						t.Logf("expecting 2 kube-state-metrics targets, got %d", n)
+						return false, nil
+					}
+
+					return true, nil
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Wait for all rule groups to be evaluated at least once without error.
+				now := time.Now()
+				err = wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
+					rsp, err := promClient.apiRequest("/api/v1/rules", "type", "")
+					if err != nil {
+						return false, err
+					}
+
+					res, err := gabs.ParseJSON(rsp.Data)
+					if err != nil {
+						return false, err
+					}
+
+					groups, err := res.Path("groups").Children()
+					if err != nil {
+						return false, err
+					}
+
+					if len(groups) == 0 {
+						return false, errors.New("got 0 rule groups")
+					}
+
+					for _, group := range groups {
+						groupName := group.Path("name").Data().(string)
+						if err != nil {
+							return false, err
+						}
+
+						lastEvalString := group.Path("lastEvaluation").Data().(string)
+						lastEval, err := time.Parse(time.RFC3339Nano, lastEvalString)
+						if err != nil {
+							return false, err
+						}
+
+						if lastEval.Before(now) {
+							t.Logf("%s not yet evaluated", groupName)
+							return false, nil
+						}
+
+						rules, err := group.Path("rules").Children()
+						if err != nil {
+							return false, err
+						}
+
+						if len(rules) == 0 {
+							return false, errors.Errorf("got 0 rules in group %s", groupName)
+						}
+
+						for _, rule := range rules {
+							health := rule.Path("health").Data().(string)
+							if health != "ok" {
+								return false, errors.Errorf("error evaluating rule: %v", rule)
+							}
+						}
+					}
+
+					return true, nil
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+			},
 		}, {
-			query:   `up{job="prometheus-operator"} == 1`,
-			expectN: 1,
-		}, {
-			query:   `up{job="alertmanager-main"} == 1`,
-			expectN: 2,
+			name: "TestGrafana",
+			test: func(t *testing.T) {
+				t.Parallel()
+				kClient := promClient.kubeClient
+
+				err := wait.Poll(15*time.Second, 5*time.Minute, func() (bool, error) {
+					grafanaDeployment, err := kClient.AppsV1().Deployments("monitoring").Get(context.Background(), "grafana", metav1.GetOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+					return grafanaDeployment.Status.ReadyReplicas == *grafanaDeployment.Spec.Replicas, nil
+				})
+				if err != nil {
+					t.Fatal(errors.Wrap(err, "Timeout while waiting for deployment ready condition."))
+				}
+			},
 		},
 	}
 
-	// Wait for pod to respond at queries at all. Then start verifying their results.
-	err := wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
-		_, err := promClient.query("up")
-		return err == nil, nil
-	})
-	if err != nil {
-		t.Fatal(errors.Wrap(err, "wait for prometheus-k8s"))
-	}
-
-	err = wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
-		defer t.Log("---------------------------\n")
-
-		for _, q := range queries {
-			n, err := promClient.query(q.query)
-			if err != nil {
-				return false, err
-			}
-			if n < q.expectN {
-				// Don't return an error as targets may only become visible after a while.
-				t.Logf("expected at least %d results for %q but got %d", q.expectN, q.query, n)
-				return false, nil
-			}
-			t.Logf("query %q succeeded", q.query)
-		}
-		return true, nil
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestDroppedMetrics(t *testing.T) {
-	// query metadata for all metrics and their metadata
-	md, err := promClient.metadata("{job=~\".+\"}")
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, k := range md {
-		// check if the metric' help text contains Deprecated
-		if strings.Contains(k.Help, "Deprecated") {
-			// query prometheus for the Deprecated metric
-			n, err := promClient.query(k.Metric)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if n > 0 {
-				t.Fatalf("deprecated metric with name: %s and help text: %s exists.", k.Metric, k.Help)
-			}
-		}
-	}
-}
-
-func TestTargetsScheme(t *testing.T) {
-	// query targets for all endpoints
-	tgs, err := promClient.targets()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// exclude jobs from checking for http endpoints
-	// TODO(paulfantom): This should be reduced as we secure connections for those components
-	exclude := map[string]bool{
-		"alertmanager-main": true,
-		"prometheus-k8s":    true,
-		"kube-dns":          true,
-		"grafana":           true,
-	}
-
-	for _, k := range tgs.Active {
-		job := k.Labels["job"]
-		if k.DiscoveredLabels["__scheme__"] == "http" && !exclude[string(job)] {
-			t.Fatalf("target exposing metrics over HTTP instead of HTTPS: %+v", k)
-		}
-	}
-}
-
-// TestFailedRuleEvaluations detects recording and alerting rules that may
-// trigger "many-to-many" evaluation errors when multiple kube-state-metrics
-// instances are running.
-func TestFailedRuleEvaluations(t *testing.T) {
-	// Scale kube-state-metrics to 2 replicas.
-	kClient := promClient.kubeClient
-
-	scale, err := kClient.AppsV1().Deployments("monitoring").GetScale(context.Background(), "kube-state-metrics", metav1.GetOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	scale.Spec.Replicas = 2
-	scale, err = kClient.AppsV1().Deployments("monitoring").UpdateScale(context.Background(), "kube-state-metrics", scale, metav1.UpdateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Rollback to 1 replica at the end of the test.
-	defer func() {
-		scale, err := kClient.AppsV1().Deployments("monitoring").GetScale(context.Background(), "kube-state-metrics", metav1.GetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		scale.Spec.Replicas = 1
-		_, err = kClient.AppsV1().Deployments("monitoring").UpdateScale(context.Background(), "kube-state-metrics", scale, metav1.UpdateOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	// Wait for the 2 replicas of kube-state-metrics to be successfully scraped.
-	err = wait.Poll(5*time.Second, 1*time.Minute, func() (bool, error) {
-		n, err := promClient.query(`up{job="kube-state-metrics"} == 1`)
-		if err != nil {
-			return false, err
-		}
-
-		if n != 2 {
-			t.Logf("expecting 2 kube-state-metrics targets, got %d", n)
-			return false, nil
-		}
-
-		return true, nil
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Wait for all rule groups to be evaluated at least once without error.
-	now := time.Now()
-	err = wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
-		rsp, err := promClient.apiRequest("/api/v1/rules", "type", "")
-		if err != nil {
-			return false, err
-		}
-
-		res, err := gabs.ParseJSON(rsp.Data)
-		if err != nil {
-			return false, err
-		}
-
-		groups, err := res.Path("groups").Children()
-		if err != nil {
-			return false, err
-		}
-
-		if len(groups) == 0 {
-			return false, errors.New("got 0 rule groups")
-		}
-
-		for _, group := range groups {
-			groupName := group.Path("name").Data().(string)
-			if err != nil {
-				return false, err
-			}
-
-			lastEvalString := group.Path("lastEvaluation").Data().(string)
-			lastEval, err := time.Parse(time.RFC3339Nano, lastEvalString)
-			if err != nil {
-				return false, err
-			}
-
-			if lastEval.Before(now) {
-				t.Logf("%s not yet evaluated", groupName)
-				return false, nil
-			}
-
-			rules, err := group.Path("rules").Children()
-			if err != nil {
-				return false, err
-			}
-
-			if len(rules) == 0 {
-				return false, errors.Errorf("got 0 rules in group %s", groupName)
-			}
-
-			for _, rule := range rules {
-				health := rule.Path("health").Data().(string)
-				if health != "ok" {
-					return false, errors.Errorf("error evaluating rule: %v", rule)
-				}
-			}
-		}
-
-		return true, nil
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestGrafana(t *testing.T){
-	kClient := promClient.kubeClient
-	
-	err := wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
-		grafanaDeployment, err := kClient.AppsV1().Deployments("monitoring").Get(context.Background(), "grafana", metav1.GetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		return grafanaDeployment.Status.ReadyReplicas == *grafanaDeployment.Spec.Replicas, nil
-	})
-	if err != nil {
-		t.Fatal(errors.Wrap(err, "Timeout while waiting for deployment ready condition."))
+	for _, tc := range testCases {
+		// Table-driven + parallel tests are quite tricky and require us
+		// to re-capture the range variable.
+		// Also read: https://eleni.blog/2019/05/11/parallel-test-execution-in-go/
+		tc := tc
+		t.Run(tc.name, tc.test)
 	}
 }


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description
Fixes #1419 

This PR is parallelizing all our e2e tests, except for `TestQueryPrometheus` which runs before all others. I did not parallelize `TestQueryPrometheus` because we need to make sure Prometheus has scraped the stack's components before running the remaining tests.

We do decrease test duration but, unfortunately, not that much since it still heavily depends on how lucky we are during `TestFailedRuleEvaluations`. On the other hand, I think this PR sets up a good testing structure that we could use when adding more e2e tests in the future that can run in parallel.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
