### PR TITLE
readme: Add note about server-side apply in the quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Though for a quickstart a compiled version of the Kubernetes [manifests](manifes
 
 ```shell
 # Create the namespace and CRDs, and then wait for them to be available before creating the remaining resources
+# Note that due to some CRD size we are using kubectl server-side apply feature which is generally available since kubernetes 1.22. 
+# If you are using previous kubernetes versions this feature may not be available and you would need to use kubectl create instead.
 kubectl apply --server-side -f manifests/setup
 until kubectl get servicemonitors --all-namespaces ; do date; sleep 1; echo ""; done
 kubectl apply -f manifests/


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

It is very easy to overlook the --server-side apply flag and then waste time trying to figure out the CRD too long issue.
I have copy-pasted the note about server-side apply from customizing.md. 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

- Add note about server-side apply in the quickstart

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
