### PR TITLE
addons: Always use proper values scope for namespace

### DIFF
--- a/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet
+++ b/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet
@@ -46,7 +46,7 @@
       spec+:
         $.antiaffinity(
           $.alertmanager._config.selectorLabels,
-          $.values.common.namespace,
+          $.values.alertmanager.namespace,
           $.values.alertmanager.podAntiAffinity,
           $.values.alertmanager.podAntiAffinityTopologyKey,
         ),
@@ -58,7 +58,7 @@
       spec+:
         $.antiaffinity(
           $.prometheus._config.selectorLabels,
-          $.values.common.namespace,
+          $.values.prometheus.namespace,
           $.values.prometheus.podAntiAffinity,
           $.values.prometheus.podAntiAffinityTopologyKey,
         ),
@@ -72,7 +72,7 @@
           spec+:
             $.antiaffinity(
               $.blackboxExporter._config.selectorLabels,
-              $.values.common.namespace,
+              $.values.blackboxExporter.namespace,
               $.values.blackboxExporter.podAntiAffinity,
               $.values.blackboxExporter.podAntiAffinityTopologyKey,
             ),
@@ -88,7 +88,7 @@
           spec+:
             $.antiaffinity(
               $.prometheusAdapter._config.selectorLabels,
-              $.values.common.namespace,
+              $.values.prometheusAdapter.namespace,
               $.values.prometheusAdapter.podAntiAffinity,
               $.values.prometheusAdapter.podAntiAffinityTopologyKey,
             ),

--- a/jsonnet/kube-prometheus/addons/aws-vpc-cni.libsonnet
+++ b/jsonnet/kube-prometheus/addons/aws-vpc-cni.libsonnet
@@ -37,7 +37,7 @@
       kind: 'ServiceMonitor',
       metadata: {
         name: 'aws-node',
-        namespace: $.values.common.namespace,
+        namespace: $.values.kubernetesControlPlane.namespace,
         labels: {
           'app.kubernetes.io/name': 'aws-node',
         },

--- a/jsonnet/kube-prometheus/addons/custom-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/addons/custom-metrics.libsonnet
@@ -4,7 +4,7 @@
 {
   values+:: {
     prometheusAdapter+: {
-      namespace: $.values.common.namespace,
+      namespace: $.values.prometheusAdapter.namespace,
       // Rules for custom-metrics
       config+:: {
         rules+: [

--- a/jsonnet/kube-prometheus/addons/external-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/addons/external-metrics.libsonnet
@@ -4,7 +4,6 @@
 {
   values+:: {
     prometheusAdapter+: {
-      namespace: $.values.common.namespace,
       // Rules for external-metrics
       config+:: {
         externalRules+: [

--- a/jsonnet/kube-prometheus/addons/ksm-autoscaler.libsonnet
+++ b/jsonnet/kube-prometheus/addons/ksm-autoscaler.libsonnet
@@ -30,7 +30,7 @@
         kind: 'ClusterRole',
         name: 'ksm-autoscaler',
       },
-      subjects: [{ kind: 'ServiceAccount', name: 'ksm-autoscaler', namespace: $.values.common.namespace }],
+      subjects: [{ kind: 'ServiceAccount', name: 'ksm-autoscaler', namespace: $.values.kubeStateMetrics.namespace }],
     },
 
     roleBinding: {
@@ -38,7 +38,7 @@
       kind: 'RoleBinding',
       metadata: {
         name: 'ksm-autoscaler',
-        namespace: $.values.common.namespace,
+        namespace: $.values.kubeStateMetrics.namespace,
       },
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',
@@ -53,7 +53,7 @@
       kind: 'Role',
       metadata: {
         name: 'ksm-autoscaler',
-        namespace: $.values.common.namespace,
+        namespace: $.values.kubeStateMetrics.namespace,
       },
       rules: [
         {
@@ -76,7 +76,7 @@
       kind: 'ServiceAccount',
       metadata: {
         name: 'ksm-autoscaler',
-        namespace: $.values.common.namespace,
+        namespace: $.values.kubeStateMetrics.namespace,
       },
     },
 
@@ -88,7 +88,7 @@
         args: [
           '/cpvpa',
           '--target=deployment/kube-state-metrics',
-          '--namespace=' + $.values.common.namespace,
+          '--namespace=' + $.values.kubeStateMetrics.namespace,
           '--logtostderr=true',
           '--poll-period-seconds=10',
           '--default-config={"kube-state-metrics":{"requests":{"cpu":{"base":"' + $.values.clusterVerticalAutoscaler.baseCPU +
@@ -110,7 +110,7 @@
         kind: 'Deployment',
         metadata: {
           name: 'ksm-autoscaler',
-          namespace: $.values.common.namespace,
+          namespace: $.values.kubeStateMetrics.namespace,
           labels: podLabels,
         },
         spec: {

--- a/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
+++ b/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
@@ -59,7 +59,7 @@ local restrictedPodSecurityPolicy = {
       kind: 'Role',
       metadata: {
         name: 'alertmanager-' + $.values.alertmanager.name,
-        namespace: $.values.common.namespace,
+        namespace: $.values.alertmanager.namespace,
       },
       rules: [{
         apiGroups: ['policy'],
@@ -74,7 +74,7 @@ local restrictedPodSecurityPolicy = {
       kind: 'RoleBinding',
       metadata: {
         name: 'alertmanager-' + $.values.alertmanager.name,
-        namespace: $.values.common.namespace,
+        namespace: $.values.alertmanager.namespace,
       },
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',
@@ -132,7 +132,7 @@ local restrictedPodSecurityPolicy = {
       kind: 'Role',
       metadata: {
         name: 'grafana',
-        namespace: $.values.common.namespace,
+        namespace: $.values.grafana.namespace,
       },
       rules: [{
         apiGroups: ['policy'],
@@ -147,7 +147,7 @@ local restrictedPodSecurityPolicy = {
       kind: 'RoleBinding',
       metadata: {
         name: 'grafana',
-        namespace: $.values.common.namespace,
+        namespace: $.values.grafana.namespace,
       },
       roleRef: {
         apiGroup: 'rbac.authorization.k8s.io',

--- a/jsonnet/kube-prometheus/addons/static-etcd.libsonnet
+++ b/jsonnet/kube-prometheus/addons/static-etcd.libsonnet
@@ -84,7 +84,7 @@
       type: 'Opaque',
       metadata: {
         name: 'kube-etcd-client-certs',
-        namespace: $.values.common.namespace,
+        namespace: $.values.prometheus.namespace,
       },
       data: {
         'etcd-client-ca.crt': std.base64($.values.etcd.clientCA),


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

If `namespace` is set for a component, its addons should follow. This change replaces `$.values.common` by `$.values.<component>` where applicable for addons.


`git grep 'values.common' jsonnet/kube-prometheus/addons` should return only little exceptions now.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- addons: Always use proper values scope for namespace
```
