### PR TITLE
jsonnet: do not hide prometheus object

### DIFF
--- a/jsonnet/kube-prometheus/addons/all-namespaces.libsonnet
+++ b/jsonnet/kube-prometheus/addons/all-namespaces.libsonnet
@@ -1,5 +1,5 @@
 {
-  prometheus+:: {
+  prometheus+: {
     clusterRole+: {
       rules+: [
         {


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Applying this addon hides whole `prometheus` object which is not expected.

Fixing my issue from https://github.com/thaum-xyz/ankhmorpork/blob/07cb2ae364c25c9c042db25bc097df74fcd67639/apps/monitoring/jsonnet/main.jsonnet#L195-L196

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Do not hide `prometheus` object in all-namespaces addon
```
