### PR TITLE
Fix alertmanager external config example

### DIFF
--- a/examples/alertmanager-config-template-external.jsonnet
+++ b/examples/alertmanager-config-template-external.jsonnet
@@ -15,6 +15,9 @@ local kp =
       common+: {
         namespace: 'monitoring',
       },
+      alertmanager+: {
+        config: importstr 'alertmanager-config.yaml',
+      },
     },
     alertmanager+:: {
       alertmanager+: {
@@ -26,9 +29,9 @@ local kp =
     },
     configmap+:: {
       'alert-templates': configmap(
-        'alertmanager-alert-template.tmpl',
+        'alert-templates',
         $.values.common.namespace,  // could be $._config.namespace to assign namespace once
-        { data: importstr 'alertmanager-alert-template.tmpl' },
+        { 'alertmanager-alert-template.tmpl': importstr 'alertmanager-alert-template.tmpl' },
       ),
     },
   };

--- a/examples/alertmanager-config-with-template.yaml
+++ b/examples/alertmanager-config-with-template.yaml
@@ -24,4 +24,4 @@ slack_configs:
     text: '{{ template "slack.text" . }}
 
 templates:
-- '/etc/alertmanager/configmaps/alertmanager-alert-template.tmpl'
+- '/etc/alertmanager/configmaps/alert-templates/*.tmpl'


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Problems with the current example:
* Alertmanager can't find `cm/alert-templates` and keeps failing
*  Templates path in external alertmanager config is incorrect
* We are not using the external alertmanager config with templates path included


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Fix alertmanager external config example
```
