### PR TITLE
jsonnet: filter out kube-proxy alerts when kube-proxy is disabled

### DIFF
--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -37,6 +37,14 @@ function(params) {
 
   mixin:: (import 'github.com/kubernetes-monitoring/kubernetes-mixin/mixin.libsonnet') {
     _config+:: k8s._config.mixin._config,
+  } + {
+    // Filter-out alerts related to kube-proxy when `kubeProxy: false`
+    [if !(defaults + params).kubeProxy then 'prometheusAlerts']+:: {
+      groups: std.filter(
+        function(g) !std.member(['kubernetes-system-kube-proxy'], g.name),
+        super.groups
+      ),
+    },
   },
 
   prometheusRule: {

--- a/manifests/kubernetesControlPlane-prometheusRule.yaml
+++ b/manifests/kubernetesControlPlane-prometheusRule.yaml
@@ -752,18 +752,6 @@ spec:
       for: 15m
       labels:
         severity: critical
-  - name: kubernetes-system-kube-proxy
-    rules:
-    - alert: KubeProxyDown
-      annotations:
-        description: KubeProxy has disappeared from Prometheus target discovery.
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeproxydown
-        summary: Target disappeared from Prometheus target discovery.
-      expr: |
-        absent(up{job="kube-proxy"} == 1)
-      for: 15m
-      labels:
-        severity: critical
   - name: kube-apiserver-burnrate.rules
     rules:
     - expr: |


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Fixes #1602 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Do not include kube-proxy alerts when kubeProxy is not enabled
```
