### PR TITLE
jsonnet/addons/sript-limits: Simplify logic

### DIFF
--- a/jsonnet/kube-prometheus/addons/strip-limits.libsonnet
+++ b/jsonnet/kube-prometheus/addons/strip-limits.libsonnet
@@ -2,46 +2,55 @@
 // https://github.com/prometheus-operator/kube-prometheus/issues/72
 
 {
-  local noLimit(c) =
-    //if std.objectHas(c, 'resources') && c.name != 'kube-state-metrics'
-    if c.name != 'kube-state-metrics'
-    then c { resources+: { limits: {} } }
-    else c,
+  //TODO(arthursens): Expand example once kube-rbac-proxy can be managed with a first-class
+  // object inside node-exporter, kube-state-metrics and prometheus-operator.
+  // See also: https://github.com/prometheus-operator/kube-prometheus/issues/1500#issuecomment-966727623
+  values+:: {
+    alertmanager+: {
+      resources+: {
+        limits: {},
+      },
+    },
 
-  nodeExporter+: {
-    daemonset+: {
-      spec+: {
-        template+: {
-          spec+: {
-            containers: std.map(noLimit, super.containers),
-          },
-        },
+    blackboxExporter+: {
+      resources+: {
+        limits: {},
       },
     },
-  },
-  kubeStateMetrics+: {
-    deployment+: {
-      spec+: {
-        template+: {
-          spec+: {
-            containers: std.map(noLimit, super.containers),
-          },
-        },
+
+    grafana+: {
+      resources+: {
+        limits: {},
       },
     },
-  },
-  prometheusOperator+: {
-    deployment+: {
-      spec+: {
-        template+: {
-          spec+: {
-            local addArgs(c) =
-              if c.name == 'prometheus-operator'
-              then c { args+: ['--config-reloader-cpu-limit=0', '--config-reloader-memory-limit=0'] }
-              else c,
-            containers: std.map(addArgs, super.containers),
-          },
-        },
+
+    kubeStateMetrics+: {
+      resources+: {
+        limits: {},
+      },
+    },
+
+    nodeExporter+: {
+      resources+: {
+        limits: {},
+      },
+    },
+
+    prometheusAdapter+: {
+      resources+: {
+        limits: {},
+      },
+    },
+
+    prometheusOperator+: {
+      resources+: {
+        limits: {},
+      },
+    },
+
+    prometheus+: {
+      resources+: {
+        limits: {},
       },
     },
   },


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Since `release-0.8` resources has become a first-class object to all components of kube-prometheus. Therefore, we're simplifying this addon to reflect those changes.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
