### PR TITLE
.github/workflows: automated commits should come from @prom-op-bot account

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,0 +1,2 @@
+  golang-version=1.16
+  kind-version=v0.11.1

--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -70,6 +70,8 @@ jobs:
 
           ```
         team-reviewers: kube-prometheus-reviewers
+        commiter: Prometheus Operator Bot <prom-op-bot@users.noreply.github.com>
+        author: Prometheus Operator Bot <prom-op-bot@users.noreply.github.com>
         branch: automated-updates-${{ matrix.branch }}
         delete-branch: true
         # GITHUB_TOKEN cannot be used as it won't trigger CI in a created PR


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Follow-up to https://github.com/prometheus-operator/kube-prometheus/pull/1430#issuecomment-939770687

I have no idea why {{ github.actor }} is set to `dgrissonet`, but specifying values directly as in this PR should solve the issue.

cc @dgrisonnet 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
