### PR TITLE
jsonnet/components/grafana: Address FIXME to prevent incoming bug

### DIFF
--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -110,30 +110,12 @@ function(params)
       },
     },
 
-    // FIXME(ArthurSens): The securityContext overrides can be removed after some PRs get merged
-    // 'allowPrivilegeEscalation: false' can be deleted when https://github.com/brancz/kubernetes-grafana/pull/128 gets merged.
-    // 'readOnlyRootFilesystem: true' and extra volumeMounts can be deleted when https://github.com/brancz/kubernetes-grafana/pull/129 gets merged.
     // FIXME(paulfantom): `automountServiceAccountToken` can be removed after porting to brancz/kuberentes-grafana
     deployment+: {
       spec+: {
         template+: {
           spec+: {
             automountServiceAccountToken: false,
-            containers: std.map(function(c) c {
-              securityContext+: {
-                allowPrivilegeEscalation: false,
-                readOnlyRootFilesystem: true,
-              },
-              volumeMounts+: [{
-                mountPath: '/tmp',
-                name: 'tmp-plugins',
-                readOnly: false,
-              }],
-            }, super.containers),
-            volumes+: [{
-              name: 'tmp-plugins',
-              emptyDir: {},
-            }],
           },
         },
       },

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -8,8 +8,8 @@
           "subdir": "grafana"
         }
       },
-      "version": "1c4d84de1c059b55ce83fdd76fbb4f58530b7d55",
-      "sum": "iZK7E+zDsk1zF1z4kb/RT2QGkxUaFt8pakwTA4lBPiU="
+      "version": "d039275e4916aceae1c137120882e01d857787ac",
+      "sum": "515vMn4x4tP8vegL4HLW0nDO5+njGTgnDZB5OOhtsCI="
     },
     {
       "source": {

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -62,6 +62,9 @@ spec:
         - mountPath: /etc/grafana/provisioning/dashboards
           name: grafana-dashboards
           readOnly: false
+        - mountPath: /tmp
+          name: tmp-plugins
+          readOnly: false
         - mountPath: /grafana-dashboard-definitions/0/alertmanager-overview
           name: grafana-dashboard-alertmanager-overview
           readOnly: false
@@ -137,9 +140,6 @@ spec:
         - mountPath: /etc/grafana
           name: grafana-config
           readOnly: false
-        - mountPath: /tmp
-          name: tmp-plugins
-          readOnly: false
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:
@@ -156,6 +156,9 @@ spec:
       - configMap:
           name: grafana-dashboards
         name: grafana-dashboards
+      - emptyDir:
+          medium: Memory
+        name: tmp-plugins
       - configMap:
           name: grafana-dashboard-alertmanager-overview
         name: grafana-dashboard-alertmanager-overview
@@ -231,5 +234,3 @@ spec:
       - name: grafana-config
         secret:
           secretName: grafana-config
-      - emptyDir: {}
-        name: tmp-plugins


### PR DESCRIPTION
## Description

Removing dead-code since they got merged upstream, but more important than that:

https://github.com/brancz/kubernetes-grafana/pull/129 got merged, which adds a mountpoint under `/tmp`, so I'd like to get this one merged before our automation update dependencies runs to avoid an incoming bug. If we don't address the FIXME comment, we'll have duplicated mountpoints under `/tmp`, which will make the Grafana's Deployment invalid.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
