### PR TITLE
Drop Linux capabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ kubeconform: crdschemas manifests $(KUBECONFORM_BIN)
 
 .PHONY: kubescape
 kubescape: $(KUBESCAPE_BIN) ## Runs a security analysis on generated manifests - failing if risk score is above threshold percentage 't'
-	$(KUBESCAPE_BIN) scan -s framework -t 20 nsa manifests/*.yaml --exceptions 'kubescape-exceptions.json'
+	$(KUBESCAPE_BIN) scan -s framework -t 16 nsa manifests/*.yaml --exceptions 'kubescape-exceptions.json'
 
 .PHONY: fmt
 fmt: $(JSONNETFMT_BIN)

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -175,6 +175,7 @@ function(params) {
         runAsUser: 65534,
         allowPrivilegeEscalation: false,
         readOnlyRootFilesystem: true,
+        capabilities: { drop: ['ALL'] },
       },
       volumeMounts: [{
         mountPath: '/etc/blackbox_exporter/',
@@ -196,6 +197,7 @@ function(params) {
         runAsUser: 65534,
         allowPrivilegeEscalation: false,
         readOnlyRootFilesystem: true,
+        capabilities: { drop: ['ALL'] },
       },
       terminationMessagePath: '/dev/termination-log',
       terminationMessagePolicy: 'FallbackToLogsOnError',

--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -87,6 +87,7 @@ function(params)
     // FIXME(ArthurSens): The securityContext overrides can be removed after some PRs get merged
     // 'allowPrivilegeEscalation: false' can be deleted when https://github.com/brancz/kubernetes-grafana/pull/128 gets merged.
     // 'readOnlyRootFilesystem: true' can be deleted when https://github.com/brancz/kubernetes-grafana/pull/129 gets merged.
+    // 'capabilities: { drop: ['ALL'] }' can be deleted when https://github.com/brancz/kubernetes-grafana/pull/130 gets merged.
     deployment+: {
       spec+: {
         template+: {
@@ -95,6 +96,7 @@ function(params)
               securityContext+: {
                 allowPrivilegeEscalation: false,
                 readOnlyRootFilesystem: true,
+                capabilities: { drop: ['ALL'] },
               },
             }, super.containers),
           },

--- a/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet
@@ -63,5 +63,6 @@ function(params) {
     runAsNonRoot: true,
     allowPrivilegeEscalation: false,
     readOnlyRootFilesystem: true,
+    capabilities: { drop: ['ALL'] },
   },
 }

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -118,6 +118,8 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
     image: ksm._config.kubeRbacProxyImage,
   }),
 
+  // FIXME(ArthurSens): The securityContext overrides can be removed after some PRs get merged
+  // 'capabilities: { drop: ['ALL'] },' can be deleted when https://github.com/kubernetes/kube-state-metrics/pull/1674 gets merged.
   deployment+: {
     spec+: {
       template+: {
@@ -133,6 +135,9 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
             readinessProbe:: null,
             args: ['--host=127.0.0.1', '--port=8081', '--telemetry-host=127.0.0.1', '--telemetry-port=8082'],
             resources: ksm._config.resources,
+            securityContext+: {
+              capabilities: { drop: ['ALL'] },
+            },
           }, super.containers) + [kubeRbacProxyMain, kubeRbacProxySelf],
         },
       },

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -184,6 +184,7 @@ function(params) {
       securityContext: {
         allowPrivilegeEscalation: false,
         readOnlyRootFilesystem: true,
+        capabilities: { drop: ['ALL'], add: ['CAP_SYS_TIME'] },
       },
     };
 

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -229,6 +229,7 @@ function(params) {
       securityContext: {
         allowPrivilegeEscalation: false,
         readOnlyRootFilesystem: true,
+        capabilities: { drop: ['ALL'] },
       },
     };
 

--- a/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
@@ -125,11 +125,17 @@ function(params)
       image: po._config.kubeRbacProxyImage,
     }),
 
+    // FIXME(ArthurSens): The securityContext overrides can be removed after some PRs get merged
+    // 'capabilities: { drop: ['ALL'] },' can be deleted when https://github.com/prometheus-operator/prometheus-operator/pull/4546 gets merged.
     deployment+: {
       spec+: {
         template+: {
           spec+: {
-            containers+: [kubeRbacProxy],
+            containers: std.map(function(c) c {
+              securityContext+: {
+                capabilities: { drop: ['ALL'] },
+              },
+            }, super.containers) + [kubeRbacProxy],
           },
         },
       },

--- a/manifests/blackboxExporter-deployment.yaml
+++ b/manifests/blackboxExporter-deployment.yaml
@@ -43,6 +43,9 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
@@ -64,6 +67,9 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 65534
@@ -92,6 +98,9 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
           runAsGroup: 65532
           runAsNonRoot: true

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -47,6 +47,9 @@ spec:
             memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /var/lib/grafana

--- a/manifests/kubeStateMetrics-deployment.yaml
+++ b/manifests/kubeStateMetrics-deployment.yaml
@@ -43,6 +43,9 @@ spec:
             memory: 190Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
           runAsUser: 65534
       - args:
@@ -64,6 +67,9 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
           runAsGroup: 65532
           runAsNonRoot: true
@@ -87,6 +93,9 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
           runAsGroup: 65532
           runAsNonRoot: true

--- a/manifests/nodeExporter-daemonset.yaml
+++ b/manifests/nodeExporter-daemonset.yaml
@@ -45,6 +45,11 @@ spec:
             memory: 180Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - CAP_SYS_TIME
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /host/sys
@@ -80,6 +85,9 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
           runAsGroup: 65532
           runAsNonRoot: true

--- a/manifests/prometheusAdapter-deployment.yaml
+++ b/manifests/prometheusAdapter-deployment.yaml
@@ -49,6 +49,9 @@ spec:
             memory: 180Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
         volumeMounts:
         - mountPath: /tmp

--- a/manifests/prometheusOperator-deployment.yaml
+++ b/manifests/prometheusOperator-deployment.yaml
@@ -44,6 +44,9 @@ spec:
             memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
       - args:
         - --logtostderr
@@ -64,6 +67,9 @@ spec:
             memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
           runAsGroup: 65532
           runAsNonRoot: true


### PR DESCRIPTION
## Description
This is part of the initiative to tighten security in kube-prometheus

We're reducing the attack surface by dropping all Linux capabilities of all components, just keeping `CAP_SYS_TIME` for node-exporter because it is required by the time collector.

Following remediation docs from https://hub.armo.cloud/docs/c-0055

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Reduce attack surface by dropping unnecessary Linux capabilities
```
