### PR TITLE
cheery-pick: Adds readinessProbe and livenessProbe to prometheus-adapter jsonnet

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -240,7 +240,7 @@ function(params) {
         periodSeconds: 5,
         failureThreshold: 5,
       },
-      ports: [{ containerPort: 6443 }],
+      ports: [{ containerPort: 6443, name: 'https' }],
       volumeMounts: [
         { name: 'tmpfs', mountPath: '/tmp', readOnly: false },
         { name: 'volume-serving-cert', mountPath: '/var/run/serving-cert', readOnly: false },

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -220,6 +220,26 @@ function(params) {
         '--tls-cipher-suites=' + std.join(',', pa._config.tlsCipherSuites),
       ],
       resources: pa._config.resources,
+      readinessProbe: {
+        httpGet: {
+          path: '/readyz',
+          port: 'https',
+          scheme: 'HTTPS',
+        },
+        initialDelaySeconds: 30,
+        periodSeconds: 5,
+        failureThreshold: 5,
+      },
+      livenessProbe: {
+        httpGet: {
+          path: '/livez',
+          port: 'https',
+          scheme: 'HTTPS',
+        },
+        initialDelaySeconds: 30,
+        periodSeconds: 5,
+        failureThreshold: 5,
+      },
       ports: [{ containerPort: 6443 }],
       volumeMounts: [
         { name: 'tmpfs', mountPath: '/tmp', readOnly: false },

--- a/manifests/prometheusAdapter-deployment.yaml
+++ b/manifests/prometheusAdapter-deployment.yaml
@@ -48,6 +48,7 @@ spec:
         name: prometheus-adapter
         ports:
         - containerPort: 6443
+          name: https
         readinessProbe:
           failureThreshold: 5
           httpGet:

--- a/manifests/prometheusAdapter-deployment.yaml
+++ b/manifests/prometheusAdapter-deployment.yaml
@@ -37,9 +37,25 @@ spec:
         - --secure-port=6443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
         image: k8s.gcr.io/prometheus-adapter/prometheus-adapter:v0.9.1
+        livenessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
         name: prometheus-adapter
         ports:
         - containerPort: 6443
+        readinessProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          periodSeconds: 5
         resources:
           limits:
             cpu: 250m


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description
Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2099526

Problem: Currently the prometheus-adapter pods are restarted at the same
time even though the deployment is configured with strategy RollingUpdate.
This happens because the kubelet does not know when the prometheus-adapter
pods are ready to start receiving requests.

Solution: Add both readinessProbe and livenessProbe to the
prometheus-adapter, this way the kubelet will know when either the pod
stoped working and should be restarted or simply when it ready to start
receiving requests.



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
