### PR TITLE
Strip blackbox exporter limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,7 +678,8 @@ local kp = (import 'kube-prometheus/main.libsonnet') +
 { ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
 { ['alertmanager-' + name]: kp.alertmanager[name] for name in std.objectFields(kp.alertmanager) } +
 { ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
-{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) }
+{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) } +
+{ ['blackbox-exporter-' + name]: kp.blackboxExporter[name] for name in std.objectFields(kp.blackboxExporter) }
 ```
 
 ### Customizing Prometheus alerting/recording rules and Grafana dashboards

--- a/examples/strip-limits.jsonnet
+++ b/examples/strip-limits.jsonnet
@@ -13,4 +13,5 @@ local kp = (import 'kube-prometheus/main.libsonnet') +
 { ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
 { ['alertmanager-' + name]: kp.alertmanager[name] for name in std.objectFields(kp.alertmanager) } +
 { ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
-{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) }
+{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) } +
+{ ['blackbox-exporter-' + name]: kp.blackboxExporter[name] for name in std.objectFields(kp.blackboxExporter) }

--- a/jsonnet/kube-prometheus/addons/strip-limits.libsonnet
+++ b/jsonnet/kube-prometheus/addons/strip-limits.libsonnet
@@ -8,6 +8,17 @@
     then c { resources+: { limits: {} } }
     else c,
 
+  blackboxExporter+: {
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: std.map(noLimit, super.containers),
+          },
+        },
+      },
+    },
+  },
   nodeExporter+: {
     daemonset+: {
       spec+: {


### PR DESCRIPTION
## Description

Just as described in https://github.com/prometheus-operator/kube-prometheus/issues/72, my clusters sporadically alert about blackbox exporter being throttled. This patch makes the strip-limits addon remove the blackbox exporter limits.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

```release-note
The strip-limits addon removes the blackbox exporter limits.
```
