### PR TITLE
examples: add example usage of prometheus-agent

### DIFF
--- a/docs/customizations/prometheus-agent.md
+++ b/docs/customizations/prometheus-agent.md
@@ -9,9 +9,6 @@ local kp =
     values+:: {
       common+: {
         namespace: 'monitoring',
-        versions+: {
-          prometheus: '2.32.0-beta.0',
-        },
       },
       prometheus+: {
         resources: {

--- a/examples/prometheus-agent.jsonnet
+++ b/examples/prometheus-agent.jsonnet
@@ -4,9 +4,6 @@ local kp =
     values+:: {
       common+: {
         namespace: 'monitoring',
-        versions+: {
-          prometheus: '2.32.0-beta.0',
-        },
       },
       prometheus+: {
         resources: {

--- a/examples/prometheus-agent.jsonnet
+++ b/examples/prometheus-agent.jsonnet
@@ -1,0 +1,41 @@
+local kp =
+  (import 'kube-prometheus/main.libsonnet') +
+  {
+    values+:: {
+      common+: {
+        namespace: 'monitoring',
+      },
+      prometheus+: {
+        version: '2.32.0',
+        resources: {
+          requests: { memory: '100Mi' },
+        },
+        enableFeatures: ['agent']
+      },
+    },
+    prometheus+: {
+      prometheus+: {
+        alerting:: {},
+        remoteWrite: {
+	  // Remote-write config
+        },
+      },
+    },
+  };
+
+{ 'setup/0namespace-namespace': kp.kubePrometheus.namespace } +
+{
+  ['setup/prometheus-operator-' + name]: kp.prometheusOperator[name]
+  for name in std.filter((function(name) name != 'serviceMonitor' && name != 'prometheusRule'), std.objectFields(kp.prometheusOperator))
+} +
+// serviceMonitor and prometheusRule are separated so that they can be created after the CRDs are ready
+{ 'prometheus-operator-serviceMonitor': kp.prometheusOperator.serviceMonitor } +
+{ 'prometheus-operator-prometheusRule': kp.prometheusOperator.prometheusRule } +
+{ 'kube-prometheus-prometheusRule': kp.kubePrometheus.prometheusRule } +
+{ ['blackbox-exporter-' + name]: kp.blackboxExporter[name] for name in std.objectFields(kp.blackboxExporter) } +
+{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) } +
+{ ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
+{ ['kubernetes-' + name]: kp.kubernetesControlPlane[name] for name in std.objectFields(kp.kubernetesControlPlane) }
+{ ['node-exporter-' + name]: kp.nodeExporter[name] for name in std.objectFields(kp.nodeExporter) } +
+{ ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
+{ ['prometheus-adapter-' + name]: kp.prometheusAdapter[name] for name in std.objectFields(kp.prometheusAdapter) }


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

PoC for running prometheus-agent with kube-prometheus.

**NOTE**: I do not have time to finalize this, so I welcome everyone wants to step up and finish this PR.

What needs to be improved:
- remote write configuration should be a first class config included in https://github.com/prometheus-operator/kube-prometheus/blob/main/jsonnet/kube-prometheus/components/prometheus.libsonnet#L1-L39
- alertmanagerName shouldn't be a required field. Lack of the field should remove `alerting` config section from `prometheus` object.
- 



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
example of running prometheus-agent with kube-prometheus
```
