### PR TITLE
Source kube-rbac-proxy configs from values

### DIFF
--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -11,6 +11,16 @@ local defaults = {
     requests: { cpu: '10m', memory: '20Mi' },
     limits: { cpu: '20m', memory: '40Mi' },
   },
+  kubeRbacProxy:: {
+    name: 'kube-rbac-proxy',
+    upstream: 'http://127.0.0.1:' + defaults.internalPort + '/',
+    resources: defaults.resources,
+    secureListenAddress: ':' + defaults.port,
+    ports: [
+      { name: 'https', containerPort: defaults.port },
+    ],
+    image: defaults.kubeRbacProxyImage,
+  },
   commonLabels:: {
     'app.kubernetes.io/name': 'blackbox-exporter',
     'app.kubernetes.io/version': defaults.version,
@@ -198,16 +208,7 @@ function(params) {
       }],
     };
 
-    local kubeRbacProxy = krp({
-      name: 'kube-rbac-proxy',
-      upstream: 'http://127.0.0.1:' + bb._config.internalPort + '/',
-      resources: bb._config.resources,
-      secureListenAddress: ':' + bb._config.port,
-      ports: [
-        { name: 'https', containerPort: bb._config.port },
-      ],
-      image: bb._config.kubeRbacProxyImage,
-    });
+    local kubeRbacProxy = krp(bb._config.kubeRbacProxy);
 
     {
       apiVersion: 'apps/v1',

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -13,12 +13,27 @@ local defaults = {
     requests: { cpu: '10m', memory: '190Mi' },
     limits: { cpu: '100m', memory: '250Mi' },
   },
-
   kubeRbacProxyMain:: {
+    name: 'kube-rbac-proxy-main',
+    upstream: 'http://127.0.0.1:8081/',
+    secureListenAddress: ':8443',
+    ports: [
+      { name: 'https-main', containerPort: 8443 },
+    ],
+    image: defaults.kubeRbacProxyImage,
     resources+: {
       limits+: { cpu: '40m' },
       requests+: { cpu: '20m' },
     },
+  },
+  kubeRbacProxySelf:: {
+    name: 'kube-rbac-proxy-self',
+    upstream: 'http://127.0.0.1:8082/',
+    secureListenAddress: ':9443',
+    ports: [
+      { name: 'https-self', containerPort: 9443 },
+    ],
+    image: defaults.kubeRbacProxyImage,
   },
   scrapeInterval:: '30s',
   scrapeTimeout:: '30s',
@@ -98,25 +113,9 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
     },
   },
 
-  local kubeRbacProxyMain = krp(ksm._config.kubeRbacProxyMain {
-    name: 'kube-rbac-proxy-main',
-    upstream: 'http://127.0.0.1:8081/',
-    secureListenAddress: ':8443',
-    ports: [
-      { name: 'https-main', containerPort: 8443 },
-    ],
-    image: ksm._config.kubeRbacProxyImage,
-  }),
+  local kubeRbacProxyMain = krp(ksm._config.kubeRbacProxyMain),
 
-  local kubeRbacProxySelf = krp({
-    name: 'kube-rbac-proxy-self',
-    upstream: 'http://127.0.0.1:8082/',
-    secureListenAddress: ':9443',
-    ports: [
-      { name: 'https-self', containerPort: 9443 },
-    ],
-    image: ksm._config.kubeRbacProxyImage,
-  }),
+  local kubeRbacProxySelf = krp(ksm._config.kubeRbacProxySelf),
 
   deployment+: {
     spec+: {

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -13,6 +13,24 @@ local defaults = {
     requests: { cpu: '102m', memory: '180Mi' },
     limits: { cpu: '250m', memory: '180Mi' },
   },
+  kubeRbacProxy:: {
+    name: 'kube-rbac-proxy',
+    //image: krpImage,
+    upstream: 'http://127.0.0.1:' + defaults.port + '/',
+    secureListenAddress: '[$(IP)]:' + defaults.port,
+    // Keep `hostPort` here, rather than in the node-exporter container
+    // because Kubernetes mandates that if you define a `hostPort` then
+    // `containerPort` must match. In our case, we are splitting the
+    // host port and container port between the two containers.
+    // We'll keep the port specification here so that the named port
+    // used by the service is tied to the proxy container. We *could*
+    // forgo declaring the host port, however it is important to declare
+    // it so that the scheduler can decide if the pod is schedulable.
+    ports: [
+      { name: 'https', containerPort: defaults.port, hostPort: defaults.port },
+    ],
+    image: defaults.kubeRbacProxyImage,
+  },
   listenAddress:: '127.0.0.1',
   filesystemMountPointsExclude:: '^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)',
   port:: 9100,
@@ -183,24 +201,7 @@ function(params) {
       resources: ne._config.resources,
     };
 
-    local kubeRbacProxy = krp({
-      name: 'kube-rbac-proxy',
-      //image: krpImage,
-      upstream: 'http://127.0.0.1:' + ne._config.port + '/',
-      secureListenAddress: '[$(IP)]:' + ne._config.port,
-      // Keep `hostPort` here, rather than in the node-exporter container
-      // because Kubernetes mandates that if you define a `hostPort` then
-      // `containerPort` must match. In our case, we are splitting the
-      // host port and container port between the two containers.
-      // We'll keep the port specification here so that the named port
-      // used by the service is tied to the proxy container. We *could*
-      // forgo declaring the host port, however it is important to declare
-      // it so that the scheduler can decide if the pod is schedulable.
-      ports: [
-        { name: 'https', containerPort: ne._config.port, hostPort: ne._config.port },
-      ],
-      image: ne._config.kubeRbacProxyImage,
-    }) + {
+    local kubeRbacProxy = krp(ne._config.kubeRbacProxy) + {
       env: [
         { name: 'IP', valueFrom: { fieldRef: { fieldPath: 'status.podIP' } } },
       ],

--- a/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
@@ -15,6 +15,15 @@ local defaults = {
     limits: { cpu: '200m', memory: '200Mi' },
     requests: { cpu: '100m', memory: '100Mi' },
   },
+  kubeRbacProxy:: {
+    name: 'kube-rbac-proxy',
+    upstream: 'http://127.0.0.1:8080/',
+    secureListenAddress: ':8443',
+    ports: [
+      { name: 'https', containerPort: 8443 },
+    ],
+    image: defaults.kubeRbacProxyImage,
+  },
   commonLabels:: {
     'app.kubernetes.io/name': defaults.name,
     'app.kubernetes.io/version': defaults.version,
@@ -115,15 +124,7 @@ function(params)
       ],
     },
 
-    local kubeRbacProxy = krp({
-      name: 'kube-rbac-proxy',
-      upstream: 'http://127.0.0.1:8080/',
-      secureListenAddress: ':8443',
-      ports: [
-        { name: 'https', containerPort: 8443 },
-      ],
-      image: po._config.kubeRbacProxyImage,
-    }),
+    local kubeRbacProxy = krp(po._config.kubeRbacProxy),
 
     deployment+: {
       spec+: {


### PR DESCRIPTION
## Description

This started off from "I want to easily configure the resources of any kube-rbac-proxy" and end by "we can do the full config for kube-rbac-proxy in values like everything else".

No manifest changes.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- Source kube-rbac-proxy configs from values
```
