### PR TITLE
Adds NetworkPolicies to all components of Kube-prometheus

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,25 @@ jobs:
       with:
         version: ${{ env.kind-version }}
         image: ${{ matrix.kind-image }}
-        wait: 300s
+        wait: 10s # Without default CNI, control-plane doesn't get ready until Cilium is installed
+        config: .github/workflows/kind/config.yml
+    - name: Setup Helm
+      uses: azure/setup-helm@v1
+    - name: Install Cilium
+      run: |
+        helm repo add cilium https://helm.cilium.io/
+        helm install cilium cilium/cilium --version 1.9.13 \
+        --namespace kube-system \
+        --set nodeinit.enabled=true \
+        --set kubeProxyReplacement=partial \
+        --set hostServices.enabled=false \
+        --set externalIPs.enabled=true \
+        --set nodePort.enabled=true \
+        --set hostPort.enabled=true \
+        --set bpf.masquerade=false \
+        --set image.pullPolicy=IfNotPresent \
+        --set ipam.mode=kubernetes \
+        --set operator.replicas=1
     - name: Wait for cluster to finish bootstraping
       run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
     - name: Create kube-prometheus stack

--- a/.github/workflows/kind/config.yml
+++ b/.github/workflows/kind/config.yml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  podSubnet: "10.10.0.0/16"
+  serviceSubnet: "10.11.0.0/16"

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ vendor/
 crdschemas/
 
 developer-workspace/gitpod/_output
-kind
+developer-workspace/codespaces/kind 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ JSONNETFMT_ARGS=-n 2 --max-blank-lines 2 --string-style s --comment-style s
 MDOX_VALIDATE_CONFIG?=.mdox.validate.yaml
 MD_FILES_TO_FORMAT=$(shell find docs developer-workspace examples experimental jsonnet manifests -name "*.md") $(shell ls *.md)
 
-KUBESCAPE_THRESHOLD=9
+KUBESCAPE_THRESHOLD=1
 
 all: generate fmt test docs
 

--- a/developer-workspace/codespaces/prepare-kind.sh
+++ b/developer-workspace/codespaces/prepare-kind.sh
@@ -9,12 +9,27 @@ if [[ $? != 0 ]]; then
     | cut -d : -f 2,3 \
     | tr -d \" \
     | wget -qi -
-    mv kind-linux-amd64 kind && chmod +x kind
+    mv kind-linux-amd64 developer-workspace/codespaces/kind && chmod +x developer-workspace/codespaces/kind
+    export PATH=$PATH:$PWD/developer-workspace/codespaces
 fi
 
-cluster_created=$($PWD/kind get clusters 2>&1)
+cluster_created=$($PWD/developer-workspace/codespaces/kind get clusters 2>&1)
 if [[ "$cluster_created" == "No kind clusters found." ]]; then 
-    $PWD/kind create cluster
+    $PWD/developer-workspace/codespaces/kind create cluster --config $PWD/.github/workflows/kind/config.yml
 else
     echo "Cluster '$cluster_created' already present" 
 fi
+
+helm repo add --force-update cilium https://helm.cilium.io/ 
+helm install cilium cilium/cilium --version 1.9.13 \
+  --namespace kube-system \
+  --set nodeinit.enabled=true \
+  --set kubeProxyReplacement=partial \
+  --set hostServices.enabled=false \
+  --set externalIPs.enabled=true \
+  --set nodePort.enabled=true \
+  --set hostPort.enabled=true \
+  --set bpf.masquerade=false \
+  --set image.pullPolicy=IfNotPresent \
+  --set ipam.mode=kubernetes \
+  --set operator.replicas=1

