### PR TITLE
Update network policy to get metrics from adapter

### DIFF
--- a/manifests/prometheus-networkPolicy.yaml
+++ b/manifests/prometheus-networkPolicy.yaml
@@ -26,6 +26,9 @@ spec:
     - podSelector:
         matchLabels:
           app.kubernetes.io/name: grafana
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus-adapter
     ports:
     - port: 9090
       protocol: TCP


### PR DESCRIPTION
kubectl top nodes & kubectl top pods -A fails

prometheus-adapter logs:
E0910 20:08:11.883369       1 provider.go:284] failed querying node metrics: unable to fetch node CPU metrics: unable to execute query: Get "http://prometheus-k8s.monitoring.svc:9090/api/v1/query?query=sum+by+%28node%29+%28%0A++1+-+irate%28%0A++++node_cpu_seconds_total%7Bmode%3D%22idle%22%7D%5B60s%5D%0A++%29%0A++%2A+on%28namespace%2C+pod%29+group_left%28node%29+%28%0A++++node_namespace_pod%3Akube_pod_info%3A%7Bnode%3D~%22k8s-n06%7Ck8s-n01%7Ck8s-n02%7Ck8s-n03%7Ck8s-n04%7Ck8s-n05%22%7D%0A++%29%0A%29%0Aor+sum+by+%28node%29+%28%0A++1+-+irate%28%0A++++windows_cpu_time_total%7Bmode%3D%22idle%22%2C+job%3D%22windows-exporter%22%2Cnode%3D~%22k8s-n06%7Ck8s-n01%7Ck8s-n02%7Ck8s-n03%7Ck8s-n04%7Ck8s-n05%22%7D%5B4m%5D%0A++%29%0A%29%0A&time=1662840461.882": dial tcp 10.104.93.219:9090: i/o timeout

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
