### PR TITLE
Default to main branch in prometheus-operator

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -26,7 +26,7 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "master"
+      "version": "main"
     },
     {
       "source": {
@@ -35,7 +35,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "master",
+      "version": "main",
       "name": "prometheus-operator-mixin"
     },
     {


### PR DESCRIPTION
## Description

Branch master was renamed to main in https://github.com/prometheus-operator/prometheus-operator/

`jb` tool provides the following error while installing/updating:
```
GET https://github.com/prometheus-operator/prometheus-operator/archive/.tar.gz 404
archive install failed: unexpected status code 404
retrying with git...
...
error: pathspec 'master' did not match any file(s) known to git
jb: error: updating: downloading: exit status 1
```

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- default to main branch in prometheus-operator
```
