### PR TITLE
jsonnet: add networkpolicies for components accessed by prometheus

### DIFF
--- a/examples/networkpolicies-disabled.jsonnet
+++ b/examples/networkpolicies-disabled.jsonnet
@@ -1,0 +1,25 @@
+local kp = (import 'kube-prometheus/main.libsonnet') +
+           (import 'kube-prometheus/addons/networkpolicies-disabled.libsonnet') + {
+  values+:: {
+    common+: {
+      namespace: 'monitoring',
+    },
+  },
+};
+
+{
+  ['setup/' + resource]: kp[component][resource]
+  for component in std.objectFields(kp)
+  for resource in std.filter(
+    function(resource)
+      kp[component][resource].kind == 'CustomResourceDefinition' || kp[component][resource].kind == 'Namespace', std.objectFields(kp[component])
+  )
+} +
+{
+  [component + '-' + resource]: kp[component][resource]
+  for component in std.objectFields(kp)
+  for resource in std.filter(
+    function(resource)
+      kp[component][resource].kind != 'CustomResourceDefinition' && kp[component][resource].kind != 'Namespace', std.objectFields(kp[component])
+  )
+}

--- a/jsonnet/kube-prometheus/addons/networkpolicies-disabled.libsonnet
+++ b/jsonnet/kube-prometheus/addons/networkpolicies-disabled.libsonnet
@@ -1,0 +1,20 @@
+// Disables creation of NetworkPolicies
+
+{
+  blackboxExporter+: {
+    networkPolicies:: {},
+  },
+
+  kubeStateMetrics+: {
+    networkPolicies:: {},
+  },
+
+  nodeExporter+: {
+    networkPolicies:: {},
+  },
+
+  prometheusAdapter+: {
+    networkPolicies:: {},
+  },
+
+}

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -238,6 +238,30 @@ function(params) {
       },
     },
 
