### PR TITLE
added allowedCapabilities to node-exporter psp

### DIFF
--- a/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
+++ b/jsonnet/kube-prometheus/addons/podsecuritypolicies.libsonnet
@@ -200,6 +200,9 @@ local restrictedPodSecurityPolicy = {
         name: 'node-exporter-psp',
       },
       spec+: {
+        allowedCapabilities: [
+          'SYS_TIME',
+        ],
         allowedHostPaths+: [
           {
             pathPrefix: '/proc',


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

The PR https://github.com/prometheus-operator/kube-prometheus/pull/1610 added capabilites and they needed to be added to the PodSecurityPolicy as well.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
added allowedCapabilities to node-exporter psp
```
