### PR TITLE
jsonnet: Expose prometheus alerting configuration in $.values.prometheus configuration

### DIFF
--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -91,7 +91,14 @@ local utils = import './lib/utils.libsonnet';
       version: $.values.common.versions.prometheus,
       image: $.values.common.images.prometheus,
       name: 'k8s',
-      alertmanagerName: $.values.alertmanager.name,
+      alerting: {
+        alertmanagers: [{
+          namespace: $.values.common.namespace,
+          name: 'alertmanager-' + $.values.alertmanager.name,
+          port: $.alertmanager.service.spec.ports[0].name,
+          apiVersion: 'v2',
+        }],
+      },
       mixin+: { ruleLabels: $.values.common.ruleLabels },
     },
     prometheusAdapter: {


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Blocked by #1475

Allow passing PrometheusSpec-native `alerting` configuration in `$.values.prometheus` instead of `alertmanagerName`. The latter option is still available, but should be removed post `release-0.10`.

This is part of aligning configuration options with ones present in CRDs.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Expose prometheus alerting configuration in $.values.prometheus configuration
```