--- a/examples/networkpolicies-disabled.jsonnet
+++ b/examples/networkpolicies-disabled.jsonnet
@@ -1,0 +1,25 @@
+local kp = (import 'kube-prometheus/main.libsonnet') +
+           (import 'kube-prometheus/addons/networkpolicies-disabled.libsonnet') + {
+  values+:: {
+    common+: {
+      namespace: 'monitoring',
+    },
+  },
+};
+
+{
+  ['setup/' + resource]: kp[component][resource]
+  for component in std.objectFields(kp)
+  for resource in std.filter(
+    function(resource)
+      kp[component][resource].kind == 'CustomResourceDefinition' || kp[component][resource].kind == 'Namespace', std.objectFields(kp[component])
+  )
+} +
+{
+  [component + '-' + resource]: kp[component][resource]
+  for component in std.objectFields(kp)
+  for resource in std.filter(
+    function(resource)
+      kp[component][resource].kind != 'CustomResourceDefinition' && kp[component][resource].kind != 'Namespace', std.objectFields(kp[component])
+  )
+}

--- a/jsonnet/kube-prometheus/addons/networkpolicies-disabled.libsonnet
+++ b/jsonnet/kube-prometheus/addons/networkpolicies-disabled.libsonnet
@@ -1,0 +1,35 @@
+// Disables creation of NetworkPolicies
+
+{
+  blackboxExporter+: {
+    networkPolicies:: {},
+  },
+
+  kubeStateMetrics+: {
+    networkPolicies:: {},
+  },
+
+  nodeExporter+: {
+    networkPolicies:: {},
+  },
+
+  prometheusAdapter+: {
+    networkPolicies:: {},
+  },
+
+  alertmanager+: {
+    networkPolicies:: {},
+  },
+
+  grafana+: {
+    networkPolicies:: {},
+  },
+
+  prometheus+: {
+    networkPolicies:: {},
+  },
+
+  prometheusOperator+: {
+    networkPolicies:: {},
+  },
+}

--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -103,6 +103,32 @@ function(params) {
     },
   },
 
+  networkPolicy: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'NetworkPolicy',
+    metadata: am.service.metadata,
+    spec: {
+      podSelector: {
+        matchLabels: am._config.selectorLabels,
+      },
+      policyTypes: ['Egress', 'Ingress'],
+      egress: [{}],
+      ingress: [{
+        from: [{
+          podSelector: {
+            matchLabels: {
+              'app.kubernetes.io/name': 'prometheus',
+            },
+          },
+        }],
+        ports: std.map(function(o) {
+          port: o.port,
+          protocol: 'TCP',
+        }, am.service.spec.ports),
+      }],
+    },
+  },
+
   secret: {
     apiVersion: 'v1',
     kind: 'Secret',

--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -113,19 +113,38 @@ function(params) {
       },
       policyTypes: ['Egress', 'Ingress'],
       egress: [{}],
-      ingress: [{
-        from: [{
-          podSelector: {
-            matchLabels: {
-              'app.kubernetes.io/name': 'prometheus',
+      ingress: [
+        {
+          from: [{
+            podSelector: {
+              matchLabels: {
+                'app.kubernetes.io/name': 'prometheus',
+              },
             },
-          },
-        }],
-        ports: std.map(function(o) {
-          port: o.port,
-          protocol: 'TCP',
-        }, am.service.spec.ports),
-      }],
+          }],
+          ports: std.map(function(o) {
+            port: o.port,
+            protocol: 'TCP',
+          }, am.service.spec.ports),
+        },
+        // Alertmanager cluster peer-to-peer communication
+        {
+          from: [{
+            podSelector: {
+              matchLabels: {
+                'app.kubernetes.io/name': 'alertmanager',
+              },
+            },
+          }],
+          ports: [{
+            port: 9094,
+            protocol: 'TCP',
+          }, {
+            port: 9094,
+            protocol: 'UDP',
+          }],
+        },
+      ],
     },
   },
 

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -250,6 +250,30 @@ function(params) {
       },
     },
 
