### PR TITLE
workflows/versions: Enable auto-merge

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -45,6 +45,7 @@ jobs:
         fi
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
+      id: cpr
       with:
         commit-message: "[bot] [${{ matrix.branch }}] Automated version update"
         title: "[bot] [${{ matrix.branch }}] Automated version update"
@@ -77,3 +78,9 @@ jobs:
         # GITHUB_TOKEN cannot be used as it won't trigger CI in a created PR
         # More in https://github.com/peter-evans/create-pull-request/issues/155
         token: ${{ secrets.PROM_OP_BOT_PAT }}
+
+    - name: Enable auto-merge
+      uses: peter-evans/enable-pull-request-automerge@v1
+      with:
+        token: ${{ secrets.PROM_OP_BOT_PAT }}
+        pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Description

We've introduced the workflow that updates our dependencies and components version to reduce the maintenance effort of doing so manually.

Looking at all PRs opened by this automation, it doesn't seem that any of them got rejected because it would have broken the stack. With that in mind, I believe we can further automate the workflow by enabling auto-merge, only to the PRs created by this workflow.

Auto-merge needs to be enabled for the repository though, it can be done so in the [repository settings](https://github.com/prometheus-operator/kube-prometheus/settings) if you have access to it (I don't)
![image](https://user-images.githubusercontent.com/24193764/151008136-618550fb-03a0-45b5-b11c-cd41c3800928.png)




## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
