### PR TITLE
Deprecate `thanosSelector` and expose `mixin._config.thanos` config variable for thanos sidecar

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -34,6 +34,8 @@ local defaults = {
     _config: {
       prometheusSelector: 'job="prometheus-' + defaults.name + '",namespace="' + defaults.namespace + '"',
       prometheusName: '{{$labels.namespace}}/{{$labels.pod}}',
+      // TODO: remove `thanosSelector` after 0.10.0 release.
+      thanosSelector: '',
       thanos: {
         targetGroups: {
           namespace: defaults.namespace,
@@ -74,7 +76,8 @@ function(params) {
     (import 'github.com/kubernetes-monitoring/kubernetes-mixin/lib/add-runbook-links.libsonnet') + {
       _config+:: p._config.mixin._config,
       targetGroups+: p._config.mixin._config.thanos.targetGroups,
-      sidecar+: p._config.mixin._config.thanos.sidecar,
+      // TODO: remove `_config.thanosSelector` after 0.10.0 release.
+      sidecar+: { selector: p._config.mixin._config.thanosSelector } + p._config.mixin._config.thanos.sidecar,
     },
 
   prometheusRule: {


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This commit deprecates existing `thanosSelector` and exposes a single config variable `mixin._config.thanos` to customize thanos sidecar mixins. It follows same structure as https://github.com/thanos-io/thanos/blob/d2d74dac9878f633f1fb0e253bcc0b1cdea376d3/mixin/config.libsonnet

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Deprecate `thanosSelector` and expose `mixin._config.thanos` config variable for thanos sidecar
```
