### PR TITLE
Update Pyrra to 0.4.2

### DIFF
--- a/jsonnet/kube-prometheus/versions.json
+++ b/jsonnet/kube-prometheus/versions.json
@@ -9,5 +9,5 @@
   "prometheusOperator": "0.57.0",
   "kubeRbacProxy": "0.12.0",
   "configmapReload": "0.5.0",
-  "pyrra": "0.4.1"
+  "pyrra": "0.4.2"
 }


### PR DESCRIPTION
## Description

Pyrra 0.4.1 is crashing at start time and the fixed version is 0.4.2 so we should change the version used, starting from release-0.11

See the issue in Pyrra repository: https://github.com/pyrra-dev/pyrra/issues/324

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Upgrade Pyrra to 0.4.2

```release-note
Upgrade Pyrra to 0.4.2
```
