### PR TITLE
Fix problems when enabling eks platform patch

### DIFF
--- a/jsonnet/kube-prometheus/addons/aws-vpc-cni.libsonnet
+++ b/jsonnet/kube-prometheus/addons/aws-vpc-cni.libsonnet
@@ -77,9 +77,13 @@
       apiVersion: 'monitoring.coreos.com/v1',
       kind: 'PrometheusRule',
       metadata: {
-        labels: $.prometheus._config.commonLabels + $.prometheus._config.mixin.ruleLabels,
+        labels: {
+          'app.kubernetes.io/name': 'prometheus-vpc-cni-rules',
+          'app.kubernetes.io/component': 'prometheus',
+          'app.kubernetes.io/part-of': 'kube-prometheus',
+        },
         name: 'aws-vpc-cni-rules',
-        namespace: $.prometheus._config.namespace,
+        namespace: $.values.prometheus.namespace,
       },
       spec: {
         groups: [

--- a/jsonnet/kube-prometheus/platforms/platforms.libsonnet
+++ b/jsonnet/kube-prometheus/platforms/platforms.libsonnet
@@ -16,6 +16,7 @@ local platformPatch(p) = if p != null && std.objectHas(platforms, p) then platfo
 {
   // initialize the object to prevent "Indexed object has no field" lint errors
   local p = {
+    values+:: $.values,
     alertmanager: {},
     blackboxExporter: {},
     grafana: {},


### PR DESCRIPTION
## Description

This PR fixes a problem where users are unable to generate k8s manifests when they enable `platform: 'eks'` in their libsonnet configuration.

An attempt for fixing this has been made in https://github.com/prometheus-operator/kube-prometheus/pull/1286, but it tried to fix all the platforms at once including the documentation. However, in this PR, I would like to focus on just fixing the problem when enabling `platform: 'eks'` part.

Without this patch, user will get an error when they enable `platform: 'eks'` part like this:

```jsonnet
local kp = (import 'kube-prometheus/main.libsonnet') + {
  values+:: {
    common+: {
      namespace: 'monitoring',
      platform: 'eks',
    },
  },
};
```

```
RUNTIME ERROR: Field does not exist: _config
	vendor/kube-prometheus/addons/aws-vpc-cni.libsonnet:80:17-37	
	Field "labels"	
	Field "metadata"	
	Field "resources/kubernetes-prometheusRuleAwsVpcCni"	
	During manifestation
```

To fix the problem, this patch passes `$.values` to make those values available for the platform patches. Then, in `aws-vpc-cni.libsonnet`, I changed those `$.prometheus` to use values from `$.values` or just hard-coded alternate values instead.

I think I will submit follow-up patch to update documentation where necessary to reflect the fact that  you need to set `platform:` inside the `common` object, after this PR is merged.

By the way, this is the first time for me to work with Jsonnet and kube-prometheus codebase, so please feel free to give me feedback if I misunderstood anything. Thank you very much.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- Fixes a problem when enabling EKS platform patch.
```