### PR TITLE
kube-state-metrics switched from master to main

### DIFF
--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -64,7 +64,7 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "master"
+      "version": "main"
     },
     {
       "source": {
@@ -73,7 +73,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "master"
+      "version": "main"
     },
     {
       "source": {


### PR DESCRIPTION
## Description
As kubernetes/kube-state-metrics changed master branch to main branch, jb install currently fails. 

```
jb install <snip>/kube-prometheus@main 
```
Is currently failing with the hint, that kubernetes/kube-state-metrics under the "master" branch creates a nice 404.



## Type of change

I changed version "master" to version "main".

## Changelog entry

Adapted to renamed upstream master branch -> main branch
