### PR TITLE
Fix prometheus URL in prometheus-adapter

### DIFF
--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -98,7 +98,7 @@ local utils = import './lib/utils.libsonnet';
       namespace: $.values.common.namespace,
       version: $.values.common.versions.prometheusAdapter,
       image: $.values.common.images.prometheusAdapter,
-      prometheusURL: 'http://prometheus-' + $.values.prometheus.name + '.' + $.values.common.namespace + '.svc.cluster.local:9090/',
+      prometheusURL: 'http://prometheus-' + $.values.prometheus.name + '.' + $.values.prometheus.namespace + '.svc:9090/',
       rangeIntervals+: {
         kubelet: utils.rangeInterval($.kubernetesControlPlane.serviceMonitorKubelet.spec.endpoints[0].interval),
         nodeExporter: utils.rangeInterval($.nodeExporter.serviceMonitor.spec.endpoints[0].interval),

--- a/manifests/prometheus-adapter-deployment.yaml
+++ b/manifests/prometheus-adapter-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - --config=/etc/adapter/config.yaml
         - --logtostderr=true
         - --metrics-relist-interval=1m
-        - --prometheus-url=http://prometheus-k8s.monitoring.svc.cluster.local:9090/
+        - --prometheus-url=http://prometheus-k8s.monitoring.svc:9090/
         - --secure-port=6443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
         image: k8s.gcr.io/prometheus-adapter/prometheus-adapter:v0.9.1


### PR DESCRIPTION
## Description

If the kube-prometheus stack on a cluster with a cluster domain that is different than the default `.cluster.local`,
prometheus adapter fails to connect to the prometheus server with the following error:
```
E1025 04:54:59.638367       1 provider.go:163] unable to fetch metrics for pods in namespace "istio-system", skipping: unable to fetch node CPU metrics: unable to execute query: Get "http://prometheus-k8s.monitoring.svc.cluster.local:9090/api/v1/query?query=sum+by+%28pod%2Ccontainer%29+%28%0A++irate+%28%0A++++++container_cpu_usage_seconds_total%7Bnamespace%3D%22istio-system%22%2Cpod%3D%22istio-ingressgateway-78d9c46fcb-zv5bs%22%2Ccontainer%21%3D%22%22%2Cpod%21%3D%22%22%7D%5B120s%5D%0A++%29%0A%29%0A&time=1635137699.631": dial tcp: lookup prometheus-k8s.monitoring.svc.cluster.local on 169.254.25.10:53: no such host
```
This would also fail if prometheus was deployed in a different namespace than the namespace specified in `$.values.common.namespace`

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Fix prometheus URL in prometheus-adapter.
```
