### PR TITLE
fix missing recording rule cluster:node_cpu_seconds_total:rate5m

### DIFF
--- a/jsonnet/kube-prometheus/components/mixin/rules/node-rules.libsonnet
+++ b/jsonnet/kube-prometheus/components/mixin/rules/node-rules.libsonnet
@@ -22,7 +22,7 @@
           },
           {
             expr: 'sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m]))',
-            record: 'cluster:node_cpu:sum_rate5m',
+            record: 'cluster:node_cpu_seconds_total:rate5m',
           },
           {
             expr: 'cluster:node_cpu_seconds_total:rate5m / count(sum(node_cpu_seconds_total) BY (instance, cpu))',


### PR DESCRIPTION
## Description

this recording rule was renamed/broken back here:

https://github.com/prometheus-operator/kube-prometheus/commit/5ba6285ede463aec803600b6860c19e12d0bebe8#diff-ed0402189356a3fc33d8201222a9a1bd75f2ed59d8032e2c415532e23fcee123L305

renaming `cluster:node_cpu:sum_rate5m` to `cluster:node_cpu_seconds_total:rate5m` will fix the other rule that creates `cluster:node_cpu:ratio`

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

rename `cluster:node_cpu:sum_rate5m` to `cluster:node_cpu_seconds_total:rate5m`.  Fixes the dependent rule `cluster:node_cpu:ratio`

```release-note
- Rename a misnamed recording rule
```
