### PR TITLE
*: point to using server-side apply with kubectl as a solution to large CRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ Though for a quickstart a compiled version of the Kubernetes [manifests](manifes
 
 ```shell
 # Create the namespace and CRDs, and then wait for them to be available before creating the remaining resources
-kubectl create -f manifests/setup
+kubectl apply --server-side -f manifests/setup
 until kubectl get servicemonitors --all-namespaces ; do date; sleep 1; echo ""; done
-kubectl create -f manifests/
+kubectl apply -f manifests/
 ```
 
 We create the namespace and CustomResourceDefinitions first to avoid race conditions when deploying the monitoring components.
 Alternatively, the resources in both folders can be applied with a single command
-`kubectl create -f manifests/setup -f manifests`, but it may be necessary to run the command multiple times for all components to
+`kubectl apply --server-side -f manifests/setup -f manifests`, but it may be necessary to run the command multiple times for all components to
 be created successfullly.
 
 * And to teardown the stack:
@@ -274,12 +274,16 @@ Now simply use `kubectl` to install Prometheus and Grafana as per your configura
 
 ```shell
 # Update the namespace and CRDs, and then wait for them to be available before creating the remaining resources
-$ kubectl apply -f manifests/setup
+$ kubectl apply --server-side -f manifests/setup
 $ kubectl apply -f manifests/
 ```
 
+> Note that due to some CRD size we are using kubeclt server-side apply feature which is generally available since
+> kubernetes 1.22. If you are using previous kubernetes versions this feature may not be available and you would need to
+> use `kubectl create` instead.
+
 Alternatively, the resources in both folders can be applied with a single command
-`kubectl apply -Rf manifests`, but it may be necessary to run the command multiple times for all components to
+`kubectl apply --server-side -Rf manifests`, but it may be necessary to run the command multiple times for all components to
 be created successfullly.
 
 Check the monitoring namespace (or the namespace you have specific in `namespace: `) and make sure the pods are running. Prometheus and Grafana should be up and running soon.

--- a/developer-workspace/common/deploy-kube-prometheus.sh
+++ b/developer-workspace/common/deploy-kube-prometheus.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-kubectl apply -f manifests/setup
+kubectl apply --server-side -f manifests/setup
 
 # Safety wait for CRDs to be working
 sleep 30


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Using server-side apply allows to still use `kubectl apply` instead of `kubectl create` and works with large CRDs. Since the feature was in beta 2 since k8s 1.18 and is [GA since k8s 1.22](https://kubernetes.io/docs/reference/using-api/server-side-apply/) I think we can safely start pointing kube-prometheus users to it.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
