### PR TITLE
jsonnet: unify metadata management

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -137,9 +137,9 @@ function(params) {
         { name: 'web', targetPort: 'web', port: 9093 },
         { name: 'reloader-web', port: am._config.reloaderPort, targetPort: 'reloader-web' },
       ],
-      selector: {
+      selector: am._config.selectorLabels {
         alertmanager: am._config.name,
-      } + am._config.selectorLabels,
+      },
       sessionAffinity: 'ClientIP',
     },
   },
@@ -150,9 +150,9 @@ function(params) {
     metadata: am._metadata,
     spec: {
       selector: {
-        matchLabels: {
+        matchLabels: am._config.selectorLabels {
           alertmanager: am._config.name,
-        } + am._config.selectorLabels,
+        },
       },
       endpoints: [
         { port: 'web', interval: '30s' },
@@ -168,9 +168,9 @@ function(params) {
     spec: {
       maxUnavailable: 1,
       selector: {
-        matchLabels: {
+        matchLabels: am._config.selectorLabels {
           alertmanager: am._config.name,
-        } + am._config.selectorLabels,
+        },
       },
     },
   },
@@ -189,11 +189,11 @@ function(params) {
       version: am._config.version,
       image: am._config.image,
       podMetadata: {
-        labels: am._metadata.labels,
+        labels: am.alertmanager.metadata.labels,
       },
       resources: am._config.resources,
       nodeSelector: { 'kubernetes.io/os': 'linux' },
-      serviceAccountName: am._metadata.name,
+      serviceAccountName: am.serviceAccount.metadata.name,
       securityContext: {
         runAsUser: 1000,
         runAsNonRoot: true,

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -92,14 +92,17 @@ function(params) {
   _config:: defaults + params,
   // Safety check
   assert std.isObject(bb._config.resources),
+  _metadata:: {
+    name: 'blackbox-exporter',
+    namespace: bb._config.namespace,
+    labels: bb._config.commonLabels,
+  },
 
   configuration: {
     apiVersion: 'v1',
     kind: 'ConfigMap',
-    metadata: {
+    metadata: bb._metadata {
       name: 'blackbox-exporter-configuration',
-      namespace: bb._config.namespace,
-      labels: bb._config.commonLabels,
     },
     data: {
       'config.yml': std.manifestYamlDoc({ modules: bb._config.modules }),
@@ -109,10 +112,7 @@ function(params) {
   serviceAccount: {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
-    metadata: {
-      name: 'blackbox-exporter',
-      namespace: bb._config.namespace,
-    },
+    metadata: bb._metadata,
   },
 
   clusterRole: {
@@ -138,9 +138,7 @@ function(params) {
   clusterRoleBinding: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
-    metadata: {
-      name: 'blackbox-exporter',
-    },
+    metadata: bb._metadata,
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
       kind: 'ClusterRole',
@@ -212,11 +210,7 @@ function(params) {
     {
       apiVersion: 'apps/v1',
       kind: 'Deployment',
-      metadata: {
-        name: 'blackbox-exporter',
-        namespace: bb._config.namespace,
-        labels: bb._config.commonLabels,
-      },
+      metadata: bb._metadata,
       spec: {
         replicas: bb._config.replicas,
         selector: { matchLabels: bb._config.selectorLabels },
@@ -243,11 +237,7 @@ function(params) {
   service: {
     apiVersion: 'v1',
     kind: 'Service',
-    metadata: {
-      name: 'blackbox-exporter',
-      namespace: bb._config.namespace,
-      labels: bb._config.commonLabels,
-    },
+    metadata: bb._metadata,
     spec: {
       ports: [{
         name: 'https',
@@ -262,29 +252,24 @@ function(params) {
     },
   },
 
-  serviceMonitor:
-    {
-      apiVersion: 'monitoring.coreos.com/v1',
-      kind: 'ServiceMonitor',
-      metadata: {
-        name: 'blackbox-exporter',
-        namespace: bb._config.namespace,
-        labels: bb._config.commonLabels,
-      },
-      spec: {
-        endpoints: [{
-          bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
-          interval: '30s',
-          path: '/metrics',
-          port: 'https',
-          scheme: 'https',
-          tlsConfig: {
-            insecureSkipVerify: true,
-          },
-        }],
-        selector: {
-          matchLabels: bb._config.selectorLabels,
+  serviceMonitor: {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'ServiceMonitor',
+    metadata: bb._metadata,
+    spec: {
+      endpoints: [{
+        bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+        interval: '30s',
+        path: '/metrics',
+        port: 'https',
+        scheme: 'https',
+        tlsConfig: {
+          insecureSkipVerify: true,
         },
+      }],
+      selector: {
+        matchLabels: bb._config.selectorLabels,
       },
     },
+  },
 }

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -214,7 +214,7 @@ function(params) {
       spec: {
         replicas: bb._config.replicas,
         selector: {
-          matchLabels: bb._config.selectorLabels
+          matchLabels: bb._config.selectorLabels,
         },
         template: {
           metadata: {

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -213,7 +213,9 @@ function(params) {
       metadata: bb._metadata,
       spec: {
         replicas: bb._config.replicas,
-        selector: { matchLabels: bb._config.selectorLabels },
+        selector: {
+          matchLabels: bb._config.selectorLabels
+        },
         template: {
           metadata: {
             labels: bb._config.commonLabels,

--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -32,15 +32,16 @@ function(params)
   kubernetesGrafana(config) {
     local g = self,
     _config+:: config,
+    _metadata:: {
+      name: 'grafana',
+      namespace: g._config.namespace,
+      labels: g._config.commonLabels,
+    },
 
     serviceMonitor: {
       apiVersion: 'monitoring.coreos.com/v1',
       kind: 'ServiceMonitor',
-      metadata: {
-        name: 'grafana',
-        namespace: g._config.namespace,
-        labels: g._config.commonLabels,
-      },
+      metadata: g._metadata,
       spec: {
         selector: {
           matchLabels: {

--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -28,6 +28,10 @@ local defaults = {
 function(params) {
   local k8s = self,
   _config:: defaults + params,
+  _metadata:: {
+    labels: k8s._config.commonLabels,
+    namespace: k8s._config.namespace,
+  },
 
   mixin:: (import 'github.com/kubernetes-monitoring/kubernetes-mixin/mixin.libsonnet') {
     _config+:: k8s._config.mixin._config,
@@ -36,10 +40,9 @@ function(params) {
   prometheusRule: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'PrometheusRule',
-    metadata: {
-      labels: k8s._config.commonLabels + k8s._config.mixin.ruleLabels,
+    metadata: k8s._metadata {
       name: 'kubernetes-monitoring-rules',
-      namespace: k8s._config.namespace,
+      labels+: k8s._config.mixin.ruleLabels,
     },
     spec: {
       local r = if std.objectHasAll(k8s.mixin, 'prometheusRules') then k8s.mixin.prometheusRules.groups else {},
@@ -51,10 +54,9 @@ function(params) {
   serviceMonitorKubeScheduler: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'ServiceMonitor',
-    metadata: {
+    metadata: k8s._metadata {
       name: 'kube-scheduler',
-      namespace: k8s._config.namespace,
-      labels: { 'app.kubernetes.io/name': 'kube-scheduler' },
+      labels+: { 'app.kubernetes.io/name': 'kube-scheduler' },
     },
     spec: {
       jobLabel: 'app.kubernetes.io/name',
@@ -77,10 +79,9 @@ function(params) {
   serviceMonitorKubelet: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'ServiceMonitor',
-    metadata: {
+    metadata: k8s._metadata {
       name: 'kubelet',
-      namespace: k8s._config.namespace,
-      labels: { 'app.kubernetes.io/name': 'kubelet' },
+      labels+: { 'app.kubernetes.io/name': 'kubelet' },
     },
     spec: {
       jobLabel: 'app.kubernetes.io/name',
@@ -172,10 +173,9 @@ function(params) {
   serviceMonitorKubeControllerManager: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'ServiceMonitor',
-    metadata: {
+    metadata: k8s._metadata {
       name: 'kube-controller-manager',
-      namespace: k8s._config.namespace,
-      labels: { 'app.kubernetes.io/name': 'kube-controller-manager' },
+      labels+: { 'app.kubernetes.io/name': 'kube-controller-manager' },
     },
     spec: {
       jobLabel: 'app.kubernetes.io/name',
@@ -207,10 +207,9 @@ function(params) {
   serviceMonitorApiserver: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'ServiceMonitor',
-    metadata: {
+    metadata: k8s._metadata {
       name: 'kube-apiserver',
-      namespace: k8s._config.namespace,
-      labels: { 'app.kubernetes.io/name': 'apiserver' },
+      labels+: { 'app.kubernetes.io/name': 'apiserver' },
     },
     spec: {
       jobLabel: 'component',
@@ -261,12 +260,9 @@ function(params) {
   [if (defaults + params).kubeProxy then 'podMonitorKubeProxy']: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'PodMonitor',
-    metadata: {
-      labels: {
-        'k8s-app': 'kube-proxy',
-      },
+    metadata: k8s._metadata {
+      labels+: { 'k8s-app': 'kube-proxy' },
       name: 'kube-proxy',
-      namespace: k8s._config.namespace,
     },
     spec: {
       jobLabel: 'k8s-app',
@@ -300,10 +296,9 @@ function(params) {
   serviceMonitorCoreDNS: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'ServiceMonitor',
-    metadata: {
+    metadata: k8s._metadata {
       name: 'coredns',
-      namespace: k8s._config.namespace,
-      labels: { 'app.kubernetes.io/name': 'coredns' },
+      labels+: { 'app.kubernetes.io/name': 'coredns' },
     },
     spec: {
       jobLabel: 'app.kubernetes.io/name',

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -144,7 +144,7 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
       spec: {
         jobLabel: 'app.kubernetes.io/name',
         selector: {
-          matchLabels: ksm._config.selectorLabels
+          matchLabels: ksm._config.selectorLabels,
         },
         endpoints: [
           {

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -54,6 +54,12 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
   commonLabels:: ksm._config.commonLabels,
   podLabels:: ksm._config.selectorLabels,
 
+  _metadata:: {
+    labels: ksm._config.commonLabels,
+    name: ksm._config.name,
+    namespace: ksm._config.namespace,
+  },
+
   mixin:: (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-state-metrics-mixin/mixin.libsonnet') +
           (import 'github.com/kubernetes-monitoring/kubernetes-mixin/lib/add-runbook-links.libsonnet') {
             _config+:: ksm._config.mixin._config,
@@ -62,10 +68,9 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
   prometheusRule: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'PrometheusRule',
-    metadata: {
-      labels: ksm._config.commonLabels + ksm._config.mixin.ruleLabels,
+    metadata: ksm._metadata {
+      labels+: ksm._config.mixin.ruleLabels,
       name: ksm._config.name + '-rules',
-      namespace: ksm._config.namespace,
     },
     spec: {
       local r = if std.objectHasAll(ksm.mixin, 'prometheusRules') then ksm.mixin.prometheusRules.groups else [],
@@ -135,11 +140,7 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
     {
       apiVersion: 'monitoring.coreos.com/v1',
       kind: 'ServiceMonitor',
-      metadata: {
-        name: ksm.name,
-        namespace: ksm._config.namespace,
-        labels: ksm._config.commonLabels,
-      },
+      metadata: ksm._metadata,
       spec: {
         jobLabel: 'app.kubernetes.io/name',
         selector: { matchLabels: ksm._config.selectorLabels },

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -143,7 +143,9 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
       metadata: ksm._metadata,
       spec: {
         jobLabel: 'app.kubernetes.io/name',
-        selector: { matchLabels: ksm._config.selectorLabels },
+        selector: {
+          matchLabels: ksm._config.selectorLabels
+        },
         endpoints: [
           {
             port: 'https-main',

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -210,7 +210,7 @@ function(params) {
       metadata: ne._metadata,
       spec: {
         selector: {
-          matchLabels: ne._config.selectorLabels
+          matchLabels: ne._config.selectorLabels,
         },
         updateStrategy: {
           type: 'RollingUpdate',

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -209,7 +209,9 @@ function(params) {
       kind: 'DaemonSet',
       metadata: ne._metadata,
       spec: {
-        selector: { matchLabels: ne._config.selectorLabels },
+        selector: {
+          matchLabels: ne._config.selectorLabels
+        },
         updateStrategy: {
           type: 'RollingUpdate',
           rollingUpdate: { maxUnavailable: '10%' },

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -233,7 +233,7 @@ function(params) {
       spec: {
         replicas: pa._config.replicas,
         selector: {
-          matchLabels: pa._config.selectorLabels
+          matchLabels: pa._config.selectorLabels,
         },
         strategy: {
           rollingUpdate: {

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -120,6 +120,12 @@ function(params) {
   // Safety check
   assert std.isObject(pa._config.resources),
 
+  _metadata:: {
+    name: pa._config.name,
+    namespace: pa._config.namespace,
+    labels: pa._config.commonLabels,
+  },
+
   apiService: {
     apiVersion: 'apiregistration.k8s.io/v1',
     kind: 'APIService',
@@ -143,10 +149,8 @@ function(params) {
   configMap: {
     apiVersion: 'v1',
     kind: 'ConfigMap',
-    metadata: {
+    metadata: pa._metadata {
       name: 'adapter-config',
-      namespace: pa._config.namespace,
-      labels: pa._config.commonLabels,
     },
     data: { 'config.yaml': std.manifestYamlDoc(pa._config.config) },
   },
@@ -154,11 +158,7 @@ function(params) {
   serviceMonitor: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'ServiceMonitor',
-    metadata: {
-      name: pa._config.name,
-      namespace: pa._config.namespace,
-      labels: pa._config.commonLabels,
-    },
+    metadata: pa._metadata,
     spec: {
       selector: {
         matchLabels: pa._config.selectorLabels,
@@ -195,11 +195,7 @@ function(params) {
   service: {
     apiVersion: 'v1',
     kind: 'Service',
-    metadata: {
-      name: pa._config.name,
-      namespace: pa._config.namespace,
-      labels: pa._config.commonLabels,
-    },
+    metadata: pa._metadata,
     spec: {
       ports: [
         { name: 'https', targetPort: 6443, port: 443 },
@@ -233,11 +229,7 @@ function(params) {
     {
       apiVersion: 'apps/v1',
       kind: 'Deployment',
-      metadata: {
-        name: pa._config.name,
-        namespace: pa._config.namespace,
-        labels: pa._config.commonLabels,
-      },
+      metadata: pa._metadata,
       spec: {
         replicas: pa._config.replicas,
         selector: { matchLabels: pa._config.selectorLabels },
@@ -266,20 +258,13 @@ function(params) {
   serviceAccount: {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
-    metadata: {
-      name: pa._config.name,
-      namespace: pa._config.namespace,
-      labels: pa._config.commonLabels,
-    },
+    metadata: pa._metadata,
   },
 
   clusterRole: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
-    metadata: {
-      name: pa._config.name,
-      labels: pa._config.commonLabels,
-    },
+    metadata: pa._metadata,
     rules: [{
       apiGroups: [''],
       resources: ['nodes', 'namespaces', 'pods', 'services'],
@@ -290,10 +275,7 @@ function(params) {
   clusterRoleBinding: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
-    metadata: {
-      name: pa._config.name,
-      labels: pa._config.commonLabels,
-    },
+    metadata: pa._metadata,
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
       kind: 'ClusterRole',
@@ -309,9 +291,8 @@ function(params) {
   clusterRoleBindingDelegator: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
-    metadata: {
+    metadata: pa._metadata {
       name: 'resource-metrics:system:auth-delegator',
-      labels: pa._config.commonLabels,
     },
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
@@ -328,9 +309,8 @@ function(params) {
   clusterRoleServerResources: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
-    metadata: {
+    metadata: pa._metadata {
       name: 'resource-metrics-server-resources',
-      labels: pa._config.commonLabels,
     },
     rules: [{
       apiGroups: ['metrics.k8s.io'],
@@ -342,13 +322,13 @@ function(params) {
   clusterRoleAggregatedMetricsReader: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
-    metadata: {
+    metadata: pa._metadata {
       name: 'system:aggregated-metrics-reader',
-      labels: {
+      labels+: {
         'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
         'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
         'rbac.authorization.k8s.io/aggregate-to-view': 'true',
-      } + pa._config.commonLabels,
+      },
     },
     rules: [{
       apiGroups: ['metrics.k8s.io'],
@@ -360,10 +340,9 @@ function(params) {
   roleBindingAuthReader: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'RoleBinding',
-    metadata: {
+    metadata: pa._metadata {
       name: 'resource-metrics-auth-reader',
       namespace: 'kube-system',
-      labels: pa._config.commonLabels,
     },
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
@@ -380,11 +359,7 @@ function(params) {
   [if (defaults + params).replicas > 1 then 'podDisruptionBudget']: {
     apiVersion: 'policy/v1',
     kind: 'PodDisruptionBudget',
-    metadata: {
-      name: pa._config.name,
-      namespace: pa._config.namespace,
-      labels: pa._config.commonLabels,
-    },
+    metadata: pa._metadata,
     spec: {
       minAvailable: 1,
       selector: {

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -232,7 +232,9 @@ function(params) {
       metadata: pa._metadata,
       spec: {
         replicas: pa._config.replicas,
-        selector: { matchLabels: pa._config.selectorLabels },
+        selector: {
+          matchLabels: pa._config.selectorLabels
+        },
         strategy: {
           rollingUpdate: {
             maxSurge: 1,

--- a/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
@@ -45,6 +45,11 @@ function(params)
     local po = self,
     // declare variable as a field to allow overriding options and to have unified API across all components
     _config:: config,
+    _metadata:: {
+      labels: po._config.commonLabels,
+      name: po._config.name,
+      namespace: po._config.namespace,
+    },
     mixin:: (import 'github.com/prometheus-operator/prometheus-operator/jsonnet/mixin/mixin.libsonnet') +
             (import 'github.com/kubernetes-monitoring/kubernetes-mixin/lib/add-runbook-links.libsonnet') {
               _config+:: po._config.mixin._config,

--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -120,11 +120,11 @@ function(params) {
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',
         kind: 'Role',
-        name: 'prometheus-' + p._config.name,
+        name: p._metadata.name,
       },
       subjects: [{
         kind: 'ServiceAccount',
-        name: 'prometheus-' + p._config.name,
+        name: p.serviceAccount.metadata.name,
         namespace: p._config.namespace,
       }],
     };
@@ -236,9 +236,9 @@ function(params) {
     spec: {
       minAvailable: 1,
       selector: {
-        matchLabels: {
+        matchLabels: p._config.selectorLabels {
           prometheus: p._config.name,
-        } + p._config.selectorLabels,
+        },
       },
     },
   },
@@ -255,11 +255,11 @@ function(params) {
       version: p._config.version,
       image: p._config.image,
       podMetadata: {
-        labels: p._metadata.labels,
+        labels: p.prometheus.metadata.labels,
       },
       externalLabels: p._config.externalLabels,
       enableFeatures: p._config.enableFeatures,
-      serviceAccountName: p._metadata.name,
+      serviceAccountName: p.serviceAccount.metadata.name,
       podMonitorSelector: {},
       podMonitorNamespaceSelector: {},
       probeSelector: {},

--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -45,6 +45,11 @@ function(params) {
   // Safety check
   assert std.isObject(p._config.resources),
   assert std.isObject(p._config.mixin._config),
+  _metadata:: {
+    name: 'prometheus-' + p._config.name,
+    namespace: p._config.namespace,
+    labels: p._config.commonLabels,
+  },
 
   mixin::
     (import 'github.com/prometheus/prometheus/documentation/prometheus-mixin/mixin.libsonnet') +
@@ -67,10 +72,9 @@ function(params) {
   prometheusRule: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'PrometheusRule',
-    metadata: {
-      labels: p._config.commonLabels + p._config.mixin.ruleLabels,
-      name: 'prometheus-' + p._config.name + '-prometheus-rules',
-      namespace: p._config.namespace,
+    metadata: p._metadata {
+      labels+: p._config.mixin.ruleLabels,
+      name: p._metadata.name + '-prometheus-rules',
     },
     spec: {
       local r = if std.objectHasAll(p.mixin, 'prometheusRules') then p.mixin.prometheusRules.groups else [],
@@ -82,20 +86,14 @@ function(params) {
   serviceAccount: {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
-    metadata: {
-      name: 'prometheus-' + p._config.name,
-      namespace: p._config.namespace,
-      labels: p._config.commonLabels,
-    },
+    metadata: p._metadata,
   },
 
   service: {
     apiVersion: 'v1',
     kind: 'Service',
-    metadata: {
-      name: 'prometheus-' + p._config.name,
-      namespace: p._config.namespace,
-      labels: { prometheus: p._config.name } + p._config.commonLabels,
+    metadata: p._metadata {
+      labels+: { prometheus: p._config.name },
     },
     spec: {
       ports: [
@@ -116,10 +114,8 @@ function(params) {
     local newSpecificRoleBinding(namespace) = {
       apiVersion: 'rbac.authorization.k8s.io/v1',
       kind: 'RoleBinding',
-      metadata: {
-        name: 'prometheus-' + p._config.name,
+      metadata: p._metadata {
         namespace: namespace,
-        labels: p._config.commonLabels,
       },
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',
@@ -141,10 +137,7 @@ function(params) {
   clusterRole: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
-    metadata: {
-      name: 'prometheus-' + p._config.name,
-      labels: p._config.commonLabels,
-    },
+    metadata: p._metadata,
     rules: [
       {
         apiGroups: [''],
@@ -161,10 +154,8 @@ function(params) {
   roleConfig: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'Role',
-    metadata: {
-      name: 'prometheus-' + p._config.name + '-config',
-      namespace: p._config.namespace,
-      labels: p._config.commonLabels,
+    metadata: p._metadata {
+      name: p._metadata.name + '-config',
     },
     rules: [{
       apiGroups: [''],
@@ -176,19 +167,17 @@ function(params) {
   roleBindingConfig: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'RoleBinding',
-    metadata: {
-      name: 'prometheus-' + p._config.name + '-config',
-      namespace: p._config.namespace,
-      labels: p._config.commonLabels,
+    metadata: p._metadata {
+      name: p._metadata.name + '-config',
     },
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
       kind: 'Role',
-      name: 'prometheus-' + p._config.name + '-config',
+      name: p._metadata.name + '-config',
     },
     subjects: [{
       kind: 'ServiceAccount',
-      name: 'prometheus-' + p._config.name,
+      name: p._metadata.name,
       namespace: p._config.namespace,
     }],
   },
@@ -196,18 +185,15 @@ function(params) {
   clusterRoleBinding: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
-    metadata: {
-      name: 'prometheus-' + p._config.name,
-      labels: p._config.commonLabels,
-    },
+    metadata: p._metadata,
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
       kind: 'ClusterRole',
-      name: 'prometheus-' + p._config.name,
+      name: p._metadata.name,
     },
     subjects: [{
       kind: 'ServiceAccount',
-      name: 'prometheus-' + p._config.name,
+      name: p._metadata.name,
       namespace: p._config.namespace,
     }],
   },
@@ -216,10 +202,8 @@ function(params) {
     local newSpecificRole(namespace) = {
       apiVersion: 'rbac.authorization.k8s.io/v1',
       kind: 'Role',
-      metadata: {
-        name: 'prometheus-' + p._config.name,
+      metadata: p._metadata {
         namespace: namespace,
-        labels: p._config.commonLabels,
       },
       rules: [
         {
@@ -248,11 +232,7 @@ function(params) {
   [if (defaults + params).replicas > 1 then 'podDisruptionBudget']: {
     apiVersion: 'policy/v1',
     kind: 'PodDisruptionBudget',
-    metadata: {
-      name: 'prometheus-' + p._config.name,
-      namespace: p._config.namespace,
-      labels: p._config.commonLabels,
-    },
+    metadata: p._metadata,
     spec: {
       minAvailable: 1,
       selector: {
@@ -266,21 +246,20 @@ function(params) {
   prometheus: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'Prometheus',
-    metadata: {
+    metadata: p._metadata {
       name: p._config.name,
-      namespace: p._config.namespace,
-      labels: { prometheus: p._config.name } + p._config.commonLabels,
+      labels+: { prometheus: p._config.name },
     },
     spec: {
       replicas: p._config.replicas,
       version: p._config.version,
       image: p._config.image,
       podMetadata: {
-        labels: p._config.commonLabels,
+        labels: p._metadata.labels,
       },
       externalLabels: p._config.externalLabels,
       enableFeatures: p._config.enableFeatures,
-      serviceAccountName: 'prometheus-' + p._config.name,
+      serviceAccountName: p._metadata.name,
       podMonitorSelector: {},
       podMonitorNamespaceSelector: {},
       probeSelector: {},
@@ -311,11 +290,7 @@ function(params) {
   serviceMonitor: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'ServiceMonitor',
-    metadata: {
-      name: 'prometheus-' + p._config.name,
-      namespace: p._config.namespace,
-      labels: p._config.commonLabels,
-    },
+    metadata: p._metadata,
     spec: {
       selector: {
         matchLabels: p._config.selectorLabels,
@@ -331,10 +306,9 @@ function(params) {
   [if std.objectHas(params, 'thanos') && params.thanos != null then 'prometheusRuleThanosSidecar']: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'PrometheusRule',
-    metadata: {
-      labels: p._config.commonLabels + p._config.mixin.ruleLabels,
-      name: 'prometheus-' + p._config.name + '-thanos-sidecar-rules',
-      namespace: p._config.namespace,
+    metadata: p._metadata {
+      labels+: p._config.mixin.ruleLabels,
+      name: p._metadata.name + '-thanos-sidecar-rules',
     },
     spec: {
       local r = if std.objectHasAll(p.mixinThanos, 'prometheusRules') then p.mixinThanos.prometheusRules.groups else [],
@@ -347,10 +321,9 @@ function(params) {
   [if std.objectHas(params, 'thanos') && params.thanos != null then 'serviceThanosSidecar']: {
     apiVersion: 'v1',
     kind: 'Service',
-    metadata+: {
-      name: 'prometheus-' + p._config.name + '-thanos-sidecar',
-      namespace: p._config.namespace,
-      labels+: p._config.commonLabels {
+    metadata+: p._metadata {
+      name: p._metadata.name + '-thanos-sidecar',
+      labels+: {
         prometheus: p._config.name,
         'app.kubernetes.io/component': 'thanos-sidecar',
       },
@@ -372,10 +345,9 @@ function(params) {
   [if std.objectHas(params, 'thanos') && params.thanos != null then 'serviceMonitorThanosSidecar']: {
     apiVersion: 'monitoring.coreos.com/v1',
     kind: 'ServiceMonitor',
-    metadata+: {
+    metadata+: p._metadata {
       name: 'thanos-sidecar',
-      namespace: p._config.namespace,
-      labels: p._config.commonLabels {
+      labels+: {
         prometheus: p._config.name,
         'app.kubernetes.io/component': 'thanos-sidecar',
       },

--- a/manifests/alertmanager-alertmanager.yaml
+++ b/manifests/alertmanager-alertmanager.yaml
@@ -15,6 +15,7 @@ spec:
     kubernetes.io/os: linux
   podMetadata:
     labels:
+      alertmanager: main
       app.kubernetes.io/component: alert-router
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: kube-prometheus

--- a/manifests/alertmanager-serviceMonitor.yaml
+++ b/manifests/alertmanager-serviceMonitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
-  name: alertmanager
+  name: alertmanager-main
   namespace: monitoring
 spec:
   endpoints:

--- a/manifests/blackbox-exporter-clusterRoleBinding.yaml
+++ b/manifests/blackbox-exporter-clusterRoleBinding.yaml
@@ -1,7 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: blackbox-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
+  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/blackbox-exporter-serviceAccount.yaml
+++ b/manifests/blackbox-exporter-serviceAccount.yaml
@@ -1,5 +1,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: blackbox-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.19.0
   name: blackbox-exporter
   namespace: monitoring

--- a/manifests/kubernetes-serviceMonitorApiserver.yaml
+++ b/manifests/kubernetes-serviceMonitorApiserver.yaml
@@ -3,6 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: apiserver
+    app.kubernetes.io/part-of: kube-prometheus
   name: kube-apiserver
   namespace: monitoring
 spec:

--- a/manifests/kubernetes-serviceMonitorCoreDNS.yaml
+++ b/manifests/kubernetes-serviceMonitorCoreDNS.yaml
@@ -3,6 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: coredns
+    app.kubernetes.io/part-of: kube-prometheus
   name: coredns
   namespace: monitoring
 spec:

--- a/manifests/kubernetes-serviceMonitorKubeControllerManager.yaml
+++ b/manifests/kubernetes-serviceMonitorKubeControllerManager.yaml
@@ -3,6 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: kube-controller-manager
+    app.kubernetes.io/part-of: kube-prometheus
   name: kube-controller-manager
   namespace: monitoring
 spec:

--- a/manifests/kubernetes-serviceMonitorKubeScheduler.yaml
+++ b/manifests/kubernetes-serviceMonitorKubeScheduler.yaml
@@ -3,6 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: kube-scheduler
+    app.kubernetes.io/part-of: kube-prometheus
   name: kube-scheduler
   namespace: monitoring
 spec:

--- a/manifests/kubernetes-serviceMonitorKubelet.yaml
+++ b/manifests/kubernetes-serviceMonitorKubelet.yaml
@@ -3,6 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/name: kubelet
+    app.kubernetes.io/part-of: kube-prometheus
   name: kubelet
   namespace: monitoring
 spec:

--- a/manifests/node-exporter-clusterRole.yaml
+++ b/manifests/node-exporter-clusterRole.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.2.2
   name: node-exporter
+  namespace: monitoring
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/manifests/node-exporter-clusterRoleBinding.yaml
+++ b/manifests/node-exporter-clusterRoleBinding.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.2.2
   name: node-exporter
+  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/prometheus-adapter-clusterRole.yaml
+++ b/manifests/prometheus-adapter-clusterRole.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheus-adapter
+  namespace: monitoring
 rules:
 - apiGroups:
   - ""

--- a/manifests/prometheus-adapter-clusterRoleAggregatedMetricsReader.yaml
+++ b/manifests/prometheus-adapter-clusterRoleAggregatedMetricsReader.yaml
@@ -10,6 +10,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: system:aggregated-metrics-reader
+  namespace: monitoring
 rules:
 - apiGroups:
   - metrics.k8s.io

--- a/manifests/prometheus-adapter-clusterRoleBinding.yaml
+++ b/manifests/prometheus-adapter-clusterRoleBinding.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: prometheus-adapter
+  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/prometheus-adapter-clusterRoleBindingDelegator.yaml
+++ b/manifests/prometheus-adapter-clusterRoleBindingDelegator.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: resource-metrics:system:auth-delegator
+  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/prometheus-adapter-clusterRoleServerResources.yaml
+++ b/manifests/prometheus-adapter-clusterRoleServerResources.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.9.1
   name: resource-metrics-server-resources
+  namespace: monitoring
 rules:
 - apiGroups:
   - metrics.k8s.io

--- a/manifests/prometheus-clusterRole.yaml
+++ b/manifests/prometheus-clusterRole.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.30.3
   name: prometheus-k8s
+  namespace: monitoring
 rules:
 - apiGroups:
   - ""

--- a/manifests/prometheus-clusterRoleBinding.yaml
+++ b/manifests/prometheus-clusterRoleBinding.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.30.3
   name: prometheus-k8s
+  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/prometheus-prometheus.yaml
+++ b/manifests/prometheus-prometheus.yaml
@@ -27,6 +27,7 @@ spec:
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 2.30.3
+      prometheus: k8s
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
   probeNamespaceSelector: {}


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

To simplify code and reduce duplication this PR introduces hidden field `_metadata` which is then used to set metadata for all objects in a component.

This PR also cleans jsonnet codebase to first assign objects as value and then add data to that value. This way object won't be overriding explicit settings. Example: https://github.com/prometheus-operator/kube-prometheus/pull/1471/files#diff-9ada6ed45123a448cead005447e28c3d11af80858521ef7d85a7e0ea57e168daR153-R155

I am also starting to establish relations between objects in this PR as can be seen in `serviceAccountName` fields. This should further reduce code duplication and allow a better understanding of the codebase.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Make metadata consistent across objects in the same component
```
