### PR TITLE
Inhibit info alerts unless other alerts fire

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -35,6 +35,10 @@ local defaults = {
       source_matchers: ['severity = warning'],
       target_matchers: ['severity = info'],
       equal: ['namespace', 'alertname'],
+    }, {
+      source_matchers: ['alertname = InfoInhibitor'],
+      target_matchers: ['severity = info'],
+      equal: ['namespace'],
     }],
     route: {
       group_by: ['namespace'],
@@ -45,12 +49,14 @@ local defaults = {
       routes: [
         { receiver: 'Watchdog', matchers: ['alertname = Watchdog'] },
         { receiver: 'Critical', matchers: ['severity = critical'] },
+        { receiver: 'null', matchers: ['alertname = InfoInhibitor'] },
       ],
     },
     receivers: [
       { name: 'Default' },
       { name: 'Watchdog' },
       { name: 'Critical' },
+      { name: 'null' },
     ],
   },
   replicas: 3,

--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -48,8 +48,8 @@ local defaults = {
       receiver: 'Default',
       routes: [
         { receiver: 'Watchdog', matchers: ['alertname = Watchdog'] },
-        { receiver: 'Critical', matchers: ['severity = critical'] },
         { receiver: 'null', matchers: ['alertname = InfoInhibitor'] },
+        { receiver: 'Critical', matchers: ['severity = critical'] },
       ],
     },
     receivers: [

--- a/jsonnet/kube-prometheus/components/mixin/alerts/general.libsonnet
+++ b/jsonnet/kube-prometheus/components/mixin/alerts/general.libsonnet
@@ -33,6 +33,24 @@
               severity: 'none',
             },
           },
+          {
+            alert: 'InfoInhibitor',
+            annotations: {
+              summary: 'Info-level alert inhibition.',
+              description: |||
+                This is an alert that is used to inhibit info alerts.
+                By themselves, the info-level alerts are sometimes very noisy, but they are relevant when combined with
+                other alerts.
+                This alert fires whenever there's a severity="info" alert, and stops firing when another alert with a
+                severity of 'warning' or 'critical' starts firing on the same namespace.
+                This alert should be routed to a null receiver and configured to inhibit alerts with severity="info".
+              |||,
+            },
+            expr: 'ALERTS{severity = "info"} == 1 unless on(namespace) ALERTS{alertname != "InfoInhibitor", severity =~ "warning|critical", alertstate="firing"} == 1',
+            labels: {
+              severity: 'none',
+            },
+          },
         ],
       },
     ],

--- a/manifests/alertmanager-secret.yaml
+++ b/manifests/alertmanager-secret.yaml
@@ -28,10 +28,17 @@ stringData:
       - "severity = warning"
       "target_matchers":
       - "severity = info"
+    - "equal":
+      - "namespace"
+      "source_matchers":
+      - "alertname = InfoInhibitor"
+      "target_matchers":
+      - "severity = info"
     "receivers":
     - "name": "Default"
     - "name": "Watchdog"
     - "name": "Critical"
+    - "name": "null"
     "route":
       "group_by":
       - "namespace"
@@ -46,4 +53,7 @@ stringData:
       - "matchers":
         - "severity = critical"
         "receiver": "Critical"
+      - "matchers":
+        - "alertname = InfoInhibitor"
+        "receiver": "null"
 type: Opaque

--- a/manifests/alertmanager-secret.yaml
+++ b/manifests/alertmanager-secret.yaml
@@ -51,9 +51,9 @@ stringData:
         - "alertname = Watchdog"
         "receiver": "Watchdog"
       - "matchers":
-        - "severity = critical"
-        "receiver": "Critical"
-      - "matchers":
         - "alertname = InfoInhibitor"
         "receiver": "null"
+      - "matchers":
+        - "severity = critical"
+        "receiver": "Critical"
 type: Opaque

--- a/manifests/kubePrometheus-prometheusRule.yaml
+++ b/manifests/kubePrometheus-prometheusRule.yaml
@@ -38,6 +38,21 @@ spec:
       expr: vector(1)
       labels:
         severity: none
+    - alert: InfoInhibitor
+      annotations:
+        description: |
+          This is an alert that is used to inhibit info alerts.
+          By themselves, the info-level alerts are sometimes very noisy, but they are relevant when combined with
+          other alerts.
+          This alert fires whenever there's a severity="info" alert, and stops firing when another alert with a
+          severity of 'warning' or 'critical' starts firing on the same namespace.
+          This alert should be routed to a null receiver and configured to inhibit alerts with severity="info".
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/general/infoinhibitor
+        summary: Info-level alert inhibition.
+      expr: ALERTS{severity = "info"} == 1 unless on(namespace) ALERTS{alertname !=
+        "InfoInhibitor", severity =~ "warning|critical", alertstate="firing"} == 1
+      labels:
+        severity: none
   - name: node-network
     rules:
     - alert: NodeNetworkInterfaceFlapping


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Fixes #861 by adding an `InfoInhibitor` alert which fires when info alerts fire but no other alerts do. This alert is then used to inhibit info alerts. 

This is a very sketchy hack to work around alertmanager limitations.

Thanks @paulfantom for refining this solution.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [X] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Inhibit info alerts when no higher-priority alerts are firing.
```
