### PR TITLE
Use recommended instance label for Prometheus/Alertmanager resources

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -11,6 +11,7 @@ local defaults = {
   },
   commonLabels:: {
     'app.kubernetes.io/name': 'alertmanager',
+    'app.kubernetes.io/instance': defaults.name,
     'app.kubernetes.io/version': defaults.version,
     'app.kubernetes.io/component': 'alert-router',
     'app.kubernetes.io/part-of': 'kube-prometheus',
@@ -100,9 +101,7 @@ function(params) {
     apiVersion: 'v1',
     kind: 'Secret',
     type: 'Opaque',
-    metadata: am._metadata {
-      labels+: { alertmanager: am._config.name },
-    },
+    metadata: am._metadata,
     stringData: {
       'alertmanager.yaml': if std.type(am._config.config) == 'object'
       then
@@ -115,25 +114,19 @@ function(params) {
   serviceAccount: {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
-    metadata: am._metadata {
-      labels+: { alertmanager: am._config.name },
-    },
+    metadata: am._metadata,
   },
 
   service: {
     apiVersion: 'v1',
     kind: 'Service',
-    metadata: am._metadata {
-      labels+: { alertmanager: am._config.name },
-    },
+    metadata: am._metadata,
     spec: {
       ports: [
         { name: 'web', targetPort: 'web', port: 9093 },
         { name: 'reloader-web', port: am._config.reloaderPort, targetPort: 'reloader-web' },
       ],
-      selector: am._config.selectorLabels {
-        alertmanager: am._config.name,
-      },
+      selector: am._config.selectorLabels,
       sessionAffinity: 'ClientIP',
     },
   },
@@ -144,9 +137,7 @@ function(params) {
     metadata: am._metadata,
     spec: {
       selector: {
-        matchLabels: am._config.selectorLabels {
-          alertmanager: am._config.name,
-        },
+        matchLabels: am._config.selectorLabels,
       },
       endpoints: [
         { port: 'web', interval: '30s' },
@@ -162,9 +153,7 @@ function(params) {
     spec: {
       maxUnavailable: 1,
       selector: {
-        matchLabels: am._config.selectorLabels {
-          alertmanager: am._config.name,
-        },
+        matchLabels: am._config.selectorLabels,
       },
     },
   },
@@ -174,9 +163,6 @@ function(params) {
     kind: 'Alertmanager',
     metadata: am._metadata {
       name: am._config.name,
-      labels+: {
-        alertmanager: am._config.name,
-      },
     },
     spec: {
       replicas: am._config.replicas,

--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -19,6 +19,7 @@ local defaults = {
   ruleSelector: {},
   commonLabels:: {
     'app.kubernetes.io/name': 'prometheus',
+    'app.kubernetes.io/instance': defaults.name,
     'app.kubernetes.io/version': defaults.version,
     'app.kubernetes.io/component': 'prometheus',
     'app.kubernetes.io/part-of': 'kube-prometheus',
@@ -27,7 +28,7 @@ local defaults = {
     [labelName]: defaults.commonLabels[labelName]
     for labelName in std.objectFields(defaults.commonLabels)
     if !std.setMember(labelName, ['app.kubernetes.io/version'])
-  } + { prometheus: defaults.name },
+  },
   mixin:: {
     ruleLabels: {},
     _config: {
@@ -95,9 +96,7 @@ function(params) {
   service: {
     apiVersion: 'v1',
     kind: 'Service',
-    metadata: p._metadata {
-      labels+: { prometheus: p._config.name },
-    },
+    metadata: p._metadata,
     spec: {
       ports: [
                { name: 'web', targetPort: 'web', port: 9090 },
@@ -239,9 +238,7 @@ function(params) {
     spec: {
       minAvailable: 1,
       selector: {
-        matchLabels: p._config.selectorLabels {
-          prometheus: p._config.name,
-        },
+        matchLabels: p._config.selectorLabels,
       },
     },
   },
@@ -251,7 +248,6 @@ function(params) {
     kind: 'Prometheus',
     metadata: p._metadata {
       name: p._config.name,
-      labels+: { prometheus: p._config.name },
     },
     spec: {
       replicas: p._config.replicas,
@@ -327,7 +323,6 @@ function(params) {
     metadata+: p._metadata {
       name: p._metadata.name + '-thanos-sidecar',
       labels+: {
-        prometheus: p._config.name,
         'app.kubernetes.io/component': 'thanos-sidecar',
       },
     },
@@ -337,7 +332,6 @@ function(params) {
         { name: 'http', port: 10902, targetPort: 10902 },
       ],
       selector: p._config.selectorLabels {
-        prometheus: p._config.name,
         'app.kubernetes.io/component': 'prometheus',
       },
       clusterIP: 'None',
@@ -351,7 +345,6 @@ function(params) {
     metadata+: p._metadata {
       name: 'thanos-sidecar',
       labels+: {
-        prometheus: p._config.name,
         'app.kubernetes.io/component': 'thanos-sidecar',
       },
     },
@@ -359,7 +352,6 @@ function(params) {
       jobLabel: 'app.kubernetes.io/component',
       selector: {
         matchLabels: {
-          prometheus: p._config.name,
           'app.kubernetes.io/component': 'thanos-sidecar',
         },
       },

--- a/manifests/alertmanager-alertmanager.yaml
+++ b/manifests/alertmanager-alertmanager.yaml
@@ -2,8 +2,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
   labels:
-    alertmanager: main
     app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
@@ -15,8 +15,8 @@ spec:
     kubernetes.io/os: linux
   podMetadata:
     labels:
-      alertmanager: main
       app.kubernetes.io/component: alert-router
+      app.kubernetes.io/instance: main
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 0.23.0

--- a/manifests/alertmanager-podDisruptionBudget.yaml
+++ b/manifests/alertmanager-podDisruptionBudget.yaml
@@ -3,6 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
@@ -12,7 +13,7 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      alertmanager: main
       app.kubernetes.io/component: alert-router
+      app.kubernetes.io/instance: main
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: kube-prometheus

--- a/manifests/alertmanager-prometheusRule.yaml
+++ b/manifests/alertmanager-prometheusRule.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0

--- a/manifests/alertmanager-secret.yaml
+++ b/manifests/alertmanager-secret.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   labels:
-    alertmanager: main
     app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0

--- a/manifests/alertmanager-service.yaml
+++ b/manifests/alertmanager-service.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    alertmanager: main
     app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
@@ -18,8 +18,8 @@ spec:
     port: 8080
     targetPort: reloader-web
   selector:
-    alertmanager: main
     app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
   sessionAffinity: ClientIP

--- a/manifests/alertmanager-serviceAccount.yaml
+++ b/manifests/alertmanager-serviceAccount.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    alertmanager: main
     app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0

--- a/manifests/alertmanager-serviceMonitor.yaml
+++ b/manifests/alertmanager-serviceMonitor.yaml
@@ -3,6 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: main
     app.kubernetes.io/name: alertmanager
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.23.0
@@ -16,7 +17,7 @@ spec:
     port: reloader-web
   selector:
     matchLabels:
-      alertmanager: main
       app.kubernetes.io/component: alert-router
+      app.kubernetes.io/instance: main
       app.kubernetes.io/name: alertmanager
       app.kubernetes.io/part-of: kube-prometheus

--- a/manifests/prometheus-clusterRole.yaml
+++ b/manifests/prometheus-clusterRole.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.31.1

--- a/manifests/prometheus-clusterRoleBinding.yaml
+++ b/manifests/prometheus-clusterRoleBinding.yaml
@@ -3,6 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.31.1

--- a/manifests/prometheus-podDisruptionBudget.yaml
+++ b/manifests/prometheus-podDisruptionBudget.yaml
@@ -3,6 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.31.1
@@ -13,6 +14,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
-      prometheus: k8s

--- a/manifests/prometheus-prometheus.yaml
+++ b/manifests/prometheus-prometheus.yaml
@@ -3,10 +3,10 @@ kind: Prometheus
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.31.1
-    prometheus: k8s
   name: k8s
   namespace: monitoring
 spec:
@@ -24,10 +24,10 @@ spec:
   podMetadata:
     labels:
       app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 2.31.1
-      prometheus: k8s
   podMonitorNamespaceSelector: {}
   podMonitorSelector: {}
   probeNamespaceSelector: {}

--- a/manifests/prometheus-prometheusRule.yaml
+++ b/manifests/prometheus-prometheusRule.yaml
@@ -3,6 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.31.1

--- a/manifests/prometheus-roleBindingConfig.yaml
+++ b/manifests/prometheus-roleBindingConfig.yaml
@@ -3,6 +3,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.31.1

--- a/manifests/prometheus-roleBindingSpecificNamespaces.yaml
+++ b/manifests/prometheus-roleBindingSpecificNamespaces.yaml
@@ -5,6 +5,7 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 2.31.1
@@ -23,6 +24,7 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 2.31.1
@@ -41,6 +43,7 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 2.31.1

--- a/manifests/prometheus-roleConfig.yaml
+++ b/manifests/prometheus-roleConfig.yaml
@@ -3,6 +3,7 @@ kind: Role
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.31.1

--- a/manifests/prometheus-roleSpecificNamespaces.yaml
+++ b/manifests/prometheus-roleSpecificNamespaces.yaml
@@ -5,6 +5,7 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 2.31.1
@@ -42,6 +43,7 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 2.31.1
@@ -79,6 +81,7 @@ items:
   metadata:
     labels:
       app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 2.31.1

--- a/manifests/prometheus-service.yaml
+++ b/manifests/prometheus-service.yaml
@@ -3,10 +3,10 @@ kind: Service
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.31.1
-    prometheus: k8s
   name: prometheus-k8s
   namespace: monitoring
 spec:
@@ -19,7 +19,7 @@ spec:
     targetPort: reloader-web
   selector:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    prometheus: k8s
   sessionAffinity: ClientIP

--- a/manifests/prometheus-serviceAccount.yaml
+++ b/manifests/prometheus-serviceAccount.yaml
@@ -3,6 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.31.1

--- a/manifests/prometheus-serviceMonitor.yaml
+++ b/manifests/prometheus-serviceMonitor.yaml
@@ -3,6 +3,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 2.31.1
@@ -17,6 +18,6 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
-      prometheus: k8s


### PR DESCRIPTION
## Description

This sets the recommmended `app.kubernetes.io/instance` label on all Prometheus/Alertmanager component resources, and removes the legacy `prometheus`/`alertmanager` ones.

Prometheus already had the instance label in `selectorLabels`, Alertmanager did not. Is there any concern about having it in `commonLabels` for both? I have tested these labels in my setup without issues.

For reference, the recommended labels were added in prometheus-operator/prometheus-operator#3841, this is in the continuity of #832

## Type of change

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- Use recommended instance label for Prometheus/Alertmanager resources
```