### PR TITLE
add pod phase="Failed"

### DIFF
--- a/manifests/kubernetesControlPlane-prometheusRule.yaml
+++ b/manifests/kubernetesControlPlane-prometheusRule.yaml
@@ -32,7 +32,7 @@ spec:
       expr: |
         sum by (namespace, pod, cluster) (
           max by(namespace, pod, cluster) (
-            kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}
+            kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown|Failed"}
           ) * on(namespace, pod, cluster) group_left(owner_kind) topk by(namespace, pod, cluster) (
             1, max by(namespace, pod, owner_kind, cluster) (kube_pod_owner{owner_kind!="Job"})
           )


### PR DESCRIPTION
my pods phase="Failed",but not alert ,so need add it to fix

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

my pods has Failed.but not alert
![wecom-temp-143384-cd4b7664b147c667d67bfe82710e715c](https://user-images.githubusercontent.com/55949132/185274405-f919533c-d45b-474c-8b4b-9c80bb7f6bbd.png)

![image](https://user-images.githubusercontent.com/55949132/185274481-84b26794-bd1e-4e09-8eef-1c6d4bb0601c.png)

so need to fix it 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
add pod phase="Failed" for KubePodNotReady
```
