### PR TITLE
Update PodMonitor for kube-proxy

### DIFF
--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -288,7 +288,6 @@ function(params) {
       },
       podMetricsEndpoints: [{
         honorLabels: true,
-        targetPort: 10249,
         relabelings: [
           {
             action: 'replace',
@@ -296,6 +295,13 @@ function(params) {
             replacement: '$1',
             sourceLabels: ['__meta_kubernetes_pod_node_name'],
             targetLabel: 'instance',
+          },
+          {
+            action: 'replace',
+            regex: '(.*)',
+            replacement: '$1:10249',
+            targetLabel: '__address__',
+            sourceLabels: ['__meta_kubernetes_pod_ip'],
           },
         ],
       }],


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

The default PodMonitor that was shipped for `kube-proxy` was causing the target to never appear, and in SD, the target labels appeared as `Dropped`.

<img width="1792" alt="Screenshot 2022-02-09 at 12 54 39" src="https://user-images.githubusercontent.com/5781491/153387103-b6248e35-dc78-416c-b5da-25d97dec15cf.png">

Because the PodMonitor has `targetPort` set, prometheus-operator is adding relabelling with `action: keep` which causes discovered targets to be kept, only if the regex matches a source label and since the DaemonSet for `kube-proxy` has no ports defined, we dont have `__meta_kubernetes_pod_container_port_name` label,  and Prometheus doesn't have anything to match, so it discards the target.

https://github.com/prometheus-operator/prometheus-operator/blob/main/pkg/prometheus/promcfg.go#L745-L750

This is why the fix suggested in https://github.com/prometheus-operator/kube-prometheus/issues/1603#issuecomment-1030815589 actually works.

Screenshot of targets up after this fix is applied:

<img width="1892" alt="Screenshot 2022-02-10 at 11 08 18" src="https://user-images.githubusercontent.com/5781491/153394977-9c42a2a4-65e8-4af5-81e8-897e52e0aef9.png">


Thanks @paulfantom for help investigating the solution.

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Fixes #1603 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add __address__ relabelling for kube-proxy PodMonitor to stop target being dropped
```
