### PR TITLE
Allow Grafana ingress to Prometheus

### DIFF
--- a/manifests/prometheus-networkPolicy.yaml
+++ b/manifests/prometheus-networkPolicy.yaml
@@ -22,6 +22,13 @@ spec:
       protocol: TCP
     - port: 8080
       protocol: TCP
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: grafana
+    ports:
+    - port: 9090
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/component: prometheus


### PR DESCRIPTION
## Description

Fixes Grafana access to Prometheus which broke in #1650

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```
Fix the Prometheus network policy to allow ingress from Grafana
```
