### PR TITLE
addons/pyrra: Fix prometheus namespace connection

### DIFF
--- a/jsonnet/kube-prometheus/addons/pyrra.libsonnet
+++ b/jsonnet/kube-prometheus/addons/pyrra.libsonnet
@@ -73,7 +73,7 @@
         args: [
           'api',
           '--api-url=http://%s.%s.svc.cluster.local:9444' % [pyrra.kubernetesService.metadata.name, pyrra.kubernetesService.metadata.namespace],
-          '--prometheus-url=http://prometheus-k8s.monitoring.svc.cluster.local:9090',
+          '--prometheus-url=http://prometheus-k8s.%s.svc.cluster.local:9090' % pyrra._config.namespace,
         ],
         // resources: pyrra._config.resources,
         ports: [{ containerPort: pyrra._config.port }],


### PR DESCRIPTION
## Description

If kube-prometheus runs on a namespace different than `monitoring`, pyrra has network problems when communicating with prometheus

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix a bug where pyrra can't connect to prometheus when deployed to a namespace other than 'monitoring'
```