+  networkPolicy: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'NetworkPolicy',
+    metadata: bb.service.metadata,
+    spec: {
+      podSelector: {
+        matchLabels: bb._config.selectorLabels,
+      },
+      ingress: [{
+        from: [{
+          podSelector: {
+            matchLabels: {
+              'app.kubernetes.io/name': 'prometheus',
+            },
+          },
+        }],
+        ports: std.map(function(o) {
+          port: o.port,
+          protocol: 'TCP',
+        }, bb.service.spec.ports),
+      }],
+    },
+  },
+
   service: {
     apiVersion: 'v1',
     kind: 'Service',

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -246,6 +246,8 @@ function(params) {
       podSelector: {
         matchLabels: bb._config.selectorLabels,
       },
+      policyTypes: ['Egress', 'Ingress'],
+      egress: [{}],
       ingress: [{
         from: [{
           podSelector: {

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -118,6 +118,30 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
     image: ksm._config.kubeRbacProxyImage,
   }),
 
+  networkPolicy: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'NetworkPolicy',
+    metadata: ksm.service.metadata,
+    spec: {
+      podSelector: {
+        matchLabels: ksm._config.selectorLabels,
+      },
+      ingress: [{
+        from: [{
+          podSelector: {
+            matchLabels: {
+              'app.kubernetes.io/name': 'prometheus',
+            },
+          },
+        }],
+        ports: std.map(function(o) {
+          port: o.port,
+          protocol: 'TCP',
+        }, ksm.service.spec.ports),
+      }],
+    },
+  },
+
   deployment+: {
     spec+: {
       template+: {

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -126,6 +126,8 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
       podSelector: {
         matchLabels: ksm._config.selectorLabels,
       },
+      policyTypes: ['Egress', 'Ingress'],
+      egress: [{}],
       ingress: [{
         from: [{
           podSelector: {

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -159,6 +159,30 @@ function(params) {
     },
   },
 
+  networkPolicy: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'NetworkPolicy',
+    metadata: ne.service.metadata,
+    spec: {
+      podSelector: {
+        matchLabels: ne._config.selectorLabels,
+      },
+      ingress: [{
+        from: [{
+          podSelector: {
+            matchLabels: {
+              'app.kubernetes.io/name': 'prometheus',
+            },
+          },
+        }],
+        ports: std.map(function(o) {
+          port: o.port,
+          protocol: 'TCP',
+        }, ne.service.spec.ports),
+      }],
+    },
+  },
+
   daemonset:
     local nodeExporter = {
       name: ne._config.name,

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -167,6 +167,8 @@ function(params) {
       podSelector: {
         matchLabels: ne._config.selectorLabels,
       },
+      policyTypes: ['Egress', 'Ingress'],
+      egress: [{}],
       ingress: [{
         from: [{
           podSelector: {

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -206,6 +206,30 @@ function(params) {
     },
   },
 
+  networkPolicy: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'NetworkPolicy',
+    metadata: pa.service.metadata,
+    spec: {
+      podSelector: {
+        matchLabels: pa._config.selectorLabels,
+      },
+      ingress: [{
+        from: [{
+          podSelector: {
+            matchLabels: {
+              'app.kubernetes.io/name': 'prometheus',
+            },
+          },
+        }],
+        ports: std.map(function(o) {
+          port: o.port,
+          protocol: 'TCP',
+        }, pa.service.spec.ports),
+      }],
+    },
+  },
+
   deployment:
     local c = {
       name: pa._config.name,

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -214,6 +214,8 @@ function(params) {
       podSelector: {
         matchLabels: pa._config.selectorLabels,
       },
+      policyTypes: ['Egress', 'Ingress'],
+      egress: [{}],
       ingress: [{
         from: [{
           podSelector: {

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - ./manifests/blackboxExporter-clusterRoleBinding.yaml
 - ./manifests/blackboxExporter-configuration.yaml
 - ./manifests/blackboxExporter-deployment.yaml
+- ./manifests/blackboxExporter-networkPolicy.yaml
 - ./manifests/blackboxExporter-service.yaml
 - ./manifests/blackboxExporter-serviceAccount.yaml
 - ./manifests/blackboxExporter-serviceMonitor.yaml
@@ -27,6 +28,7 @@ resources:
 - ./manifests/kubeStateMetrics-clusterRole.yaml
 - ./manifests/kubeStateMetrics-clusterRoleBinding.yaml
 - ./manifests/kubeStateMetrics-deployment.yaml
+- ./manifests/kubeStateMetrics-networkPolicy.yaml
 - ./manifests/kubeStateMetrics-prometheusRule.yaml
 - ./manifests/kubeStateMetrics-service.yaml
 - ./manifests/kubeStateMetrics-serviceAccount.yaml
@@ -40,6 +42,7 @@ resources:
 - ./manifests/nodeExporter-clusterRole.yaml
 - ./manifests/nodeExporter-clusterRoleBinding.yaml
 - ./manifests/nodeExporter-daemonset.yaml
+- ./manifests/nodeExporter-networkPolicy.yaml
 - ./manifests/nodeExporter-prometheusRule.yaml
 - ./manifests/nodeExporter-service.yaml
 - ./manifests/nodeExporter-serviceAccount.yaml
@@ -64,6 +67,7 @@ resources:
 - ./manifests/prometheusAdapter-clusterRoleServerResources.yaml
 - ./manifests/prometheusAdapter-configMap.yaml
 - ./manifests/prometheusAdapter-deployment.yaml
+- ./manifests/prometheusAdapter-networkPolicy.yaml
 - ./manifests/prometheusAdapter-podDisruptionBudget.yaml
 - ./manifests/prometheusAdapter-roleBindingAuthReader.yaml
 - ./manifests/prometheusAdapter-service.yaml

--- a/manifests/blackboxExporter-networkPolicy.yaml
+++ b/manifests/blackboxExporter-networkPolicy.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: blackbox-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.19.0
+  name: blackbox-exporter
+  namespace: monitoring
+spec:
+  egress:
+  - {}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 9115
+      protocol: TCP
+    - port: 19115
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: blackbox-exporter
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Egress
+  - Ingress

--- a/manifests/kubeStateMetrics-networkPolicy.yaml
+++ b/manifests/kubeStateMetrics-networkPolicy.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.2.4
+  name: kube-state-metrics
+  namespace: monitoring
+spec:
+  egress:
+  - {}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 8443
+      protocol: TCP
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Egress
+  - Ingress

--- a/manifests/nodeExporter-networkPolicy.yaml
+++ b/manifests/nodeExporter-networkPolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 1.3.0
+  name: node-exporter
+  namespace: monitoring
+spec:
+  egress:
+  - {}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 9100
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: node-exporter
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Egress
+  - Ingress

--- a/manifests/prometheusAdapter-networkPolicy.yaml
+++ b/manifests/prometheusAdapter-networkPolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.9.1
+  name: prometheus-adapter
+  namespace: monitoring
+spec:
+  egress:
+  - {}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: metrics-adapter
+      app.kubernetes.io/name: prometheus-adapter
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Egress
+  - Ingress


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Adding NetworkPolicies for components that should be accessed only by Prometheus.

**WARNING**: This is untested as I don't have a cluster with CNI supporting NetworkPolicies. I would be grateful if anyone could test it, especially blackbox-exporter one.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add NetworkPolicy for metrics exporters
```
