### PR TITLE
addon: prometheus-adapter addon to enable audit logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ local kp =
   // (import 'kube-prometheus/addons/static-etcd.libsonnet') +
   // (import 'kube-prometheus/addons/custom-metrics.libsonnet') +
   // (import 'kube-prometheus/addons/external-metrics.libsonnet') +
+  // (import 'kube-prometheus/addons/prometheus-adapter-audit.libsonnet') +
   {
     values+:: {
       common+: {

--- a/docs/developing-prometheus-rules-and-grafana-dashboards.md
+++ b/docs/developing-prometheus-rules-and-grafana-dashboards.md
@@ -31,6 +31,7 @@ local kp =
   // (import 'kube-prometheus/addons/static-etcd.libsonnet') +
   // (import 'kube-prometheus/addons/custom-metrics.libsonnet') +
   // (import 'kube-prometheus/addons/external-metrics.libsonnet') +
+  // (import 'kube-prometheus/addons/prometheus-adapter-audit.libsonnet') +
   {
     values+:: {
       common+: {

--- a/example.jsonnet
+++ b/example.jsonnet
@@ -7,6 +7,7 @@ local kp =
   // (import 'kube-prometheus/addons/static-etcd.libsonnet') +
   // (import 'kube-prometheus/addons/custom-metrics.libsonnet') +
   // (import 'kube-prometheus/addons/external-metrics.libsonnet') +
+  // (import 'kube-prometheus/addons/prometheus-adapter-audit.libsonnet') +
   {
     values+:: {
       common+: {

--- a/examples/prometheus-adapter-audit-example.jsonnet
+++ b/examples/prometheus-adapter-audit-example.jsonnet
@@ -1,0 +1,13 @@
+local kp = (import 'kube-prometheus/main.libsonnet') +
+           (import 'kube-prometheus/addons/prometheus-adapter-audit.libsonnet') + {
+  values+:: {
+    common+: {
+      namespace: 'monitoring',
+    },
+    pa+: {
+      auditProfile: 'request',
+    },
+  },
+};
+
+{ ['prometheus-adapter-' + name]: kp.prometheusAdapter[name] for name in std.objectFields(kp.prometheusAdapter) }

--- a/jsonnet/kube-prometheus/addons/prometheus-adapter-audit.libsonnet
+++ b/jsonnet/kube-prometheus/addons/prometheus-adapter-audit.libsonnet
@@ -1,0 +1,90 @@
+{
+  values+:: {
+    pa+: {
+      profilesCM: 'prometheus-adapter-audit-profiles',
+      auditProfile: 'metadata',
+      auditLogPath: '/var/log/adapter',
+      auditProfilesDir: '/etc/audit',
+      auditVolume: 'audit-log',
+      auditLogMaxSize: '100',
+    },
+  },
+  profile(level):: {
+    apiVersion: 'audit.k8s.io/v1',
+    kind: 'Policy',
+    metadata: {
+      name: level,
+    },
+    // omit stage RequestReceived to avoid duplication of logs for both stages
+    // RequestReceived and ResponseComplete
+    omitStages: ['RequestReceived'],
+    rules: [{ level: level }],
+  },
+
+  enableAudit(c):: c {
+    local profileFile = '%s/%s-profile.yaml' % [
+      $.values.pa.auditProfilesDir,
+      $.values.pa.auditProfile,
+    ],
+
+    args+: [
+      '--audit-profile-file=%s' % profileFile,
+      '--audit-log-path=%s' % $.values.pa.auditLogPath,
+      '--audit-log-maxsize=%s' % $.values.pa.auditLogMaxSize,
+    ],
+    volumeMounts+: [{
+      mountPath: $.values.pa.auditProfilesDir,
+      name: $.values.pa.profilesCM,
+      readOnly: true,
+    }, {
+      mountPath: $.values.pa.auditLogPath,
+      name: $.values.pa.auditVolume,
+      readOnly: false,
+    }],
+
+  },
+  prometheusAdapter+: {
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers:
+              std.map(
+                function(c)
+                  if c.name == 'prometheus-adapter' then
+                    $.enableAudit(c)
+                  else
+                    c,
+                super.containers,
+              ),
+
+            volumes+: [{
+              name: $.values.pa.auditVolume,
+              emptyDir: {},
+            }, {
+              name: $.values.pa.profilesCM,
+              configMap: {
+                name: $.values.pa.profilesCM,
+              },
+            }],
+          },  // spec
+        },  // template
+      },  // spec
+    },  // deployment
+
+    configmapAuditProfiles: {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: {
+        name: $.values.pa.profilesCM,
+        namespace: $.values.common.namespace,
+      },
+      data: {
+        // TODO(sthaha): use quote_keys=false when version > 0.17 is released
+        // generate <level>-profile.yaml for all log levels
+        [std.asciiLower(x) + '-profile.yaml']: std.manifestYamlDoc($.profile(x))
+        for x in ['None', 'Metadata', 'Request', 'RequestResponse']
+      },
+    },
+  },  // pa
+}


### PR DESCRIPTION

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This addon configures Prometheus Adapter to turn on audit logs. Enabling
audit log requires passing in a Policy file to the adapater. The addon
adds a list policies that match K8S Policy log-level such as
- None
- Metadata
- RequestResponse
- Request

See: https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy

The adapter will be configured to log at a Metadata level by default
which can be configured by setting values.pa.auditProfile
See examples/prometheus-adapter-audit-example.jsonnet




## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
New addon for Prometheus Adapater to configure audit logs. 
```
