### PR TITLE
Sanitize all regex denylist in ksm-lite addon

### DIFF
--- a/jsonnet/kube-prometheus/addons/ksm-lite.libsonnet
+++ b/jsonnet/kube-prometheus/addons/ksm-lite.libsonnet
@@ -16,17 +16,17 @@ local addArgs(args, name, containers) = std.map(
             containers: addArgs(
               [|||
                 --metric-denylist=
-                kube_.+_created,
-                kube_.+_metadata_resource_version,
-                kube_replicaset_metadata_generation,
-                kube_replicaset_status_observed_generation,
-                kube_pod_restart_policy,
-                kube_pod_init_container_status_terminated$,
-                kube_pod_init_container_status_running,
-                kube_pod_container_status_terminated$,
-                kube_pod_container_status_running,
-                kube_pod_completion_time,
-                kube_pod_status_scheduled$
+                ^kube_.+_created$,
+                ^kube_.+_metadata_resource_version$,
+                ^kube_replicaset_metadata_generation$,
+                ^kube_replicaset_status_observed_generation$,
+                ^kube_pod_restart_policy$,
+                ^kube_pod_init_container_status_terminated$,
+                ^kube_pod_init_container_status_running$,
+                ^kube_pod_container_status_terminated$,
+                ^kube_pod_container_status_running$,
+                ^kube_pod_completion_time$,
+                ^kube_pod_status_scheduled$
               |||],
               'kube-state-metrics',
               super.containers


### PR DESCRIPTION
This is a follow up fix of https://github.com/prometheus-operator/kube-prometheus/pull/1613. @simonpasquier recommended to sanitize all denylist metrics.

Signed-off-by: Arunprasad Rajkumar <arajkuma@redhat.com>

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Sanitize all regex denylist in ksm-lite addon
```
