### PR TITLE
etcd: Add Prometheus alerting and recording rules

### DIFF
--- a/jsonnet/kube-prometheus/components/etcd.libsonnet
+++ b/jsonnet/kube-prometheus/components/etcd.libsonnet
@@ -1,0 +1,40 @@
+local defaults = {
+  // Convention: Top-level fields related to CRDs are public, other fields are hidden
+  // If there is no CRD for the component, everything is hidden in defaults.
+  namespace:: error 'must provide namespace',
+  commonLabels:: {
+    'app.kubernetes.io/name': 'kube-prometheus',
+    'app.kubernetes.io/part-of': 'kube-prometheus',
+  },
+  mixin:: {
+    ruleLabels: {},
+    _config: {},
+  },
+};
+
+function(params) {
+  local etcd = self,
+  _config:: defaults + params,
+  _metadata:: {
+    labels: etcd._config.commonLabels,
+    namespace: etcd._config.namespace,
+  },
+
+  mixin:: (import 'github.com/etcd-io/etcd/contrib/mixin/mixin.libsonnet') {
+    _config+:: etcd._config.mixin._config,
+  },
+
+  prometheusRule: {
+    apiVersion: 'monitoring.coreos.com/v1',
+    kind: 'PrometheusRule',
+    metadata: etcd._metadata {
+      name: 'etcd-monitoring-rules',
+      labels+: etcd._config.mixin.ruleLabels,
+    },
+    spec: {
+      local r = if std.objectHasAll(etcd.mixin, 'prometheusRules') then etcd.mixin.prometheusRules.groups else [],
+      local a = if std.objectHasAll(etcd.mixin, 'prometheusAlerts') then etcd.mixin.prometheusAlerts.groups else [],
+      groups: a + r,
+    },
+  },
+}

--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -1,5 +1,6 @@
 local alertmanager = import './components/alertmanager.libsonnet';
 local blackboxExporter = import './components/blackbox-exporter.libsonnet';
+local etcd = import './components/etcd.libsonnet';
 local grafana = import './components/grafana.libsonnet';
 local kubernetesControlPlane = import './components/k8s-control-plane.libsonnet';
 local kubeStateMetrics = import './components/kube-state-metrics.libsonnet';
@@ -63,6 +64,10 @@ local utils = import './lib/utils.libsonnet';
       image: $.values.common.images.blackboxExporter,
       kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
       configmapReloaderImage: $.values.common.images.configmapReload,
