### PR TITLE
Updates Prometheus Adapater version to 0.10.0

### DIFF
--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -43,7 +43,7 @@ local utils = import './lib/utils.libsonnet';
         kubeStateMetrics: 'k8s.gcr.io/kube-state-metrics/kube-state-metrics:v' + $.values.common.versions.kubeStateMetrics,
         nodeExporter: 'quay.io/prometheus/node-exporter:v' + $.values.common.versions.nodeExporter,
         prometheus: 'quay.io/prometheus/prometheus:v' + $.values.common.versions.prometheus,
-        prometheusAdapter: 'k8s.gcr.io/prometheus-adapter/prometheus-adapter:v' + $.values.common.versions.prometheusAdapter,
+        prometheusAdapter: 'registry.k8s.io/prometheus-adapter/prometheus-adapter:v' + $.values.common.versions.prometheusAdapter,
         prometheusOperator: 'quay.io/prometheus-operator/prometheus-operator:v' + $.values.common.versions.prometheusOperator,
         prometheusOperatorReloader: 'quay.io/prometheus-operator/prometheus-config-reloader:v' + $.values.common.versions.prometheusOperator,
         kubeRbacProxy: 'quay.io/brancz/kube-rbac-proxy:v' + $.values.common.versions.kubeRbacProxy,

--- a/jsonnet/kube-prometheus/versions.json
+++ b/jsonnet/kube-prometheus/versions.json
@@ -5,7 +5,7 @@
   "kubeStateMetrics": "2.6.0",
   "nodeExporter": "1.3.1",
   "prometheus": "2.38.0",
-  "prometheusAdapter": "0.9.1",
+  "prometheusAdapter": "0.10.0",
   "prometheusOperator": "0.59.0",
   "kubeRbacProxy": "0.13.0",
   "configmapReload": "0.5.0",

--- a/manifests/prometheusAdapter-apiService.yaml
+++ b/manifests/prometheusAdapter-apiService.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: v1beta1.metrics.k8s.io
 spec:
   group: metrics.k8s.io

--- a/manifests/prometheusAdapter-clusterRole.yaml
+++ b/manifests/prometheusAdapter-clusterRole.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: prometheus-adapter
   namespace: monitoring
 rules:

--- a/manifests/prometheusAdapter-clusterRoleAggregatedMetricsReader.yaml
+++ b/manifests/prometheusAdapter-clusterRoleAggregatedMetricsReader.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"

--- a/manifests/prometheusAdapter-clusterRoleBinding.yaml
+++ b/manifests/prometheusAdapter-clusterRoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: prometheus-adapter
   namespace: monitoring
 roleRef:

--- a/manifests/prometheusAdapter-clusterRoleBindingDelegator.yaml
+++ b/manifests/prometheusAdapter-clusterRoleBindingDelegator.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: resource-metrics:system:auth-delegator
   namespace: monitoring
 roleRef:

--- a/manifests/prometheusAdapter-clusterRoleServerResources.yaml
+++ b/manifests/prometheusAdapter-clusterRoleServerResources.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: resource-metrics-server-resources
   namespace: monitoring
 rules:

--- a/manifests/prometheusAdapter-configMap.yaml
+++ b/manifests/prometheusAdapter-configMap.yaml
@@ -64,6 +64,6 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: adapter-config
   namespace: monitoring

--- a/manifests/prometheusAdapter-deployment.yaml
+++ b/manifests/prometheusAdapter-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: prometheus-adapter
   namespace: monitoring
 spec:
@@ -25,7 +25,7 @@ spec:
         app.kubernetes.io/component: metrics-adapter
         app.kubernetes.io/name: prometheus-adapter
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 0.9.1
+        app.kubernetes.io/version: 0.10.0
     spec:
       automountServiceAccountToken: true
       containers:
@@ -37,7 +37,7 @@ spec:
         - --prometheus-url=http://prometheus-k8s.monitoring.svc:9090/
         - --secure-port=6443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA
-        image: k8s.gcr.io/prometheus-adapter/prometheus-adapter:v0.9.1
+        image: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.10.0
         livenessProbe:
           failureThreshold: 5
           httpGet:

--- a/manifests/prometheusAdapter-networkPolicy.yaml
+++ b/manifests/prometheusAdapter-networkPolicy.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: prometheus-adapter
   namespace: monitoring
 spec:

--- a/manifests/prometheusAdapter-podDisruptionBudget.yaml
+++ b/manifests/prometheusAdapter-podDisruptionBudget.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: prometheus-adapter
   namespace: monitoring
 spec:

--- a/manifests/prometheusAdapter-roleBindingAuthReader.yaml
+++ b/manifests/prometheusAdapter-roleBindingAuthReader.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: resource-metrics-auth-reader
   namespace: kube-system
 roleRef:

--- a/manifests/prometheusAdapter-service.yaml
+++ b/manifests/prometheusAdapter-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: prometheus-adapter
   namespace: monitoring
 spec:

--- a/manifests/prometheusAdapter-serviceAccount.yaml
+++ b/manifests/prometheusAdapter-serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: prometheus-adapter
   namespace: monitoring

--- a/manifests/prometheusAdapter-serviceMonitor.yaml
+++ b/manifests/prometheusAdapter-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: metrics-adapter
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 0.9.1
+    app.kubernetes.io/version: 0.10.0
   name: prometheus-adapter
   namespace: monitoring
 spec:


### PR DESCRIPTION


<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Updates Prometheus Adapater version to 0.10.0
Updates Prometheus Adapater image to official image documented in kubernetes-sigs/prometheus-adapter/README.md

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Updates Prometheus Adapater image to official image documented in kubernetes-sigs/prometheus-adapter 
```
