### PR TITLE
fix kubeletdown alert, remove absent

### DIFF
--- a/manifests/kubernetesControlPlane-prometheusRule.yaml
+++ b/manifests/kubernetesControlPlane-prometheusRule.yaml
@@ -773,7 +773,7 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletdown
         summary: Target disappeared from Prometheus target discovery.
       expr: |
-        absent(up{job="kubelet", metrics_path="/metrics"} == 1)
+        up{job="kubelet", metrics_path="/metrics"} == 0
       for: 15m
       labels:
         severity: critical


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._
I found that kubelet down was not alerting if a kubelet was down or a node was offline.

This is how absent is described in the docs:
```
absent(v instant-vector) returns an empty vector if the vector passed 
to it has any elements (floats or native histograms) and a 1-element vector 
with the value 1 if the vector passed to it has no elements.
```

So it will only trigger when all kubelets are down and not when 1 or n-1 is down.
So i changed the expression to evaluate if the metrics is `0` with out `absent`.

The kubelet went down:
![Screenshot from 2022-12-01 10-45-53](https://user-images.githubusercontent.com/12862587/205020585-c10860e4-b1d4-4fef-bb07-f47ee3b8fe75.png)

The alert expression does not pick it up:
![Screenshot from 2022-12-01 10-46-06](https://user-images.githubusercontent.com/12862587/205020737-25896606-a564-4252-af26-a8f57aff0252.png)

The new expression picks it up:

![Screenshot from 2022-12-01 10-46-14](https://user-images.githubusercontent.com/12862587/205020854-f3efe149-7c6e-4dd3-b3b0-e742b63258fa.png)


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix kubeletDown alert by not using absent
```
