### PR TITLE
Added custom overrides for kube-rbac-proxy-self.

### DIFF
--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -20,6 +20,12 @@ local defaults = {
       requests+: { cpu: '20m' },
     },
   },
+  kubeRbacProxySelf:: {
+    resources+: {
+      limits+: { cpu: '20m' },
+      requests+: { cpu: '10m' },
+    },
+  },
   scrapeInterval:: '30s',
   scrapeTimeout:: '30s',
   commonLabels:: {
@@ -108,7 +114,7 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
     image: ksm._config.kubeRbacProxyImage,
   }),
 
-  local kubeRbacProxySelf = krp({
+  local kubeRbacProxySelf = krp(ksm._config.kubeRbacProxySelf {
     name: 'kube-rbac-proxy-self',
     upstream: 'http://127.0.0.1:8082/',
     secureListenAddress: ':9443',


### PR DESCRIPTION
## Description
I have discovered that kube-state-metrics tends tends to experience CPU throttling in my kubernetes cluster. I want to get CPU throttling down to a decent level below 10%. Right now I don't have a way to change this.

this is a picture from my cluster. the sidecar called  kube-rbac-proxy-self experiences a CPU throttling of 19%. This gives bad performance 
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/1487947/153613352-3a1a6544-a73f-478c-8c57-f4097dc73b01.png">


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

By looking at existing code I am extending  kube-rbac-proxy-self with the same set of overrides as a similar sidecar container kube-rbac-proxy-main. This way I get a pitch point where i can add more CPU resources to the container.

```release-note
Added configurable default values for sidecar container kube-rbac-proxy-self in deployment kube-statate-metrics.
```
