### PR TITLE
jsonnet/components/prometheus: Fix grafana network access

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -116,6 +116,18 @@ function(params) {
           port: o.port,
           protocol: 'TCP',
         }, p.service.spec.ports),
+      }, {
+        from: [{
+          podSelector: {
+            matchLabels: {
+              'app.kubernetes.io/name': 'grafana',
+            },
+          },
+        }],
+        ports: [{
+          port: 9090,
+          protocol: 'TCP',
+        }],
       }],
     },
   },

--- a/manifests/prometheus-networkPolicy.yaml
+++ b/manifests/prometheus-networkPolicy.yaml
@@ -22,6 +22,13 @@ spec:
       protocol: TCP
     - port: 8080
       protocol: TCP
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: grafana
+    ports:
+    - port: 9090
+      protocol: TCP
   podSelector:
     matchLabels:
       app.kubernetes.io/component: prometheus


### PR DESCRIPTION
## Description

Fixes a bug introduced in #1650, which is currently forbidding Grafana to query Prometheus.

Superseeds #1710 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix Prometheus NetworkPolicy to allow Grafana access
```
