### PR TITLE
Security: Upgrade Grafana Version, Fixes CVE-2021-43798

### DIFF
--- a/jsonnet/kube-prometheus/versions.json
+++ b/jsonnet/kube-prometheus/versions.json
@@ -1,7 +1,7 @@
 {
   "alertmanager": "0.23.0",
   "blackboxExporter": "0.19.0",
-  "grafana": "8.2.6",
+  "grafana": "8.3.1",
   "kubeStateMetrics": "2.2.4",
   "nodeExporter": "1.3.1",
   "prometheus": "2.31.1",

--- a/manifests/grafana-config.yaml
+++ b/manifests/grafana-config.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 8.2.6
+    app.kubernetes.io/version: 8.3.1
   name: grafana-config
   namespace: monitoring
 stringData:

--- a/manifests/grafana-dashboardDatasources.yaml
+++ b/manifests/grafana-dashboardDatasources.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 8.2.6
+    app.kubernetes.io/version: 8.3.1
   name: grafana-datasources
   namespace: monitoring
 stringData:

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -596,7 +596,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-alertmanager-overview
     namespace: monitoring
 - apiVersion: v1
@@ -2357,7 +2357,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-apiserver
     namespace: monitoring
 - apiVersion: v1
@@ -4228,7 +4228,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-cluster-total
     namespace: monitoring
 - apiVersion: v1
@@ -5407,7 +5407,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-controller-manager
     namespace: monitoring
 - apiVersion: v1
@@ -8484,7 +8484,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-k8s-resources-cluster
     namespace: monitoring
 - apiVersion: v1
@@ -11270,7 +11270,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-k8s-resources-namespace
     namespace: monitoring
 - apiVersion: v1
@@ -12285,7 +12285,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-k8s-resources-node
     namespace: monitoring
 - apiVersion: v1
@@ -14743,7 +14743,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-k8s-resources-pod
     namespace: monitoring
 - apiVersion: v1
@@ -16756,7 +16756,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-k8s-resources-workload
     namespace: monitoring
 - apiVersion: v1
@@ -18934,7 +18934,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-k8s-resources-workloads-namespace
     namespace: monitoring
 - apiVersion: v1
@@ -21177,7 +21177,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-kubelet
     namespace: monitoring
 - apiVersion: v1
@@ -22630,7 +22630,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-namespace-by-pod
     namespace: monitoring
 - apiVersion: v1
@@ -24355,7 +24355,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-namespace-by-workload
     namespace: monitoring
 - apiVersion: v1
@@ -25407,7 +25407,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-node-cluster-rsrc-use
     namespace: monitoring
 - apiVersion: v1
@@ -26485,7 +26485,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-node-rsrc-use
     namespace: monitoring
 - apiVersion: v1
@@ -27465,7 +27465,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-nodes
     namespace: monitoring
 - apiVersion: v1
@@ -28041,7 +28041,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-persistentvolumesusage
     namespace: monitoring
 - apiVersion: v1
@@ -29258,7 +29258,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-pod-total
     namespace: monitoring
 - apiVersion: v1
@@ -30917,7 +30917,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-prometheus-remote-write
     namespace: monitoring
 - apiVersion: v1
@@ -32141,7 +32141,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-prometheus
     namespace: monitoring
 - apiVersion: v1
@@ -33401,7 +33401,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-proxy
     namespace: monitoring
 - apiVersion: v1
@@ -34502,7 +34502,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-scheduler
     namespace: monitoring
 - apiVersion: v1
@@ -35929,7 +35929,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 8.2.6
+      app.kubernetes.io/version: 8.3.1
     name: grafana-dashboard-workload-total
     namespace: monitoring
 kind: ConfigMapList

--- a/manifests/grafana-dashboardSources.yaml
+++ b/manifests/grafana-dashboardSources.yaml
@@ -22,6 +22,6 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 8.2.6
+    app.kubernetes.io/version: 8.3.1
   name: grafana-dashboards
   namespace: monitoring

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 8.2.6
+    app.kubernetes.io/version: 8.3.1
   name: grafana
   namespace: monitoring
 spec:
@@ -25,11 +25,11 @@ spec:
         app.kubernetes.io/component: grafana
         app.kubernetes.io/name: grafana
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 8.2.6
+        app.kubernetes.io/version: 8.3.1
     spec:
       containers:
       - env: []
-        image: grafana/grafana:8.2.6
+        image: grafana/grafana:8.3.1
         name: grafana
         ports:
         - containerPort: 3000

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -18,9 +18,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/grafana-config: 4b307096c13247f897eb04971bc72f1d
-        checksum/grafana-dashboardproviders: a2828e7ffe910faaecda6b5af486a5cd
-        checksum/grafana-datasources: 450b1a10b3cb4a755bdbc77f2c4a58ba
+        checksum/grafana-config: 195eb41a323ee6cfb55c97686f401be3
+        checksum/grafana-dashboardproviders: b3605fa7a3ffdbf40289bf690a05e24f
+        checksum/grafana-datasources: b186175d4c8b0cd39feebffbe0b2d528
       labels:
         app.kubernetes.io/component: grafana
         app.kubernetes.io/name: grafana

--- a/manifests/grafana-service.yaml
+++ b/manifests/grafana-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 8.2.6
+    app.kubernetes.io/version: 8.3.1
   name: grafana
   namespace: monitoring
 spec:

--- a/manifests/grafana-serviceAccount.yaml
+++ b/manifests/grafana-serviceAccount.yaml
@@ -5,6 +5,6 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 8.2.6
+    app.kubernetes.io/version: 8.3.1
   name: grafana
   namespace: monitoring

--- a/manifests/grafana-serviceMonitor.yaml
+++ b/manifests/grafana-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 8.2.6
+    app.kubernetes.io/version: 8.3.1
   name: grafana
   namespace: monitoring
 spec:


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Grafana is an open-source platform for monitoring and observability. Grafana versions 8.0.0-beta1 through 8.3.0 (except for patched versions) iss vulnerable to directory traversal, allowing access to local files. The vulnerable URL path is: `<grafana_host_url>/public/plugins//`, where is the plugin ID for any installed plugin. At no time has Grafana Cloud been vulnerable. Users are advised to upgrade to patched versions 8.0.7, 8.1.8, 8.2.7, or 8.3.1. The GitHub Security Advisory contains more information about vulnerable URL paths, mitigation, and the disclosure timeline._



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Grafana 8.3.1, 8.2.7, 8.1.8, and 8.0.7 released with high severity security fix.
```
