### PR TITLE
Revert "workflows/versions: Enable auto-merge"

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -45,7 +45,6 @@ jobs:
         fi
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
-      id: cpr
       with:
         commit-message: "[bot] [${{ matrix.branch }}] Automated version update"
         title: "[bot] [${{ matrix.branch }}] Automated version update"
@@ -78,9 +77,3 @@ jobs:
         # GITHUB_TOKEN cannot be used as it won't trigger CI in a created PR
         # More in https://github.com/peter-evans/create-pull-request/issues/155
         token: ${{ secrets.PROM_OP_BOT_PAT }}
-
-    - name: Enable auto-merge
-      uses: peter-evans/enable-pull-request-automerge@v1
-      with:
-        token: ${{ secrets.PROM_OP_BOT_PAT }}
-        pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
This reverts commit f0d9be27b3722bb4adf9279576e472b40c97311b.

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Reverting #1598 as it seems to break the update workflow. More in https://github.com/prometheus-operator/kube-prometheus/actions/runs/1771374196

cc @ArthurSens 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
