### PR TITLE
Document security audit exceptions for node-exporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ kubeconform: crdschemas manifests $(KUBECONFORM_BIN)
 	$(KUBECONFORM_BIN) -kubernetes-version $(KUBE_VERSION) -schema-location 'default' -schema-location 'crdschemas/{{ .ResourceKind }}.json' -skip CustomResourceDefinition manifests/
 
 .PHONY: kubescape
-kubescape: $(KUBESCAPE_BIN) ## Runs a security analysis on generated manifests - failing if risk score is above 40%
-	$(KUBESCAPE_BIN) scan -s framework -t 30 nsa manifests/*.yaml
+kubescape: $(KUBESCAPE_BIN) ## Runs a security analysis on generated manifests - failing if risk score is above threshold percentage 't'
+	$(KUBESCAPE_BIN) scan -s framework -t 25 nsa manifests/*.yaml --exceptions 'kubescape-exceptions.json'
 
 .PHONY: fmt
 fmt: $(JSONNETFMT_BIN)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ If you are migrating from `release-0.7` branch or earlier please read [what chan
   - [Customization Examples](#customization-examples)
   - [Minikube Example](#minikube-example)
   - [Continuous Delivery](#continuous-delivery)
+  - [Security](docs/security.md)
   - [Troubleshooting](#troubleshooting)
     - [Error retrieving kubelet metrics](#error-retrieving-kubelet-metrics)
       - [Authentication problem](#authentication-problem)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,11 @@
+## Security
+
+The manifests generated in this repository are subject to a security audit in CI via [kubescape](https://github.com/armosec/kubescape).
+The scan can be run locally via `make kubescape`.
+
+While we aim for best practices in terms of security by default, due to the nature of the project, we are required to make the exceptions in the following components:
+
+#### node-exporter
+* Host Port is set. https://hub.armo.cloud/docs/c-0044 is not relevant since node-exporter is considered as a core platform component running as a DaemonSet.
+* Host PID is set to `true`, since node-exporter requires direct access to the host namespace to gather statistics.
+* Host Network is set to `true`, since node-exporter requires direct access to the host network to gather statistics.

--- a/kubescape-exceptions.json
+++ b/kubescape-exceptions.json
@@ -1,0 +1,29 @@
+[
+  {
+    "name": "exclude-node-exporter-host-access-checks",
+    "policyType": "postureExceptionPolicy",
+    "actions": [
+      "alertOnly"
+    ],
+    "resources": [
+      {
+        "designatorType": "Attributes",
+        "attributes": {
+          "kind": "DaemonSet",
+          "name": "node-exporter"
+        }
+      }
+    ],
+    "posturePolicies": [
+      {
+        "controlName": "Container hostPort"
+      },
+      {
+        "controlName": "Host PID/IPC privileges"
+      },
+      {
+        "controlName": "HostNetwork access"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Because of the nature of node-exporter, we must add some exceptions to the security scan of the manifests.

This change adds those, documents the nuances and lowers the threshold appropriately for CI

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

