### PR TITLE
replace deprecated "app" label selector with "app.kubernetes.io/name" in documents and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ local kp = (import 'kube-prometheus/main.libsonnet') + {
         ],
         selector: {
           matchLabels: {
-            app: 'myapp',
+            'app.kubernetes.io/name': 'myapp',
           },
         },
       },

--- a/examples/additional-namespaces-servicemonitor.jsonnet
+++ b/examples/additional-namespaces-servicemonitor.jsonnet
@@ -24,7 +24,7 @@ local kp = (import 'kube-prometheus/main.libsonnet') + {
         ],
         selector: {
           matchLabels: {
-            app: 'myapp',
+            'app.kubernetes.io/name': 'myapp',
           },
         },
       },

--- a/examples/basic-auth/service-monitor.yaml
+++ b/examples/basic-auth/service-monitor.yaml
@@ -19,4 +19,4 @@ spec:
     - logging
   selector:
     matchLabels:
-      app: myapp
+      app.kubernetes.io/name: myapp

--- a/examples/example-app/example-app.yaml
+++ b/examples/example-app/example-app.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: default
 spec:
   selector:
-    app: example-app
+    app.kubernetes.io/name: example-app
   ports:
   - name: web
     protocol: TCP
@@ -22,17 +22,17 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: example-app
+      app.kubernetes.io/name: example-app
       version: 1.1.3
   replicas: 4
   template:
     metadata:
       labels:
-        app: example-app
+        app.kubernetes.io/name: example-app
         version: 1.1.3
     spec:
       containers:
-      - name: example-app 
+      - name: example-app
         image: quay.io/fabxc/prometheus_demo_service
         ports:
         - name: web

--- a/jsonnet/kube-prometheus/addons/ksm-autoscaler.libsonnet
+++ b/jsonnet/kube-prometheus/addons/ksm-autoscaler.libsonnet
@@ -81,7 +81,7 @@
     },
 
     deployment:
-      local podLabels = { app: 'ksm-autoscaler' };
+      local podLabels = { 'app.kubernetes.io/name': 'ksm-autoscaler' };
       local c = {
         name: 'ksm-autoscaler',
         image: $.values.clusterVerticalAutoscaler.image,


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This PR replaces the deprecated "app" label selector with "app.kubernetes.io/name" in documents and examples.



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
