### PR TITLE
jsonnet/mixin fixes _config propagation for alerts and rules

### DIFF
--- a/jsonnet/kube-prometheus/components/mixin/custom.libsonnet
+++ b/jsonnet/kube-prometheus/components/mixin/custom.libsonnet
@@ -20,7 +20,9 @@ function(params) {
   local m = self,
   _config:: defaults + params,
 
-  local alertsandrules = (import './alerts/alerts.libsonnet') + (import './rules/rules.libsonnet'),
+  local alertsandrules = (import './alerts/alerts.libsonnet') + (import './rules/rules.libsonnet') {
+    _config+:: m._config.mixin._config,
+  },
 
   mixin:: alertsandrules +
           (import 'github.com/kubernetes-monitoring/kubernetes-mixin/lib/add-runbook-links.libsonnet') {


### PR DESCRIPTION

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Problem: _config was not being propperly passed down to alerts
and rules jsonnet definitions resulting in changes to _config
being propagated

Solution: when importing alerts and rules set _config


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
jsonnet/mixin fixes _config propagation for alerts and rules
```
