### PR TITLE
Remove hostPort from node-export daemonset

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -6,6 +6,6 @@ The scan can be run locally via `make kubescape`.
 While we aim for best practices in terms of security by default, due to the nature of the project, we are required to make the exceptions in the following components:
 
 #### node-exporter
-* Host Port is set. https://hub.armo.cloud/docs/c-0044 is not relevant since node-exporter is considered as a core platform component running as a DaemonSet.
+* Host Port is set. [Kubernetes already sets a Host Port by default when Host Network is enabled.](https://github.com/kubernetes/kubernetes/blob/1945829906546caf867992669a0bfa588edf8be6/pkg/apis/core/v1/defaults.go#L402-L411). Since nothing can be done here, we configure it to our preference port.
 * Host PID is set to `true`, since node-exporter requires direct access to the host namespace to gather statistics.
 * Host Network is set to `true`, since node-exporter requires direct access to the host network to gather statistics.

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -201,6 +201,12 @@ function(params) {
       // used by the service is tied to the proxy container. We *could*
       // forgo declaring the host port, however it is important to declare
       // it so that the scheduler can decide if the pod is schedulable.
+      //
+      // Although hostPort might not seem necessary, kubernetes adds it anyway
+      // when running with 'hostNetwork'. We might as well make sure it works
+      // the way we want.
+      //
+      // See also: https://github.com/kubernetes/kubernetes/blob/1945829906546caf867992669a0bfa588edf8be6/pkg/apis/core/v1/defaults.go#L402-L411
       ports: [
         { name: 'https', containerPort: ne._config.port, hostPort: ne._config.port },
       ],


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

HostPort can cause different scheduling problems as documented here: https://hub.armo.cloud/docs/c-0044

The node-exporter pod doesn't have any requirements to have that enabled, so let's just get rid of it (for some reason it is kube-rbac-proxy that has the HostPort set as a workaround)


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Remove hostPort from node-exporter daemonset
```
