### PR TITLE
Refactor deprecated inhibit rules matchers

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -27,20 +27,12 @@ local defaults = {
       resolve_timeout: '5m',
     },
     inhibit_rules: [{
-      source_match: {
-        severity: 'critical',
-      },
-      target_match_re: {
-        severity: 'warning|info',
-      },
+      source_matchers: ['severity = critical'],
+      target_matchers: ['severity =~ warning|info'],
       equal: ['namespace', 'alertname'],
     }, {
-      source_match: {
-        severity: 'warning',
-      },
-      target_match_re: {
-        severity: 'info',
-      },
+      source_matchers: ['severity = warning'],
+      target_matchers: ['severity = info'],
       equal: ['namespace', 'alertname'],
     }],
     route: {

--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -42,8 +42,8 @@ local defaults = {
       repeat_interval: '12h',
       receiver: 'Default',
       routes: [
-        { receiver: 'Watchdog', match: { alertname: 'Watchdog' } },
-        { receiver: 'Critical', match: { severity: 'critical' } },
+        { receiver: 'Watchdog', matchers: ['alertname = Watchdog'] },
+        { receiver: 'Critical', matchers: ['severity = critical'] },
       ],
     },
     receivers: [

--- a/manifests/alertmanager-secret.yaml
+++ b/manifests/alertmanager-secret.yaml
@@ -40,10 +40,10 @@ stringData:
       "receiver": "Default"
       "repeat_interval": "12h"
       "routes":
-      - "match":
-          "alertname": "Watchdog"
+      - "matchers":
+        - "alertname = Watchdog"
         "receiver": "Watchdog"
-      - "match":
-          "severity": "critical"
+      - "matchers":
+        - "severity = critical"
         "receiver": "Critical"
 type: Opaque

--- a/manifests/alertmanager-secret.yaml
+++ b/manifests/alertmanager-secret.yaml
@@ -17,17 +17,17 @@ stringData:
     - "equal":
       - "namespace"
       - "alertname"
-      "source_match":
-        "severity": "critical"
-      "target_match_re":
-        "severity": "warning|info"
+      "source_matchers":
+      - "severity = critical"
+      "target_matchers":
+      - "severity =~ warning|info"
     - "equal":
       - "namespace"
       - "alertname"
-      "source_match":
-        "severity": "warning"
-      "target_match_re":
-        "severity": "info"
+      "source_matchers":
+      - "severity = warning"
+      "target_matchers":
+      - "severity = info"
     "receivers":
     - "name": "Default"
     - "name": "Watchdog"


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Refactors alertmanager config to use the new `matcher` fields. 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Alertmanager now uses the new `matcher` syntax in the routing tree and inhibition rules.
```