+  networkPolicy: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'NetworkPolicy',
+    metadata: bb.service.metadata,
+    spec: {
+      podSelector: {
+        matchLabels: bb._config.selectorLabels,
+      },
+      ingress: [{
+        from: [{
+          podSelector: {
+            matchLabels: {
+              'app.kubernetes.io/name': 'prometheus',
+            },
+          },
+        }],
+        ports: std.map(function(o) {
+          port: o.port,
+          protocol: 'TCP',
+        }, bb.service.spec.ports),
+      }],
+    },
+  },
+
   service: {
     apiVersion: 'v1',
     kind: 'Service',

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -258,6 +258,8 @@ function(params) {
       podSelector: {
         matchLabels: bb._config.selectorLabels,
       },
+      policyTypes: ['Egress', 'Ingress'],
+      egress: [{}],
       ingress: [{
         from: [{
           podSelector: {

--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -84,6 +84,32 @@ function(params)
       },
     },
 
+    networkPolicy: {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'NetworkPolicy',
+      metadata: g.service.metadata,
+      spec: {
+        podSelector: {
+          matchLabels: g._config.selectorLabels,
+        },
+        policyTypes: ['Egress', 'Ingress'],
+        egress: [{}],
+        ingress: [{
+          from: [{
+            podSelector: {
+              matchLabels: {
+                'app.kubernetes.io/name': 'prometheus',
+              },
+            },
+          }],
+          ports: std.map(function(o) {
+            port: o.port,
+            protocol: 'TCP',
+          }, g.service.spec.ports),
+        }],
+      },
+    },
+
     // FIXME(ArthurSens): The securityContext overrides can be removed after some PRs get merged
     // 'allowPrivilegeEscalation: false' can be deleted when https://github.com/brancz/kubernetes-grafana/pull/128 gets merged.
     // 'readOnlyRootFilesystem: true' and extra volumeMounts can be deleted when https://github.com/brancz/kubernetes-grafana/pull/129 gets merged.

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -124,6 +124,30 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
     image: ksm._config.kubeRbacProxyImage,
   }),
 
+  networkPolicy: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'NetworkPolicy',
+    metadata: ksm.service.metadata,
+    spec: {
+      podSelector: {
+        matchLabels: ksm._config.selectorLabels,
+      },
+      ingress: [{
+        from: [{
+          podSelector: {
+            matchLabels: {
+              'app.kubernetes.io/name': 'prometheus',
+            },
+          },
+        }],
+        ports: std.map(function(o) {
+          port: o.port,
+          protocol: 'TCP',
+        }, ksm.service.spec.ports),
+      }],
+    },
+  },
+
   deployment+: {
     spec+: {
       template+: {

--- a/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-state-metrics.libsonnet
@@ -132,6 +132,8 @@ function(params) (import 'github.com/kubernetes/kube-state-metrics/jsonnet/kube-
       podSelector: {
         matchLabels: ksm._config.selectorLabels,
       },
+      policyTypes: ['Egress', 'Ingress'],
+      egress: [{}],
       ingress: [{
         from: [{
           podSelector: {

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -160,6 +160,30 @@ function(params) {
     },
   },
 
+  networkPolicy: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'NetworkPolicy',
+    metadata: ne.service.metadata,
+    spec: {
+      podSelector: {
+        matchLabels: ne._config.selectorLabels,
+      },
+      ingress: [{
+        from: [{
+          podSelector: {
+            matchLabels: {
+              'app.kubernetes.io/name': 'prometheus',
+            },
+          },
+        }],
+        ports: std.map(function(o) {
+          port: o.port,
+          protocol: 'TCP',
+        }, ne.service.spec.ports),
+      }],
+    },
+  },
+
   daemonset:
     local nodeExporter = {
       name: ne._config.name,

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -168,6 +168,8 @@ function(params) {
       podSelector: {
         matchLabels: ne._config.selectorLabels,
       },
+      policyTypes: ['Egress', 'Ingress'],
+      egress: [{}],
       ingress: [{
         from: [{
           podSelector: {

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -206,6 +206,21 @@ function(params) {
     },
   },
 
+  networkPolicy: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'NetworkPolicy',
+    metadata: pa.service.metadata,
+    spec: {
+      podSelector: {
+        matchLabels: pa._config.selectorLabels,
+      },
+      policyTypes: ['Egress', 'Ingress'],
+      egress: [{}],
+      // Prometheus-adapter needs ingress allowed so HPAs can request metrics from it.
+      ingress: [{}],
+    },
+  },
+
   deployment:
     local c = {
       name: pa._config.name,

--- a/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-operator.libsonnet
@@ -72,6 +72,32 @@ function(params)
       },
     },
 
+    networkPolicy: {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'NetworkPolicy',
+      metadata: po.service.metadata,
+      spec: {
+        podSelector: {
+          matchLabels: po._config.selectorLabels,
+        },
+        policyTypes: ['Egress', 'Ingress'],
+        egress: [{}],
+        ingress: [{
+          from: [{
+            podSelector: {
+              matchLabels: {
+                'app.kubernetes.io/name': 'prometheus',
+              },
+            },
+          }],
+          ports: std.map(function(o) {
+            port: o.port,
+            protocol: 'TCP',
+          }, po.service.spec.ports),
+        }],
+      },
+    },
+
     service+: {
       spec+: {
         ports: [

--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -94,6 +94,32 @@ function(params) {
     },
   },
 
+  networkPolicy: {
+    apiVersion: 'networking.k8s.io/v1',
+    kind: 'NetworkPolicy',
+    metadata: p.service.metadata,
+    spec: {
+      podSelector: {
+        matchLabels: p._config.selectorLabels,
+      },
+      policyTypes: ['Egress', 'Ingress'],
+      egress: [{}],
+      ingress: [{
+        from: [{
+          podSelector: {
+            matchLabels: {
+              'app.kubernetes.io/name': 'prometheus',
+            },
+          },
+        }],
+        ports: std.map(function(o) {
+          port: o.port,
+          protocol: 'TCP',
+        }, p.service.spec.ports),
+      }],
+    },
+  },
+
   serviceAccount: {
     apiVersion: 'v1',
     kind: 'ServiceAccount',

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - ./manifests/blackboxExporter-clusterRoleBinding.yaml
 - ./manifests/blackboxExporter-configuration.yaml
 - ./manifests/blackboxExporter-deployment.yaml
+- ./manifests/blackboxExporter-networkPolicy.yaml
 - ./manifests/blackboxExporter-service.yaml
 - ./manifests/blackboxExporter-serviceAccount.yaml
 - ./manifests/blackboxExporter-serviceMonitor.yaml
@@ -30,6 +31,7 @@ resources:
 - ./manifests/kubeStateMetrics-clusterRole.yaml
 - ./manifests/kubeStateMetrics-clusterRoleBinding.yaml
 - ./manifests/kubeStateMetrics-deployment.yaml
+- ./manifests/kubeStateMetrics-networkPolicy.yaml
 - ./manifests/kubeStateMetrics-prometheusRule.yaml
 - ./manifests/kubeStateMetrics-service.yaml
 - ./manifests/kubeStateMetrics-serviceAccount.yaml
@@ -43,6 +45,7 @@ resources:
 - ./manifests/nodeExporter-clusterRole.yaml
 - ./manifests/nodeExporter-clusterRoleBinding.yaml
 - ./manifests/nodeExporter-daemonset.yaml
+- ./manifests/nodeExporter-networkPolicy.yaml
 - ./manifests/nodeExporter-prometheusRule.yaml
 - ./manifests/nodeExporter-service.yaml
 - ./manifests/nodeExporter-serviceAccount.yaml
@@ -68,6 +71,7 @@ resources:
 - ./manifests/prometheusAdapter-clusterRoleServerResources.yaml
 - ./manifests/prometheusAdapter-configMap.yaml
 - ./manifests/prometheusAdapter-deployment.yaml
+- ./manifests/prometheusAdapter-networkPolicy.yaml
 - ./manifests/prometheusAdapter-podDisruptionBudget.yaml
 - ./manifests/prometheusAdapter-roleBindingAuthReader.yaml
 - ./manifests/prometheusAdapter-service.yaml

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ./manifests/alertmanager-alertmanager.yaml
+- ./manifests/alertmanager-networkPolicy.yaml
 - ./manifests/alertmanager-podDisruptionBudget.yaml
 - ./manifests/alertmanager-prometheusRule.yaml
 - ./manifests/alertmanager-secret.yaml
@@ -20,6 +21,7 @@ resources:
 - ./manifests/grafana-dashboardDefinitions.yaml
 - ./manifests/grafana-dashboardSources.yaml
 - ./manifests/grafana-deployment.yaml
+- ./manifests/grafana-networkPolicy.yaml
 - ./manifests/grafana-prometheusRule.yaml
 - ./manifests/grafana-service.yaml
 - ./manifests/grafana-serviceAccount.yaml
@@ -47,6 +49,7 @@ resources:
 - ./manifests/nodeExporter-serviceMonitor.yaml
 - ./manifests/prometheus-clusterRole.yaml
 - ./manifests/prometheus-clusterRoleBinding.yaml
+- ./manifests/prometheus-networkPolicy.yaml
 - ./manifests/prometheus-podDisruptionBudget.yaml
 - ./manifests/prometheus-prometheus.yaml
 - ./manifests/prometheus-prometheusRule.yaml
@@ -73,6 +76,7 @@ resources:
 - ./manifests/prometheusOperator-clusterRole.yaml
 - ./manifests/prometheusOperator-clusterRoleBinding.yaml
 - ./manifests/prometheusOperator-deployment.yaml
+- ./manifests/prometheusOperator-networkPolicy.yaml
 - ./manifests/prometheusOperator-prometheusRule.yaml
 - ./manifests/prometheusOperator-service.yaml
 - ./manifests/prometheusOperator-serviceAccount.yaml

--- a/manifests/alertmanager-networkPolicy.yaml
+++ b/manifests/alertmanager-networkPolicy.yaml
@@ -22,6 +22,15 @@ spec:
       protocol: TCP
     - port: 8080
       protocol: TCP
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: alertmanager
+    ports:
+    - port: 9094
+      protocol: TCP
+    - port: 9094
+      protocol: UDP
   podSelector:
     matchLabels:
       app.kubernetes.io/component: alert-router

--- a/manifests/alertmanager-networkPolicy.yaml
+++ b/manifests/alertmanager-networkPolicy.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: alert-router
+    app.kubernetes.io/instance: main
+    app.kubernetes.io/name: alertmanager
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.23.0
+  name: alertmanager-main
+  namespace: monitoring
+spec:
+  egress:
+  - {}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 9093
+      protocol: TCP
+    - port: 8080
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: alert-router
+      app.kubernetes.io/instance: main
+      app.kubernetes.io/name: alertmanager
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Egress
+  - Ingress

--- a/manifests/blackboxExporter-networkPolicy.yaml
+++ b/manifests/blackboxExporter-networkPolicy.yaml
@@ -3,10 +3,10 @@ kind: NetworkPolicy
 metadata:
   labels:
     app.kubernetes.io/component: exporter
-    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/name: blackbox-exporter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.4.1
-  name: kube-state-metrics
+    app.kubernetes.io/version: 0.19.0
+  name: blackbox-exporter
   namespace: monitoring
 spec:
   egress:
@@ -17,14 +17,14 @@ spec:
         matchLabels:
           app.kubernetes.io/name: prometheus
     ports:
-    - port: 8443
+    - port: 9115
       protocol: TCP
-    - port: 9443
+    - port: 19115
       protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/component: exporter
-      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/name: blackbox-exporter
       app.kubernetes.io/part-of: kube-prometheus
   policyTypes:
   - Egress

--- a/manifests/grafana-networkPolicy.yaml
+++ b/manifests/grafana-networkPolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: grafana
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 8.3.6
+  name: grafana
+  namespace: monitoring
+spec:
+  egress:
+  - {}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 3000
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: grafana
+      app.kubernetes.io/name: grafana
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Egress
+  - Ingress

--- a/manifests/grafana-networkPolicy.yaml
+++ b/manifests/grafana-networkPolicy.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 8.3.6
+    app.kubernetes.io/version: 8.4.3
   name: grafana
   namespace: monitoring
 spec:

--- a/manifests/kubeStateMetrics-networkPolicy.yaml
+++ b/manifests/kubeStateMetrics-networkPolicy.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.3.0
+  name: kube-state-metrics
+  namespace: monitoring
+spec:
+  egress:
+  - {}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 8443
+      protocol: TCP
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Egress
+  - Ingress

--- a/manifests/nodeExporter-networkPolicy.yaml
+++ b/manifests/nodeExporter-networkPolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 1.3.1
+  name: node-exporter
+  namespace: monitoring
+spec:
+  egress:
+  - {}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 9100
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: node-exporter
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Egress
+  - Ingress

--- a/manifests/prometheus-networkPolicy.yaml
+++ b/manifests/prometheus-networkPolicy.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.33.3
+  name: prometheus-k8s
+  namespace: monitoring
+spec:
+  egress:
+  - {}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 9090
+      protocol: TCP
+    - port: 8080
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: prometheus
+      app.kubernetes.io/instance: k8s
+      app.kubernetes.io/name: prometheus
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Egress
+  - Ingress

--- a/manifests/prometheus-networkPolicy.yaml
+++ b/manifests/prometheus-networkPolicy.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: k8s
     app.kubernetes.io/name: prometheus
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 2.33.3
+    app.kubernetes.io/version: 2.33.4
   name: prometheus-k8s
   namespace: monitoring
 spec:

--- a/manifests/prometheusAdapter-networkPolicy.yaml
+++ b/manifests/prometheusAdapter-networkPolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.9.1
+  name: prometheus-adapter
+  namespace: monitoring
+spec:
+  egress:
+  - {}
+  ingress:
+  - {}
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: metrics-adapter
+      app.kubernetes.io/name: prometheus-adapter
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Egress
+  - Ingress

--- a/manifests/prometheusOperator-networkPolicy.yaml
+++ b/manifests/prometheusOperator-networkPolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: prometheus-operator
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 0.54.0
+  name: prometheus-operator
+  namespace: monitoring
+spec:
+  egress:
+  - {}
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 8443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/name: prometheus-operator
+      app.kubernetes.io/part-of: kube-prometheus
+  policyTypes:
+  - Egress
+  - Ingress

--- a/manifests/prometheusOperator-networkPolicy.yaml
+++ b/manifests/prometheusOperator-networkPolicy.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.54.0
+    app.kubernetes.io/version: 0.54.1
   name: prometheus-operator
   namespace: monitoring
 spec:


### PR DESCRIPTION
## Description

This is continuing the work started at https://github.com/prometheus-operator/kube-prometheus/pull/1470.

It adds NetworkPolicies to all components of the stack:
* Egress is allowed for all just for getting NetworkPolicies in quickly - We might want to revisit and be more restrict here
* Ingress only allowed by Prometheus for all components, except Prometheus-adapter (HPAs need to send requests for metrics)


Extra changes to make sure we keep supporting NetworkPolicies without breaking anything:
* CI was updated to disable default CNI and is installing Cilium to enable NetworkPolicies
* Scripts used for development were also updated to enable NetworkPolicies with Cilium

Fixes https://github.com/prometheus-operator/kube-prometheus/issues/1596

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add NetworkPolicies to follow security best-practices
```