+    },
+    etcd: {
+      namespace: $.values.common.namespace,
+      mixin+: { ruleLabels: $.values.common.ruleLabels },
     },
     grafana: {
       namespace: $.values.common.namespace,
@@ -132,6 +137,7 @@ local utils = import './lib/utils.libsonnet';
 
   alertmanager: alertmanager($.values.alertmanager),
   blackboxExporter: blackboxExporter($.values.blackboxExporter),
+  etcd: etcd($.values.etcd),
   grafana: grafana($.values.grafana),
   kubeStateMetrics: kubeStateMetrics($.values.kubeStateMetrics),
   nodeExporter: nodeExporter($.values.nodeExporter),

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
 - ./manifests/blackboxExporter-service.yaml
 - ./manifests/blackboxExporter-serviceAccount.yaml
 - ./manifests/blackboxExporter-serviceMonitor.yaml
+- ./manifests/etcd-prometheusRule.yaml
 - ./manifests/grafana-config.yaml
 - ./manifests/grafana-dashboardDatasources.yaml
 - ./manifests/grafana-dashboardDefinitions.yaml

--- a/manifests/etcd-prometheusRule.yaml
+++ b/manifests/etcd-prometheusRule.yaml
@@ -1,0 +1,180 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: k8s
+    role: alert-rules
+  name: etcd-monitoring-rules
+  namespace: monitoring
+spec:
+  groups:
+  - name: etcd
+    rules:
+    - alert: etcdMembersDown
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": members are down ({{ $value
+          }}).'
+        summary: etcd cluster members are down.
+      expr: |
+        max without (endpoint) (
+          sum without (instance) (up{job=~".*etcd.*"} == bool 0)
+        or
+          count without (To) (
+            sum without (instance) (rate(etcd_network_peer_sent_failures_total{job=~".*etcd.*"}[120s])) > 0.01
+          )
+        )
+        > 0
+      for: 10m
+      labels:
+        severity: critical
+    - alert: etcdInsufficientMembers
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": insufficient members ({{ $value
+          }}).'
+        summary: etcd cluster has insufficient number of members.
+      expr: |
+        sum(up{job=~".*etcd.*"} == bool 1) without (instance) < ((count(up{job=~".*etcd.*"}) without (instance) + 1) / 2)
+      for: 3m
+      labels:
+        severity: critical
+    - alert: etcdNoLeader
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": member {{ $labels.instance
+          }} has no leader.'
+        summary: etcd cluster has no leader.
+      expr: |
+        etcd_server_has_leader{job=~".*etcd.*"} == 0
+      for: 1m
+      labels:
+        severity: critical
+    - alert: etcdHighNumberOfLeaderChanges
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": {{ $value }} leader changes
+          within the last 15 minutes. Frequent elections may be a sign of insufficient
+          resources, high network latency, or disruptions by other components and
+          should be investigated.'
+        summary: etcd cluster has high number of leader changes.
+      expr: |
+        increase((max without (instance) (etcd_server_leader_changes_seen_total{job=~".*etcd.*"}) or 0*absent(etcd_server_leader_changes_seen_total{job=~".*etcd.*"}))[15m:1m]) >= 4
+      for: 5m
+      labels:
+        severity: warning
+    - alert: etcdHighNumberOfFailedGRPCRequests
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
+          for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance
+          }}.'
+        summary: etcd cluster has high number of failed grpc requests.
+      expr: |
+        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[5m])) without (grpc_type, grpc_code)
+          /
+        sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) without (grpc_type, grpc_code)
+          > 1
+      for: 10m
+      labels:
+        severity: warning
+    - alert: etcdHighNumberOfFailedGRPCRequests
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": {{ $value }}% of requests
+          for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance
+          }}.'
+        summary: etcd cluster has high number of failed grpc requests.
+      expr: |
+        100 * sum(rate(grpc_server_handled_total{job=~".*etcd.*", grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"}[5m])) without (grpc_type, grpc_code)
+          /
+        sum(rate(grpc_server_handled_total{job=~".*etcd.*"}[5m])) without (grpc_type, grpc_code)
+          > 5
+      for: 5m
+      labels:
+        severity: critical
+    - alert: etcdGRPCRequestsSlow
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile of gRPC requests
+          is {{ $value }}s on etcd instance {{ $labels.instance }} for {{ $labels.grpc_method
+          }} method.'
+        summary: etcd grpc requests are slow
+      expr: |
+        histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{job=~".*etcd.*", grpc_method!="Defragment", grpc_type="unary"}[5m])) without(grpc_type))
+        > 0.15
+      for: 10m
+      labels:
+        severity: critical
+    - alert: etcdMemberCommunicationSlow
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": member communication with
+          {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance
+          }}.'
+        summary: etcd cluster member communication is slow.
+      expr: |
+        histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{job=~".*etcd.*"}[5m]))
+        > 0.15
+      for: 10m
+      labels:
+        severity: warning
+    - alert: etcdHighNumberOfFailedProposals
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures
+          within the last 30 minutes on etcd instance {{ $labels.instance }}.'
+        summary: etcd cluster has high number of proposal failures.
+      expr: |
+        rate(etcd_server_proposals_failed_total{job=~".*etcd.*"}[15m]) > 5
+      for: 15m
+      labels:
+        severity: warning
+    - alert: etcdHighFsyncDurations
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations
+          are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        summary: etcd cluster 99th percentile fsync durations are too high.
+      expr: |
+        histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
+        > 0.5
+      for: 10m
+      labels:
+        severity: warning
+    - alert: etcdHighFsyncDurations
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile fsync durations
+          are {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        summary: etcd cluster 99th percentile fsync durations are too high.
+      expr: |
+        histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
+        > 1
+      for: 10m
+      labels:
+        severity: critical
+    - alert: etcdHighCommitDurations
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": 99th percentile commit durations
+          {{ $value }}s on etcd instance {{ $labels.instance }}.'
+        summary: etcd cluster 99th percentile commit durations are too high.
+      expr: |
+        histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~".*etcd.*"}[5m]))
+        > 0.25
+      for: 10m
+      labels:
+        severity: warning
+    - alert: etcdBackendQuotaLowSpace
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": database size exceeds the
+          defined quota on etcd instance {{ $labels.instance }}, please defrag or
+          increase the quota as the writes to etcd will be disabled when it is full.'
+        summary: etcd cluster database is running full.
+      expr: |
+        (etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100 > 95
+      for: 10m
+      labels:
+        severity: critical
+    - alert: etcdExcessiveDatabaseGrowth
+      annotations:
+        description: 'etcd cluster "{{ $labels.job }}": Observed surge in etcd writes
+          leading to 50% increase in database size over the past four hours on etcd
+          instance {{ $labels.instance }}, please check as it might be disruptive.'
+        summary: etcd cluster database growing very fast.
+      expr: |
+        increase(((etcd_mvcc_db_total_size_in_bytes/etcd_server_quota_backend_bytes)*100)[240m:1m]) > 50
+      for: 10m
+      labels:
+        severity: warning


### PR DESCRIPTION
## Description

The official etcd project provides a [mixin](https://github.com/etcd-io/etcd/tree/main/contrib/mixin) for Prometheus rules and Grafana dashboards. They do not publish auto-generated YAML, so the kube-prometheus-stack project is currently [syncing](https://github.com/prometheus-community/helm-charts/blob/2e86d1618eb5d599576789c1202853dc5bc808c0/charts/kube-prometheus-stack/hack/sync_prometheus_rules.py#L63) against an old ruleset. This ruleset is from the etcd 3.4 documentation, but modern versions of Kubernetes use etcd 3.5+.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
etcd: Add Prometheus alerting and recording rules
```