### PR TITLE
Add pyrra to 'update versions' automation

### DIFF
--- a/jsonnet/kube-prometheus/versions.json
+++ b/jsonnet/kube-prometheus/versions.json
@@ -8,5 +8,6 @@
   "prometheusAdapter": "0.9.1",
   "prometheusOperator": "0.55.1",
   "kubeRbacProxy": "0.11.0",
-  "configmapReload": "0.5.0"
+  "configmapReload": "0.5.0",
+  "pyrra": "0.3.4"
 }

--- a/scripts/generate-versions.sh
+++ b/scripts/generate-versions.sh
@@ -65,6 +65,7 @@ cat <<-EOF
   "prometheusAdapter": "$(get_version "kubernetes-sigs/prometheus-adapter")",
   "prometheusOperator": "$(get_version "prometheus-operator/prometheus-operator")",
   "kubeRbacProxy": "$(get_version "brancz/kube-rbac-proxy")",
-  "configmapReload": "$(get_version "jimmidyson/configmap-reload")"
+  "configmapReload": "$(get_version "jimmidyson/configmap-reload")",
+  "pyrra": "$(get_version "pyrra-dev/pyrra")"
 }
 EOF


### PR DESCRIPTION
## Description

Pyrra got removed from our `versions.json` file by our automation in https://github.com/prometheus-operator/kube-prometheus/pull/1705, this PR adds it back and fixes the automation so it don't get deleted again.


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
