### PR TITLE
Backport PodMonitor for kube-proxy to 0.9 release

### DIFF
--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -282,7 +282,6 @@ function(params) {
       },
       podMetricsEndpoints: [{
         honorLabels: true,
-        targetPort: 10249,
         relabelings: [
           {
             action: 'replace',
@@ -290,6 +289,13 @@ function(params) {
             replacement: '$1',
             sourceLabels: ['__meta_kubernetes_pod_node_name'],
             targetLabel: 'instance',
+          },
+          {
+            action: 'replace',
+            regex: '(.*)',
+            replacement: '$1:10249',
+            targetLabel: '__address__',
+            sourceLabels: ['__meta_kubernetes_pod_ip'],
           },
         ],
       }],


### PR DESCRIPTION
Signed-off-by: yogeek <gdupin@gmail.com>

## Description

Backport #1630 to release-0.9

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)