### PR TITLE
Update grafana user:password

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Grafana
 $ kubectl --namespace monitoring port-forward svc/grafana 3000
 ```
 
-Then access via [http://localhost:3000](http://localhost:3000) and use the default grafana user:password of `admin:admin`.
+Then access via [http://localhost:3000](http://localhost:3000) and use the grafana user:password of `admin:prom-operator`.
 
 Alert Manager
 


### PR DESCRIPTION


<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

It seems the documentation for user:password was outdated, since the password actually working in grafana is `prom-operator` and not the default, `admin`

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Updated docs to reflect grafana user:password defaults
```
