### PR TITLE
Explicitly declare allowPrivilegeEscalation to false in all components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ kubeconform: crdschemas manifests $(KUBECONFORM_BIN)
 
 .PHONY: kubescape
 kubescape: $(KUBESCAPE_BIN) ## Runs a security analysis on generated manifests - failing if risk score is above 40%
-	$(KUBESCAPE_BIN) scan -s framework -t 40 nsa manifests/*.yaml
+	$(KUBESCAPE_BIN) scan -s framework -t 30 nsa manifests/*.yaml
 
 .PHONY: fmt
 fmt: $(JSONNETFMT_BIN)

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -172,6 +172,7 @@ function(params) {
       } else {
         runAsNonRoot: true,
         runAsUser: 65534,
+        allowPrivilegeEscalation: false,
       },
       volumeMounts: [{
         mountPath: '/etc/blackbox_exporter/',
@@ -188,7 +189,11 @@ function(params) {
         '--volume-dir=/etc/blackbox_exporter/',
       ],
       resources: bb._config.resources,
-      securityContext: { runAsNonRoot: true, runAsUser: 65534 },
+      securityContext: {
+        runAsNonRoot: true,
+        runAsUser: 65534,
+        allowPrivilegeEscalation: false,
+      },
       terminationMessagePath: '/dev/termination-log',
       terminationMessagePolicy: 'FallbackToLogsOnError',
       volumeMounts: [{

--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -83,4 +83,20 @@ function(params)
         }],
       },
     },
+
+    // FIXME(ArthurSens): The override adding 'allowPrivilegeEscalation: false' can be deleted when
+    // https://github.com/brancz/kubernetes-grafana/pull/128 gets merged.
+    deployment+: {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: std.map(function(c) c {
+              securityContext+: {
+                allowPrivilegeEscalation: false,
+              },
+            }, super.containers),
+          },
+        },
+      },
+    },
   }

--- a/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet
@@ -61,5 +61,6 @@ function(params) {
     runAsUser: 65532,
     runAsGroup: 65532,
     runAsNonRoot: true,
+    allowPrivilegeEscalation: false,
   },
 }

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -118,6 +118,8 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
     image: ksm._config.kubeRbacProxyImage,
   }),
 
+  // FIXME(ArthurSens): The override adding 'allowPrivilegeEscalation: false' can be deleted when
+  // https://github.com/kubernetes/kube-state-metrics/pull/1668 gets merged.
   deployment+: {
     spec+: {
       template+: {
@@ -133,6 +135,9 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
             readinessProbe:: null,
             args: ['--host=127.0.0.1', '--port=8081', '--telemetry-host=127.0.0.1', '--telemetry-port=8082'],
             resources: ksm._config.resources,
+            securityContext+: {
+              allowPrivilegeEscalation: false,
+            },
           }, super.containers) + [kubeRbacProxyMain, kubeRbacProxySelf],
         },
       },

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -181,6 +181,9 @@ function(params) {
         { name: 'root', mountPath: '/host/root', mountPropagation: 'HostToContainer', readOnly: true },
       ],
       resources: ne._config.resources,
+      securityContext: {
+        allowPrivilegeEscalation: false,
+      },
     };
 
     local kubeRbacProxy = krp({

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -226,6 +226,9 @@ function(params) {
         { name: 'volume-serving-cert', mountPath: '/var/run/serving-cert', readOnly: false },
         { name: 'config', mountPath: '/etc/adapter', readOnly: false },
       ],
+      securityContext: {
+        allowPrivilegeEscalation: false,
+      },
     };
 
     {

--- a/manifests/blackboxExporter-deployment.yaml
+++ b/manifests/blackboxExporter-deployment.yaml
@@ -42,6 +42,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsNonRoot: true
           runAsUser: 65534
         volumeMounts:
@@ -61,6 +62,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsNonRoot: true
           runAsUser: 65534
         terminationMessagePath: /dev/termination-log
@@ -87,6 +89,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -45,6 +45,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /var/lib/grafana
           name: grafana-storage

--- a/manifests/kubeStateMetrics-deployment.yaml
+++ b/manifests/kubeStateMetrics-deployment.yaml
@@ -41,6 +41,7 @@ spec:
             cpu: 10m
             memory: 190Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsUser: 65534
       - args:
         - --logtostderr
@@ -60,6 +61,7 @@ spec:
             cpu: 20m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -81,6 +83,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532

--- a/manifests/nodeExporter-daemonset.yaml
+++ b/manifests/nodeExporter-daemonset.yaml
@@ -43,6 +43,8 @@ spec:
           requests:
             cpu: 102m
             memory: 180Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /host/sys
           mountPropagation: HostToContainer
@@ -76,6 +78,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532

--- a/manifests/prometheusAdapter-deployment.yaml
+++ b/manifests/prometheusAdapter-deployment.yaml
@@ -47,6 +47,8 @@ spec:
           requests:
             cpu: 102m
             memory: 180Mi
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - mountPath: /tmp
           name: tmpfs

--- a/manifests/prometheusOperator-deployment.yaml
+++ b/manifests/prometheusOperator-deployment.yaml
@@ -61,6 +61,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         securityContext:
+          allowPrivilegeEscalation: false
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532


### PR DESCRIPTION
## Description
Looking at [Kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/), if a container isn't running as privileged and don't have `CAP_SYS_ADMIN` capabilities, then Kubernetes already sets the `allowPrivilegeEscalation` to false by default.

Kubescape asks us to explicitly declare it false anyway, I believe the intention is to future-guard against the kubernetes behavior changes for some reason.

I've run kube-prometheus from this PR in kind, the whole stack was able to run smoothly without errors. Metrics are getting collected and scraped without problems as well.

The only thing I haven't tested by hand was the privileged blackbox-exporter since I don't use it, personally.

Fixes #1588 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Explicitly declare allowPrivilegeEscalation to false in all components, decreasing threat risk.
```
