### PR TITLE
disable injecting unnecessary variables allowing access to k8s API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ JSONNETFMT_ARGS=-n 2 --max-blank-lines 2 --string-style s --comment-style s
 MDOX_VALIDATE_CONFIG?=.mdox.validate.yaml
 MD_FILES_TO_FORMAT=$(shell find docs developer-workspace examples experimental jsonnet manifests -name "*.md") $(shell ls *.md)
 
+KUBESCAPE_THRESHOLD=9
+
 all: generate fmt test docs
 
 .PHONY: clean
@@ -66,7 +68,7 @@ kubeconform: crdschemas manifests $(KUBECONFORM_BIN)
 
 .PHONY: kubescape
 kubescape: $(KUBESCAPE_BIN) ## Runs a security analysis on generated manifests - failing if risk score is above threshold percentage 't'
-	$(KUBESCAPE_BIN) scan -s framework -t 17 nsa manifests/*.yaml --exceptions 'kubescape-exceptions.json'
+	$(KUBESCAPE_BIN) scan -s framework -t $(KUBESCAPE_THRESHOLD) nsa manifests/*.yaml --exceptions 'kubescape-exceptions.json'
 
 .PHONY: fmt
 fmt: $(JSONNETFMT_BIN)

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,3 +9,16 @@ While we aim for best practices in terms of security by default, due to the natu
 * Host Port is set. https://hub.armo.cloud/docs/c-0044 is not relevant since node-exporter is considered as a core platform component running as a DaemonSet.
 * Host PID is set to `true`, since node-exporter requires direct access to the host namespace to gather statistics.
 * Host Network is set to `true`, since node-exporter requires direct access to the host network to gather statistics.
+* `automountServiceAccountToken` is set to `true` on Pod level as kube-rbac-proxy sidecar requires connection to kubernetes API server.
+
+#### prometheus-adapter
+* `automountServiceAccountToken` is set to `true` on Pod level as application requires connection to kubernetes API server.
+
+#### blackbox-exporter
+* `automountServiceAccountToken` is set to `true` on Pod level as kube-rbac-proxy sidecar requires connection to kubernetes API server.
+
+#### kube-state-metrics
+* `automountServiceAccountToken` is set to `true` on Pod level as kube-rbac-proxy sidecars requires connection to kubernetes API server.
+
+#### prometheus-operator
+* `automountServiceAccountToken` is set to `true` on Pod level as kube-rbac-proxy sidecars requires connection to kubernetes API server.

--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -121,6 +121,7 @@ function(params) {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
     metadata: am._metadata,
+    automountServiceAccountToken: false,
   },
 
   service: {

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -115,6 +115,7 @@ function(params) {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
     metadata: bb._metadata,
+    automountServiceAccountToken: false,
   },
 
   clusterRole: {
@@ -238,6 +239,7 @@ function(params) {
           spec: {
             containers: [blackboxExporter, reloader, kubeRbacProxy],
             nodeSelector: { 'kubernetes.io/os': 'linux' },
+            automountServiceAccountToken: true,
             serviceAccountName: 'blackbox-exporter',
             volumes: [{
               name: 'config',

--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -88,10 +88,12 @@ function(params)
     // 'allowPrivilegeEscalation: false' can be deleted when https://github.com/brancz/kubernetes-grafana/pull/128 gets merged.
     // 'readOnlyRootFilesystem: true' can be deleted when https://github.com/brancz/kubernetes-grafana/pull/129 gets merged.
     // 'capabilities: { drop: ['ALL'] }' can be deleted when https://github.com/brancz/kubernetes-grafana/pull/130 gets merged.
+    // FIXME(paulfantom): `automountServiceAccountToken` can be removed after porting to brancz/kuberentes-grafana
     deployment+: {
       spec+: {
         template+: {
           spec+: {
+            automountServiceAccountToken: false,
             containers: std.map(function(c) c {
               securityContext+: {
                 allowPrivilegeEscalation: false,

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -129,6 +129,7 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
           },
         },
         spec+: {
+          automountServiceAccountToken: true,
           containers: std.map(function(c) c {
             ports:: null,
             livenessProbe:: null,

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -114,6 +114,7 @@ function(params) {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
     metadata: ne._metadata,
+    automountServiceAccountToken: false,
   },
 
   service: {
@@ -240,6 +241,7 @@ function(params) {
               { name: 'sys', hostPath: { path: '/sys' } },
               { name: 'root', hostPath: { path: '/' } },
             ],
+            automountServiceAccountToken: true,
             serviceAccountName: ne._config.name,
             securityContext: {
               runAsUser: 65534,

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -253,6 +253,7 @@ function(params) {
           spec: {
             containers: [c],
             serviceAccountName: $.serviceAccount.metadata.name,
+            automountServiceAccountToken: true,
             nodeSelector: { 'kubernetes.io/os': 'linux' },
             volumes: [
               { name: 'tmpfs', emptyDir: {} },
@@ -268,6 +269,7 @@ function(params) {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
     metadata: pa._metadata,
+    automountServiceAccountToken: false,
   },
 
   clusterRole: {

--- a/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
@@ -131,6 +131,7 @@ function(params)
       spec+: {
         template+: {
           spec+: {
+            automountServiceAccountToken: true,
             containers: std.map(function(c) c {
               securityContext+: {
                 capabilities: { drop: ['ALL'] },

--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -98,6 +98,7 @@ function(params) {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
     metadata: p._metadata,
+    automountServiceAccountToken: false,
   },
 
   service: {

--- a/kubescape-exceptions.json
+++ b/kubescape-exceptions.json
@@ -1,5 +1,54 @@
 [
   {
+    "name": "exclude-automountServiceAccountToken-checks",
+    "policyType": "postureExceptionPolicy",
+    "actions": [
+      "alertOnly"
+    ],
+    "resources": [
+      {
+        "designatorType": "Attributes",
+        "attributes": {
+          "kind": "DaemonSet",
+          "name": "node-exporter"
+        }
+      },
+      {
+        "designatorType": "Attributes",
+        "attributes": {
+          "kind": "Deployment",
+          "name": "blackbox-exporter"
+        }
+      },
+      {
+        "designatorType": "Attributes",
+        "attributes": {
+          "kind": "Deployment",
+          "name": "kube-state-metrics"
+        }
+      },
+      {
+        "designatorType": "Attributes",
+        "attributes": {
+          "kind": "Deployment",
+          "name": "prometheus-adapter"
+        }
+      },
+      {
+        "designatorType": "Attributes",
+        "attributes": {
+          "kind": "Deployment",
+          "name": "prometheus-operator"
+        }
+      }
+    ],
+    "posturePolicies": [
+      {
+        "controlName": "Automatic mapping of service account"
+      }
+    ]
+  },
+  {
     "name": "exclude-node-exporter-host-access-checks",
     "policyType": "postureExceptionPolicy",
     "actions": [

--- a/manifests/alertmanager-serviceAccount.yaml
+++ b/manifests/alertmanager-serviceAccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:

--- a/manifests/blackboxExporter-deployment.yaml
+++ b/manifests/blackboxExporter-deployment.yaml
@@ -25,6 +25,7 @@ spec:
         app.kubernetes.io/part-of: kube-prometheus
         app.kubernetes.io/version: 0.19.0
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --config.file=/etc/blackbox_exporter/config.yml

--- a/manifests/blackboxExporter-serviceAccount.yaml
+++ b/manifests/blackboxExporter-serviceAccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         app.kubernetes.io/part-of: kube-prometheus
         app.kubernetes.io/version: 8.3.4
     spec:
+      automountServiceAccountToken: false
       containers:
       - env: []
         image: grafana/grafana:8.3.4

--- a/manifests/nodeExporter-daemonset.yaml
+++ b/manifests/nodeExporter-daemonset.yaml
@@ -24,6 +24,7 @@ spec:
         app.kubernetes.io/part-of: kube-prometheus
         app.kubernetes.io/version: 1.3.1
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --web.listen-address=127.0.0.1:9100

--- a/manifests/nodeExporter-serviceAccount.yaml
+++ b/manifests/nodeExporter-serviceAccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:

--- a/manifests/prometheus-serviceAccount.yaml
+++ b/manifests/prometheus-serviceAccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:

--- a/manifests/prometheusAdapter-deployment.yaml
+++ b/manifests/prometheusAdapter-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         app.kubernetes.io/part-of: kube-prometheus
         app.kubernetes.io/version: 0.9.1
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --cert-dir=/var/run/serving-cert

--- a/manifests/prometheusAdapter-serviceAccount.yaml
+++ b/manifests/prometheusAdapter-serviceAccount.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

This will explicitly specify which applications need SA token and which do not need it.

Due to how prometheus server is managed, this PR requires https://github.com/prometheus-operator/prometheus-operator/pull/4514 to be merged first.

This is a part of https://github.com/prometheus-operator/kube-prometheus/issues/1589

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Specify SA token automounting on pod-level where necessary
```
