### PR TITLE
jsonnet: establish convention for components default fields

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -1,6 +1,8 @@
 local defaults = {
   local defaults = self,
-  namespace: error 'must provide namespace',
+  // Convention: Top-level fields related to CRDs are public, other fields are hidden
+  // If there is no CRD for the component, everything is hidden in defaults.
+  namespace:: error 'must provide namespace',
   image: error 'must provide image',
   version: error 'must provide version',
   resources: {
@@ -18,9 +20,9 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if !std.setMember(labelName, ['app.kubernetes.io/version'])
   },
-  name: error 'must provide name',
-  reloaderPort: 8080,
-  config: {
+  name:: error 'must provide name',
+  reloaderPort:: 8080,
+  config:: {
     global: {
       resolve_timeout: '5m',
     },
@@ -59,7 +61,7 @@ local defaults = {
     ],
   },
   replicas: 3,
-  mixin: {
+  mixin:: {
     ruleLabels: {},
     _config: {
       alertmanagerName: '{{ $labels.namespace }}/{{ $labels.pod}}',

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -2,10 +2,12 @@ local krp = import './kube-rbac-proxy.libsonnet';
 
 local defaults = {
   local defaults = self,
-  namespace: error 'must provide namespace',
-  version: error 'must provide version',
-  image: error 'must provide version',
-  resources: {
+  // Convention: Top-level fields related to CRDs are public, other fields are hidden
+  // If there is no CRD for the component, everything is hidden in defaults.
+  namespace:: error 'must provide namespace',
+  version:: error 'must provide version',
+  image:: error 'must provide version',
+  resources:: {
     requests: { cpu: '10m', memory: '20Mi' },
     limits: { cpu: '20m', memory: '40Mi' },
   },
@@ -20,13 +22,13 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if !std.setMember(labelName, ['app.kubernetes.io/version'])
   },
-  configmapReloaderImage: error 'must provide version',
-  kubeRbacProxyImage: error 'must provide kubeRbacProxyImage',
+  configmapReloaderImage:: error 'must provide version',
+  kubeRbacProxyImage:: error 'must provide kubeRbacProxyImage',
 
-  port: 9115,
-  internalPort: 19115,
-  replicas: 1,
-  modules: {
+  port:: 9115,
+  internalPort:: 19115,
+  replicas:: 1,
+  modules:: {
     http_2xx: {
       prober: 'http',
       http: {
@@ -81,7 +83,7 @@ local defaults = {
       },
     },
   },
-  privileged:
+  privileged::
     local icmpModules = [self.modules[m] for m in std.objectFields(self.modules) if self.modules[m].prober == 'icmp'];
     std.length(icmpModules) > 0,
 };

--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -2,11 +2,13 @@ local kubernetesGrafana = import 'github.com/brancz/kubernetes-grafana/grafana/g
 
 local defaults = {
   local defaults = self,
-  name: 'grafana',
-  namespace: error 'must provide namespace',
-  version: error 'must provide version',
-  image: error 'must provide image',
-  resources: {
+  // Convention: Top-level fields related to CRDs are public, other fields are hidden
+  // If there is no CRD for the component, everything is hidden in defaults.
+  name:: 'grafana',
+  namespace:: error 'must provide namespace',
+  version:: error 'must provide version',
+  image:: error 'must provide image',
+  resources:: {
     requests: { cpu: '100m', memory: '100Mi' },
     limits: { cpu: '200m', memory: '200Mi' },
   },
@@ -21,7 +23,7 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if !std.setMember(labelName, ['app.kubernetes.io/version'])
   },
-  prometheusName: error 'must provide prometheus name',
+  prometheusName:: error 'must provide prometheus name',
 };
 
 function(params)

--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -1,12 +1,14 @@
 local relabelings = import '../addons/dropping-deprecated-metrics-relabelings.libsonnet';
 
 local defaults = {
-  namespace: error 'must provide namespace',
+  // Convention: Top-level fields related to CRDs are public, other fields are hidden
+  // If there is no CRD for the component, everything is hidden in defaults.
+  namespace:: error 'must provide namespace',
   commonLabels:: {
     'app.kubernetes.io/name': 'kube-prometheus',
     'app.kubernetes.io/part-of': 'kube-prometheus',
   },
-  mixin: {
+  mixin:: {
     ruleLabels: {},
     _config: {
       cadvisorSelector: 'job="kubelet", metrics_path="/metrics/cadvisor"',
@@ -22,7 +24,7 @@ local defaults = {
       hostNetworkInterfaceSelector: 'device!~"veth.+"',
     },
   },
-  kubeProxy: false,
+  kubeProxy:: false,
 };
 
 function(params) {

--- a/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet
@@ -1,14 +1,16 @@
 local defaults = {
-  namespace: error 'must provide namespace',
-  image: error 'must provide image',
-  ports: error 'must provide ports',
-  secureListenAddress: error 'must provide secureListenAddress',
-  upstream: error 'must provide upstream',
-  resources: {
+  // Convention: Top-level fields related to CRDs are public, other fields are hidden
+  // If there is no CRD for the component, everything is hidden in defaults.
+  namespace:: error 'must provide namespace',
+  image:: error 'must provide image',
+  ports:: error 'must provide ports',
+  secureListenAddress:: error 'must provide secureListenAddress',
+  upstream:: error 'must provide upstream',
+  resources:: {
     requests: { cpu: '10m', memory: '20Mi' },
     limits: { cpu: '20m', memory: '40Mi' },
   },
-  tlsCipherSuites: [
+  tlsCipherSuites:: [
     'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256',  // required by h2: http://golang.org/cl/30721
     'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256',  // required by h2: http://golang.org/cl/30721
 

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -2,24 +2,26 @@ local krp = import './kube-rbac-proxy.libsonnet';
 
 local defaults = {
   local defaults = self,
-  name: 'kube-state-metrics',
-  namespace: error 'must provide namespace',
-  version: error 'must provide version',
-  image: error 'must provide version',
-  kubeRbacProxyImage: error 'must provide kubeRbacProxyImage',
-  resources: {
+  // Convention: Top-level fields related to CRDs are public, other fields are hidden
+  // If there is no CRD for the component, everything is hidden in defaults.
+  name:: 'kube-state-metrics',
+  namespace:: error 'must provide namespace',
+  version:: error 'must provide version',
+  image:: error 'must provide version',
+  kubeRbacProxyImage:: error 'must provide kubeRbacProxyImage',
+  resources:: {
     requests: { cpu: '10m', memory: '190Mi' },
     limits: { cpu: '100m', memory: '250Mi' },
   },
 
-  kubeRbacProxyMain: {
+  kubeRbacProxyMain:: {
     resources+: {
       limits+: { cpu: '40m' },
       requests+: { cpu: '20m' },
     },
   },
-  scrapeInterval: '30s',
-  scrapeTimeout: '30s',
+  scrapeInterval:: '30s',
+  scrapeTimeout:: '30s',
   commonLabels:: {
     'app.kubernetes.io/name': defaults.name,
     'app.kubernetes.io/version': defaults.version,
@@ -31,7 +33,7 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if !std.setMember(labelName, ['app.kubernetes.io/version'])
   },
-  mixin: {
+  mixin:: {
     ruleLabels: {},
     _config: {
       kubeStateMetricsSelector: 'job="' + defaults.name + '"',

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -2,18 +2,20 @@ local krp = import './kube-rbac-proxy.libsonnet';
 
 local defaults = {
   local defaults = self,
-  name: 'node-exporter',
-  namespace: error 'must provide namespace',
-  version: error 'must provide version',
-  image: error 'must provide version',
-  kubeRbacProxyImage: error 'must provide kubeRbacProxyImage',
-  resources: {
+  // Convention: Top-level fields related to CRDs are public, other fields are hidden
+  // If there is no CRD for the component, everything is hidden in defaults.
+  name:: 'node-exporter',
+  namespace:: error 'must provide namespace',
+  version:: error 'must provide version',
+  image:: error 'must provide version',
+  kubeRbacProxyImage:: error 'must provide kubeRbacProxyImage',
+  resources:: {
     requests: { cpu: '102m', memory: '180Mi' },
     limits: { cpu: '250m', memory: '180Mi' },
   },
-  listenAddress: '127.0.0.1',
-  filesystemMountPointsExclude: '^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)',
-  port: 9100,
+  listenAddress:: '127.0.0.1',
+  filesystemMountPointsExclude:: '^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)',
+  port:: 9100,
   commonLabels:: {
     'app.kubernetes.io/name': defaults.name,
     'app.kubernetes.io/version': defaults.version,
@@ -25,7 +27,7 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if !std.setMember(labelName, ['app.kubernetes.io/version'])
   },
-  mixin: {
+  mixin:: {
     ruleLabels: {},
     _config: {
       nodeExporterSelector: 'job="' + defaults.name + '"',

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -1,16 +1,18 @@
 local defaults = {
   local defaults = self,
-  name: 'prometheus-adapter',
-  namespace: error 'must provide namespace',
-  version: error 'must provide version',
+  // Convention: Top-level fields related to CRDs are public, other fields are hidden
+  // If there is no CRD for the component, everything is hidden in defaults.
+  name:: 'prometheus-adapter',
+  namespace:: error 'must provide namespace',
+  version:: error 'must provide version',
   image: error 'must provide image',
-  resources: {
+  resources:: {
     requests: { cpu: '102m', memory: '180Mi' },
     limits: { cpu: '250m', memory: '180Mi' },
   },
-  replicas: 2,
-  listenAddress: '127.0.0.1',
-  port: 9100,
+  replicas:: 2,
+  listenAddress:: '127.0.0.1',
+  port:: 9100,
   commonLabels:: {
     'app.kubernetes.io/name': 'prometheus-adapter',
     'app.kubernetes.io/version': defaults.version,
@@ -24,14 +26,14 @@ local defaults = {
   },
   // Default range intervals are equal to 4 times the default scrape interval.
   // This is done in order to follow Prometheus rule of thumb with irate().
-  rangeIntervals: {
+  rangeIntervals:: {
     kubelet: '4m',
     nodeExporter: '4m',
     windowsExporter: '4m',
   },
 
-  prometheusURL: error 'must provide prometheusURL',
-  config: {
+  prometheusURL:: error 'must provide prometheusURL',
+  config:: {
     resourceRules: {
       cpu: {
         containerQuery: |||
@@ -95,7 +97,7 @@ local defaults = {
       window: '5m',
     },
   },
-  tlsCipherSuites: [
+  tlsCipherSuites:: [
     'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305',
     'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305',
     'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256',

--- a/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
@@ -3,13 +3,15 @@ local prometheusOperator = import 'github.com/prometheus-operator/prometheus-ope
 
 local defaults = {
   local defaults = self,
-  name: 'prometheus-operator',
-  namespace: error 'must provide namespace',
-  version: error 'must provide version',
-  image: error 'must provide image',
-  kubeRbacProxyImage: error 'must provide kubeRbacProxyImage',
-  configReloaderImage: error 'must provide config reloader image',
-  resources: {
+  // Convention: Top-level fields related to CRDs are public, other fields are hidden
+  // If there is no CRD for the component, everything is hidden in defaults.
+  name:: 'prometheus-operator',
+  namespace:: error 'must provide namespace',
+  version:: error 'must provide version',
+  image:: error 'must provide image',
+  kubeRbacProxyImage:: error 'must provide kubeRbacProxyImage',
+  configReloaderImage:: error 'must provide config reloader image',
+  resources:: {
     limits: { cpu: '200m', memory: '200Mi' },
     requests: { cpu: '100m', memory: '100Mi' },
   },
@@ -24,7 +26,7 @@ local defaults = {
     for labelName in std.objectFields(defaults.commonLabels)
     if !std.setMember(labelName, ['app.kubernetes.io/version'])
   },
-  mixin: {
+  mixin:: {
     ruleLabels: {
       role: 'alert-rules',
       prometheus: defaults.name,

--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -1,15 +1,18 @@
 local defaults = {
   local defaults = self,
-  namespace: error 'must provide namespace',
+  // Convention: Top-level fields related to CRDs are public, other fields are hidden
+  // If there is no CRD for the component, everything is hidden in defaults.
+  namespace:: error 'must provide namespace',
   version: error 'must provide version',
   image: error 'must provide image',
   resources: {
     requests: { memory: '400Mi' },
   },
 
-  name: error 'must provide name',
-  alertmanagerName: error 'must provide alertmanagerName',
-  namespaces: ['default', 'kube-system', defaults.namespace],
+  name:: error 'must provide name',
+  //TODO: remove alertmanagerName and convert to plain 'alerting' object
+  alertmanagerName:: error 'must provide alertmanagerName',
+  namespaces:: ['default', 'kube-system', defaults.namespace],
   replicas: 2,
   externalLabels: {},
   enableFeatures: [],
@@ -25,7 +28,7 @@ local defaults = {
     if !std.setMember(labelName, ['app.kubernetes.io/version'])
   } + { prometheus: defaults.name },
   ruleSelector: {},
-  mixin: {
+  mixin:: {
     ruleLabels: {},
     _config: {
       prometheusSelector: 'job="prometheus-' + defaults.name + '",namespace="' + defaults.namespace + '"',
@@ -35,7 +38,7 @@ local defaults = {
     },
   },
   thanos: null,
-  reloaderPort: 8080,
+  reloaderPort:: 8080,
 };
 
 


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

This is an attempt at establishing a convention for component `defaults` settings. This change has no implications on code generation as we are reassigning fields one-by-one.

I am starting to align fields in components `defaults` with CRDs and with our experiments from https://github.com/brancz/kp. Idea is that at some point we will be able to do the following (in jsonnet or cue) in prometheus component:
```jsonnet
local defaults = {
  replicas: 2,
  name:: "k8s",
  ...
}

function(params) {
  _config:: defaults + params,
  prometheus: {
    spec: _config,
  },
}
```

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
establish convention for default field types
```
