### PR TITLE
Fix broken relative links for non-github pages like prometheus-operator.dev

### DIFF
--- a/docs/customizations/developing-prometheus-rules-and-grafana-dashboards.md
+++ b/docs/customizations/developing-prometheus-rules-and-grafana-dashboards.md
@@ -19,7 +19,7 @@ Prometheus rules and Grafana dashboards in specific follow the
 
 For both the Prometheus rules and the Grafana dashboards Kubernetes `ConfigMap`s are generated within kube-prometheus. In order to add additional rules and dashboards simply merge them onto the existing json objects. This document illustrates examples for rules as well as dashboards.
 
-As a basis, all examples in this guide are based on the base example of the kube-prometheus [readme](../../README.md):
+As a basis, all examples in this guide are based on the base example of the kube-prometheus [readme](https://github.com/prometheus-operator/prometheus-operator/blob/main/README.md):
 
 ```jsonnet mdox-exec="cat example.jsonnet"
 local kp =
@@ -225,9 +225,9 @@ local kp = (import 'kube-prometheus/main.libsonnet') + {
 ### Changing default rules
 
 Along with adding additional rules, we give the user the option to filter or adjust the existing rules imported by `kube-prometheus/main.libsonnet`.
-The recording rules can be found in [kube-prometheus/components/mixin/rules](../../jsonnet/kube-prometheus/components/mixin/rules)
+The recording rules can be found in [kube-prometheus/components/mixin/rules](https://github.com/prometheus-operator/kube-prometheus/tree/main/jsonnet/kube-prometheus/components/mixin/rules)
 and [kubernetes-mixin/rules](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/rules).
-The alerting rules can be found in [kube-prometheus/components/mixin/alerts](../../jsonnet/kube-prometheus/components/mixin/alerts)
+The alerting rules can be found in [kube-prometheus/components/mixin/alerts](https://github.com/prometheus-operator/kube-prometheus/tree/main/jsonnet/kube-prometheus/components/mixin/alerts)
 and [kubernetes-mixin/alerts](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/alerts).
 
 Knowing which rules to change, the user can now use functions from the [Jsonnet standard library](https://jsonnet.org/ref/stdlib.html) to make these changes.
@@ -417,7 +417,7 @@ local kp = (import 'kube-prometheus/main.libsonnet') + {
 ### Pre-rendered Grafana dashboards
 
 As jsonnet is a superset of json, the jsonnet `import` function can be used to include Grafana dashboard json blobs.
-In this example we are importing a [provided example dashboard](../../examples/example-grafana-dashboard.json).
+In this example we are importing a [provided example dashboard](https://github.com/prometheus-operator/kube-prometheus/tree/main/examples/example-grafana-dashboard.json).
 
 ```jsonnet mdox-exec="cat examples/grafana-additional-rendered-dashboard-example.jsonnet"
 local kp = (import 'kube-prometheus/main.libsonnet') + {

--- a/docs/customizations/developing-prometheus-rules-and-grafana-dashboards.md
+++ b/docs/customizations/developing-prometheus-rules-and-grafana-dashboards.md
@@ -19,7 +19,7 @@ Prometheus rules and Grafana dashboards in specific follow the
 
 For both the Prometheus rules and the Grafana dashboards Kubernetes `ConfigMap`s are generated within kube-prometheus. In order to add additional rules and dashboards simply merge them onto the existing json objects. This document illustrates examples for rules as well as dashboards.
 
-As a basis, all examples in this guide are based on the base example of the kube-prometheus [readme](https://github.com/prometheus-operator/prometheus-operator/blob/main/README.md):
+As a basis, all examples in this guide are based on the base example of the kube-prometheus [readme](https://github.com/prometheus-operator/kube-prometheus/blob/main/README.md):
 
 ```jsonnet mdox-exec="cat example.jsonnet"
 local kp =

--- a/docs/customizations/exposing-prometheus-alertmanager-grafana-ingress.md
+++ b/docs/customizations/exposing-prometheus-alertmanager-grafana-ingress.md
@@ -101,9 +101,9 @@ k.core.v1.list.new([
 ])
 ```
 
-In order to expose Alertmanager and Grafana, simply create additional fields containing an ingress object, but simply pointing at the `alertmanager` or `grafana` instead of the `prometheus-k8s` Service. Make sure to also use the correct port respectively, for Alertmanager it is also `web`, for Grafana it is `http`. Be sure to also specify the appropriate external URL. Note that the external URL for grafana is set in a different way than the external URL for Prometheus or Alertmanager. See [ingress.jsonnet](../../examples/ingress.jsonnet) for how to set the Grafana external URL.
+In order to expose Alertmanager and Grafana, simply create additional fields containing an ingress object, but simply pointing at the `alertmanager` or `grafana` instead of the `prometheus-k8s` Service. Make sure to also use the correct port respectively, for Alertmanager it is also `web`, for Grafana it is `http`. Be sure to also specify the appropriate external URL. Note that the external URL for grafana is set in a different way than the external URL for Prometheus or Alertmanager. See [ingress.jsonnet](https://github.com/prometheus-operator/kube-prometheus/tree/main/examples/ingress.jsonnet) for how to set the Grafana external URL.
 
-In order to render the ingress objects similar to the other objects use as demonstrated in the [main readme](../../README.md):
+In order to render the ingress objects similar to the other objects use as demonstrated in the [main readme](https://github.com/prometheus-operator/kube-prometheus/tree/main/README.md):
 
 ```
 { ['00namespace-' + name]: kp.kubePrometheus[name] for name in std.objectFields(kp.kubePrometheus) } +
@@ -118,4 +118,4 @@ In order to render the ingress objects similar to the other objects use as demon
 
 Note, that in comparison only the last line was added, the rest is identical to the original.
 
-See [ingress.jsonnet](../../examples/ingress.jsonnet) for an example implementation.
+See [ingress.jsonnet](https://github.com/prometheus-operator/kube-prometheus/tree/main/examples/ingress.jsonnet) for an example implementation.

--- a/docs/customizations/pod-anti-affinity.md
+++ b/docs/customizations/pod-anti-affinity.md
@@ -1,7 +1,7 @@
 ### Pod Anti-Affinity
 
 To prevent `Prometheus` and `Alertmanager` instances from being deployed onto the same node when
-possible, one can include the [kube-prometheus-anti-affinity.libsonnet](../../jsonnet/kube-prometheus/addons/anti-affinity.libsonnet) mixin:
+possible, one can include the [kube-prometheus-anti-affinity.libsonnet](https://github.com/prometheus-operator/kube-prometheus/tree/main/jsonnet/kube-prometheus/addons/anti-affinity.libsonnet) mixin:
 
 ```jsonnet mdox-exec="cat examples/anti-affinity.jsonnet"
 local kp = (import 'kube-prometheus/main.libsonnet') +

--- a/docs/customizations/static-etcd-configuration.md
+++ b/docs/customizations/static-etcd-configuration.md
@@ -1,6 +1,6 @@
 ### Static etcd configuration
 
-In order to configure a static etcd cluster to scrape there is a simple [static-etcd.libsonnet](../../jsonnet/kube-prometheus/addons/static-etcd.libsonnet) mixin prepared.
+In order to configure a static etcd cluster to scrape there is a simple [static-etcd.libsonnet](https://github.com/prometheus-operator/kube-prometheus/tree/main/jsonnet/kube-prometheus/addons/static-etcd.libsonnet) mixin prepared.
 
 An example of how to use it can be seen below:
 

--- a/jsonnet/kube-prometheus/platforms/README.md
+++ b/jsonnet/kube-prometheus/platforms/README.md
@@ -1,3 +1,3 @@
 # Adding a new platform specific configuration
 
-Adding a new platform specific configuration requires to update the [customization example](../../../docs/customizations/platform-specific.md#running-kube-prometheus-on-specific-platforms) and the [platforms.libsonnet](platforms.libsonnet) file by adding the platform to the list of existing ones. This allow the new platform to be discoverable and easily configurable by the users.
+Adding a new platform specific configuration requires to update the [customization example](https://github.com/prometheus-operator/kube-prometheus/tree/main/../docs/customizations/platform-specific.md#running-kube-prometheus-on-specific-platforms) and the [platforms.libsonnet](platforms.libsonnet) file by adding the platform to the list of existing ones. This allow the new platform to be discoverable and easily configurable by the users.


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Relative links in docs do work for Github but will be broken on external pages like https://prometheus-operator.dev

Example:

Click on any of the links provided here, they will result in 404:
https://prometheus-operator.dev/docs/kube/developing-prometheus-rules-and-grafana-dashboards/

The markdown there looks like this:

```markdown
As a basis, all examples in this guide are based on the base example of the kube-prometheus [readme](https://prometheus-operator.dev/docs/README.md):
```

But https://prometheus-operator.dev/docs/README.md is not found.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Fix broken links to kube-prometheus docs in https://prometheus-operator.dev/
```
