### PR TITLE
Switch ksm registry to registry.k8s.io

### DIFF
--- a/docs/kube-prometheus-on-kubeadm.md
+++ b/docs/kube-prometheus-on-kubeadm.md
@@ -43,7 +43,7 @@ kubernetesVersion: "v1.23.1"
 networking:
   dnsDomain: "cluster.local"
   serviceSubnet: "10.96.0.0/12"
-imageRepository: "k8s.gcr.io"
+imageRepository: "registry.k8s.io"
 ```
 
 Notice the `.scheduler.extraArgs` and `.controllerManager.extraArgs`. This exposes the `kube-controller-manager` and `kube-scheduler` services to the rest of the cluster. If you have kubernetes core components as pods in the kube-system namespace, ensure that the `kube-prometheus-exporter-kube-scheduler` and `kube-prometheus-exporter-kube-controller-manager` services' `spec.selector` values match those of pods.

--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -40,7 +40,7 @@ local utils = import './lib/utils.libsonnet';
         alertmanager: 'quay.io/prometheus/alertmanager:v' + $.values.common.versions.alertmanager,
         blackboxExporter: 'quay.io/prometheus/blackbox-exporter:v' + $.values.common.versions.blackboxExporter,
         grafana: 'grafana/grafana:' + $.values.common.versions.grafana,
-        kubeStateMetrics: 'k8s.gcr.io/kube-state-metrics/kube-state-metrics:v' + $.values.common.versions.kubeStateMetrics,
+        kubeStateMetrics: 'registry.k8s.io/kube-state-metrics/kube-state-metrics:v' + $.values.common.versions.kubeStateMetrics,
         nodeExporter: 'quay.io/prometheus/node-exporter:v' + $.values.common.versions.nodeExporter,
         prometheus: 'quay.io/prometheus/prometheus:v' + $.values.common.versions.prometheus,
         prometheusAdapter: 'registry.k8s.io/prometheus-adapter/prometheus-adapter:v' + $.values.common.versions.prometheusAdapter,

--- a/manifests/kubeStateMetrics-deployment.yaml
+++ b/manifests/kubeStateMetrics-deployment.yaml
@@ -32,7 +32,7 @@ spec:
         - --port=8081
         - --telemetry-host=127.0.0.1
         - --telemetry-port=8082
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.6.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.6.0
         name: kube-state-metrics
         resources:
           limits:


### PR DESCRIPTION
## Description

Kubernetes has switched registry from k8s.gcr.io to registry.k8s.io in https://github.com/kubernetes/kubernetes/pull/109938.

kube-state-metrics also did the switch in https://github.com/kubernetes/kube-state-metrics/pull/1750.

This PR also updates the registry in a kubeadm configuration example.


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

```release-note
Update kube-state-metrics image registry
```
