### PR TITLE
fix cluster:node_cpu:ratio query

### DIFF
--- a/jsonnet/kube-prometheus/components/mixin/rules/node-rules.libsonnet
+++ b/jsonnet/kube-prometheus/components/mixin/rules/node-rules.libsonnet
@@ -25,7 +25,7 @@
             record: 'cluster:node_cpu:sum_rate5m',
           },
           {
-            expr: 'cluster:node_cpu_seconds_total:rate5m / count(sum(node_cpu_seconds_total) BY (instance, cpu))',
+            expr: 'cluster:node_cpu:sum_rate5m / count(sum(node_cpu_seconds_total) BY (instance, cpu))',
             record: 'cluster:node_cpu:ratio',
           },
         ],

--- a/manifests/kubePrometheus-prometheusRule.yaml
+++ b/manifests/kubePrometheus-prometheusRule.yaml
@@ -81,8 +81,8 @@ spec:
       record: instance:node_cpu:ratio
     - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal"}[5m]))
       record: cluster:node_cpu:sum_rate5m
-    - expr: cluster:node_cpu_seconds_total:rate5m / count(sum(node_cpu_seconds_total)
-        BY (instance, cpu))
+    - expr: cluster:node_cpu:sum_rate5m / count(sum(node_cpu_seconds_total) BY (instance,
+        cpu))
       record: cluster:node_cpu:ratio
   - name: kube-prometheus-general.rules
     rules:


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

`cluster:node_cpu:ratio` query expression was referring to an non-existent metric, could have been a typo. 

Also, once this is merged, planning to use `cluster:node_cpu:ratio` in the cluster resource usage dashboards [here](https://github.com/kubernetes-monitoring/kubernetes-mixin/blob/8d762e5688dab7979e70a4f5fa81b20ac213d9cb/dashboards/resources/cluster.libsonnet#L143) as the current query there is slower to evaluate on clusters having many nodes with multi-core cpus ( cores >= 64 ).  

cc @paulfantom 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
fix cluster:node_cpu:ratio query
```
