### PR TITLE
addon/podsecuritypolicies: Add projected volumes permission

### DIFF
--- a/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
+++ b/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
@@ -16,6 +16,7 @@ local restrictedPodSecurityPolicy = {
       'configMap',
       'emptyDir',
       'secret',
+      'projected',
       // Assume that persistentVolumes set up by the cluster admin are safe to use.
       'persistentVolumeClaim',
     ],


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

The operator started using projected volumes for Prometheus and Alertmanager(See https://github.com/prometheus-operator/prometheus-operator/pull/4427 and https://github.com/prometheus-operator/prometheus-operator/pull/4449). This PR updates the podsecuritypolicy addon, adding the new required permissions


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add projected volumes permissions to podsecuritypolicies addon
```
