### PR TITLE
Removed CAP_ from node-exporter daemonset

### DIFF
--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -185,7 +185,7 @@ function(params) {
       securityContext: {
         allowPrivilegeEscalation: false,
         readOnlyRootFilesystem: true,
-        capabilities: { drop: ['ALL'], add: ['CAP_SYS_TIME'] },
+        capabilities: { drop: ['ALL'], add: ['SYS_TIME'] },
       },
     };
 

--- a/manifests/nodeExporter-daemonset.yaml
+++ b/manifests/nodeExporter-daemonset.yaml
@@ -48,7 +48,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             add:
-            - CAP_SYS_TIME
+            - SYS_TIME
             drop:
             - ALL
           readOnlyRootFilesystem: true


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This fixes the `node-exporter` daemonset which had also the `CAP_` prefix which is not expected by Kubernetes according the [this documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._
removed the CAP_ prefix from node-exporter daemonset capabilites

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- removed the CAP_ prefix from node-exporter daemonset capabilites
```
