### PR TITLE
components/*: Forbid write access to root filesystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ kubeconform: crdschemas manifests $(KUBECONFORM_BIN)
 
 .PHONY: kubescape
 kubescape: $(KUBESCAPE_BIN) ## Runs a security analysis on generated manifests - failing if risk score is above threshold percentage 't'
-	$(KUBESCAPE_BIN) scan -s framework -t 25 nsa manifests/*.yaml --exceptions 'kubescape-exceptions.json'
+	$(KUBESCAPE_BIN) scan -s framework -t 20 nsa manifests/*.yaml --exceptions 'kubescape-exceptions.json'
 
 .PHONY: fmt
 fmt: $(JSONNETFMT_BIN)

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -169,10 +169,12 @@ function(params) {
       securityContext: if bb._config.privileged then {
         runAsNonRoot: false,
         capabilities: { drop: ['ALL'], add: ['NET_RAW'] },
+        readOnlyRootFilesystem: true,
       } else {
         runAsNonRoot: true,
         runAsUser: 65534,
         allowPrivilegeEscalation: false,
+        readOnlyRootFilesystem: true,
       },
       volumeMounts: [{
         mountPath: '/etc/blackbox_exporter/',
@@ -193,6 +195,7 @@ function(params) {
         runAsNonRoot: true,
         runAsUser: 65534,
         allowPrivilegeEscalation: false,
+        readOnlyRootFilesystem: true,
       },
       terminationMessagePath: '/dev/termination-log',
       terminationMessagePolicy: 'FallbackToLogsOnError',

--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -84,8 +84,9 @@ function(params)
       },
     },
 
-    // FIXME(ArthurSens): The override adding 'allowPrivilegeEscalation: false' can be deleted when
-    // https://github.com/brancz/kubernetes-grafana/pull/128 gets merged.
+    // FIXME(ArthurSens): The securityContext overrides can be removed after some PRs get merged
+    // 'allowPrivilegeEscalation: false' can be deleted when https://github.com/brancz/kubernetes-grafana/pull/128 gets merged.
+    // 'readOnlyRootFilesystem: true' can be deleted when https://github.com/brancz/kubernetes-grafana/pull/129 gets merged.
     deployment+: {
       spec+: {
         template+: {
@@ -93,6 +94,7 @@ function(params)
             containers: std.map(function(c) c {
               securityContext+: {
                 allowPrivilegeEscalation: false,
+                readOnlyRootFilesystem: true,
               },
             }, super.containers),
           },

--- a/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet
@@ -62,5 +62,6 @@ function(params) {
     runAsGroup: 65532,
     runAsNonRoot: true,
     allowPrivilegeEscalation: false,
+    readOnlyRootFilesystem: true,
   },
 }

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -118,8 +118,9 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
     image: ksm._config.kubeRbacProxyImage,
   }),
 
-  // FIXME(ArthurSens): The override adding 'allowPrivilegeEscalation: false' can be deleted when
-  // https://github.com/kubernetes/kube-state-metrics/pull/1668 gets merged.
+  // FIXME(ArthurSens): The securityContext overrides can be removed after some PRs get merged
+  // 'allowPrivilegeEscalation: false' can be deleted when https://github.com/kubernetes/kube-state-metrics/pull/1668 gets merged.
+  // 'readOnlyRootFilesystem: true' can be deleted when https://github.com/kubernetes/kube-state-metrics/pull/1671 gets merged.
   deployment+: {
     spec+: {
       template+: {
@@ -137,6 +138,7 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
             resources: ksm._config.resources,
             securityContext+: {
               allowPrivilegeEscalation: false,
+              readOnlyRootFilesystem: true,
             },
           }, super.containers) + [kubeRbacProxyMain, kubeRbacProxySelf],
         },

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -183,6 +183,7 @@ function(params) {
       resources: ne._config.resources,
       securityContext: {
         allowPrivilegeEscalation: false,
+        readOnlyRootFilesystem: true,
       },
     };
 

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -228,6 +228,7 @@ function(params) {
       ],
       securityContext: {
         allowPrivilegeEscalation: false,
+        readOnlyRootFilesystem: true,
       },
     };
 

--- a/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
@@ -125,11 +125,17 @@ function(params)
       image: po._config.kubeRbacProxyImage,
     }),
 
+    // FIXME(ArthurSens): The securityContext overrides can be removed after some PRs get merged
+    // 'readOnlyRootFilesystem: true' can be deleted when https://github.com/prometheus-operator/prometheus-operator/pull/4531 gets merged.
     deployment+: {
       spec+: {
         template+: {
           spec+: {
-            containers+: [kubeRbacProxy],
+            containers: std.map(function(c) c {
+              securityContext+: {
+                readOnlyRootFilesystem: true,
+              },
+            }, super.containers) + [kubeRbacProxy],
           },
         },
       },

--- a/manifests/blackboxExporter-deployment.yaml
+++ b/manifests/blackboxExporter-deployment.yaml
@@ -43,6 +43,7 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
         volumeMounts:
@@ -63,6 +64,7 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
         terminationMessagePath: /dev/termination-log
@@ -90,6 +92,7 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -47,6 +47,7 @@ spec:
             memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /var/lib/grafana
           name: grafana-storage

--- a/manifests/kubeStateMetrics-deployment.yaml
+++ b/manifests/kubeStateMetrics-deployment.yaml
@@ -43,6 +43,7 @@ spec:
             memory: 190Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsUser: 65534
       - args:
         - --logtostderr
@@ -63,6 +64,7 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
@@ -85,6 +87,7 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532

--- a/manifests/nodeExporter-daemonset.yaml
+++ b/manifests/nodeExporter-daemonset.yaml
@@ -45,6 +45,7 @@ spec:
             memory: 180Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /host/sys
           mountPropagation: HostToContainer
@@ -79,6 +80,7 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532

--- a/manifests/prometheusAdapter-deployment.yaml
+++ b/manifests/prometheusAdapter-deployment.yaml
@@ -49,6 +49,7 @@ spec:
             memory: 180Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp
           name: tmpfs

--- a/manifests/prometheusOperator-deployment.yaml
+++ b/manifests/prometheusOperator-deployment.yaml
@@ -44,6 +44,7 @@ spec:
             memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
       - args:
         - --logtostderr
         - --secure-listen-address=:8443
@@ -63,6 +64,7 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532


### PR DESCRIPTION
## Description

This is part of the initiative to tighten security in kube-prometheus - prometheus-operator/kube-prometheus#1595.

An attacker who has access to a container, can create files and download scripts as he wishes, and modify the underlying application running on the container. If a container needs to write to the filesystem, a strict volume mount should be used.

Following remediation docs from https://hub.armo.cloud/docs/c-0017

Fixes #1595

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Forbid write access to root filesystem for all components
```
