### PR TITLE
Update kubeadm integration of kube-prometheus

### DIFF
--- a/docs/kube-prometheus-on-kubeadm.md
+++ b/docs/kube-prometheus-on-kubeadm.md
@@ -49,7 +49,7 @@ imageRepository: "k8s.gcr.io"
 
 Notice the `.scheduler.extraArgs` and `.controllerManager.extraArgs`. This exposes the `kube-controller-manager` and `kube-scheduler` services to the rest of the cluster. If you have kubernetes core components as pods in the kube-system namespace, ensure that the `kube-prometheus-exporter-kube-scheduler` and `kube-prometheus-exporter-kube-controller-manager` services' `spec.selector` values match those of pods.
 
-In previous versions of Kubernetes, we had to make a change to the `kubelet` setting with regard to `cAdvisor` monitoring on the control-plane as well as all the nodes. But this is **no longer required due to [the change of Kubernetes](https://github.com/kubernetes/kubernetes/issues/56523)**
+In previous versions of Kubernetes, we had to make a change to the `kubelet` setting with regard to `cAdvisor` monitoring on the control-plane as well as all the nodes. But this is **no longer required due to [the change of Kubernetes](https://github.com/kubernetes/kubernetes/issues/56523)**.
 
 In case you already have a Kubernetes deployed with kubeadm, change the address kube-controller-manager and kube-scheduler listens in addition to previous kubelet change:
 

--- a/docs/kube-prometheus-on-kubeadm.md
+++ b/docs/kube-prometheus-on-kubeadm.md
@@ -23,55 +23,39 @@ This guide assumes you have some familiarity with `kubeadm` or at least have dep
 By default, `kubeadm` runs these pods on your master and bound to `127.0.0.1`. There are a couple of ways to change this. The recommended way to change these features is to use the [kubeadm config file](https://kubernetes.io/docs/reference/generated/kubeadm/#config-file). An example configuration file can be used:
 
 ```yaml
-apiVersion: kubeadm.k8s.io/v1alpha1
-kind: MasterConfiguration
-api:
-  advertiseAddress: 192.168.1.173
-  bindPort: 6443
-authorizationModes:
-- Node
-- RBAC
-certificatesDir: /etc/kubernetes/pki
-cloudProvider:
+apiVersion: kubeadm.k8s.io/v1beta2
+kind: ClusterConfiguration
+controlPlaneEndpoint: "192.168.1.173:6443"
+apiServer:
+  extraArgs:
+    authorization-mode: "Node,RBAC"
+controllerManager:
+  extraArgs:
+    bind-address: "0.0.0.0"
+scheduler:
+  extraArgs:
+    bind-address: "0.0.0.0"
+certificatesDir: "/etc/kubernetes/pki"
 etcd:
-  dataDir: /var/lib/etcd
-  endpoints: null
-imageRepository: gcr.io/google_containers
-kubernetesVersion: v1.8.3
+  # one of local or external
+  local:
+    dataDir: "/var/lib/etcd"
+kubernetesVersion: "v1.23.1"
 networking:
-  dnsDomain: cluster.local
-  serviceSubnet: 10.96.0.0/12
-nodeName: your-dev
-tokenTTL: 24h0m0s
-controllerManagerExtraArgs:
-  address: 0.0.0.0
-schedulerExtraArgs:
-  address: 0.0.0.0
+  dnsDomain: "cluster.local"
+  serviceSubnet: "10.96.0.0/12"
+imageRepository: "k8s.gcr.io"
 ```
 
-Notice the `schedulerExtraArgs` and `controllerManagerExtraArgs`. This exposes the `kube-controller-manager` and `kube-scheduler` services to the rest of the cluster. If you have kubernetes core components as pods in the kube-system namespace, ensure that the `kube-prometheus-exporter-kube-scheduler` and `kube-prometheus-exporter-kube-controller-manager` services' `spec.selector` values match those of pods.
+Notice the `.scheduler.extraArgs` and `.controllerManager.extraArgs`. This exposes the `kube-controller-manager` and `kube-scheduler` services to the rest of the cluster. If you have kubernetes core components as pods in the kube-system namespace, ensure that the `kube-prometheus-exporter-kube-scheduler` and `kube-prometheus-exporter-kube-controller-manager` services' `spec.selector` values match those of pods.
 
-In addition, we will be using `node-exporter` to monitor the `cAdvisor` service on all the nodes. This, however requires a change to the `kubelet` service on the master as well as all the nodes. According to the Kubernetes documentation
-
-> The kubeadm deb package ships with configuration for how the kubelet should be run. Note that the `kubeadm` CLI command will never touch this drop-in file. This drop-in file belongs to the kubeadm deb/rpm package.
-
-Again, we need to expose the `cadvisor` that is installed and managed by the `kubelet` daemon and allow webhook token authentication. To do so, we do the following on all the masters and nodes:
-
-```bash
-KUBEADM_SYSTEMD_CONF=/etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-sed -e "/cadvisor-port=0/d" -i "$KUBEADM_SYSTEMD_CONF"
-if ! grep -q "authentication-token-webhook=true" "$KUBEADM_SYSTEMD_CONF"; then
-  sed -e "s/--authorization-mode=Webhook/--authentication-token-webhook=true --authorization-mode=Webhook/" -i "$KUBEADM_SYSTEMD_CONF"
-fi
-systemctl daemon-reload
-systemctl restart kubelet
-```
+In previous versions of Kubernetes, we had to make a change to the `kubelet` setting with regard to `cAdvisor` monitoring on the control-plane as well as all the nodes. But this is **no longer required due to [the change of Kubernetes](https://github.com/kubernetes/kubernetes/issues/56523)**
 
 In case you already have a Kubernetes deployed with kubeadm, change the address kube-controller-manager and kube-scheduler listens in addition to previous kubelet change:
 
 ```
-sed -e "s/- --address=127.0.0.1/- --address=0.0.0.0/" -i /etc/kubernetes/manifests/kube-controller-manager.yaml
-sed -e "s/- --address=127.0.0.1/- --address=0.0.0.0/" -i /etc/kubernetes/manifests/kube-scheduler.yaml
+sed -e "s/- --bind-address=127.0.0.1/- --bind-address=0.0.0.0/" -i /etc/kubernetes/manifests/kube-controller-manager.yaml
+sed -e "s/- --bind-address=127.0.0.1/- --bind-address=0.0.0.0/" -i /etc/kubernetes/manifests/kube-scheduler.yaml
 ```
 
 With these changes, your Kubernetes cluster is ready.


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

In short, this PR fixes https://github.com/prometheus-operator/kube-prometheus/issues/1194

It was reported that kubeadm configuration advisory on this repository is very outdated; it uses `kubeadm.k8s.io/v1alpha1` while the upstream is using `kubeadm.k8s.io/v1beta2` and it has no compatibility with the current state.

I addressed this by introducing the latest kubeadm config spec based on https://pkg.go.dev/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2 and each component's args, as well as removing cAdvisor section entirely as it is no longer required due to https://github.com/kubernetes/kubernetes/issues/56523

## Type of change

- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

- Enhanced kubeadm integration doc to follow the upstream

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->
