### PR TITLE
Bugfix: Set path.udev.data Argument of Node Exporter

### DIFF
--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -201,6 +201,7 @@ function(params) {
         '--web.listen-address=' + std.join(':', [ne._config.listenAddress, std.toString(ne._config.port)]),
         '--path.sysfs=/host/sys',
         '--path.rootfs=/host/root',
+        '--path.udev.data=/host/root/run/udev/data',
         '--no-collector.wifi',
         '--no-collector.hwmon',
         '--collector.filesystem.mount-points-exclude=' + ne._config.filesystemMountPointsExclude,

--- a/manifests/nodeExporter-daemonset.yaml
+++ b/manifests/nodeExporter-daemonset.yaml
@@ -30,6 +30,7 @@ spec:
         - --web.listen-address=127.0.0.1:9100
         - --path.sysfs=/host/sys
         - --path.rootfs=/host/root
+        - --path.udev.data=/host/root/run/udev/data
         - --no-collector.wifi
         - --no-collector.hwmon
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)


### PR DESCRIPTION
## Description

This PR fix a bug in the `node-exporter` daemon set that it cannot open the /run/udev/data path.
Example error log from node-exporter pods:
```
ts=2022-10-21T15:55:50.349Z caller=diskstats_linux.go:264 level=error collector=diskstats msg="Failed to open directory, disabling udev device properties" path=/run/udev/data
```


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix a bug in Node Exporter that diskstat collector cannot open the /run/udev/data path.
```
