### PR TITLE
fix: k8s-resources-workloads-namespace query

### DIFF
--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -18527,7 +18527,7 @@ items:
                       "options": [
 
                       ],
-                      "query": "label_values(kube_pod_info{job=\"kube-state-metrics\"}, cluster=\"$cluster\"}, namespace)",
+                      "query": "label_values(kube_pod_info{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
                       "refresh": 2,
                       "regex": "",
                       "sort": 1,


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_ In the `k8s-resources-workloads-namespace`  dashboard, there was an extra bracket in the query of namespace variables that was causing the panel to show an error and not load any data 

### Screenshot

![Error in grafana](https://user-images.githubusercontent.com/32752884/143269880-6b9d48e3-1c8a-4f36-830c-181d815f306c.png)


### Original Query
```json
"query": "label_values(kube_pod_info{job=\"kube-state-metrics\"}, cluster=\"$cluster\"}, namespace)",
```

### Fixed Query
```json
"query": "label_values(kube_pod_info{job=\"kube-state-metrics\", cluster=\"$cluster\"}, namespace)",
```



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix the namespace variable query in k8s-resources-workloads-namespace  dashboard 

```
