### PR TITLE
Fix accidentally broken `thanosSelector` after #1543

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -35,13 +35,13 @@ local defaults = {
       prometheusSelector: 'job="prometheus-' + defaults.name + '",namespace="' + defaults.namespace + '"',
       prometheusName: '{{$labels.namespace}}/{{$labels.pod}}',
       // TODO: remove `thanosSelector` after 0.10.0 release.
-      thanosSelector: '',
+      thanosSelector: 'job="thanos-sidecar"',
       thanos: {
         targetGroups: {
           namespace: defaults.namespace,
         },
         sidecar: {
-          selector: 'job="thanos-sidecar"',
+          selector: defaults.mixin._config.thanosSelector,
           thanosPrometheusCommonDimensions: 'namespace, pod',
         },
       },


### PR DESCRIPTION
Previous PR #1543 which deprecated `thanosSelector` accidentally broke the
usage of it. This commit restores the old behaviour along with newly
introduced `thanos` config variable.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
