### PR TITLE
fix: prometheus network policy let prometheus-adapter pass

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -120,6 +120,18 @@ function(params) {
         from: [{
           podSelector: {
             matchLabels: {
+              'app.kubernetes.io/name': 'prometheus-adapter',
+            },
+          },
+        }],
+        ports: [{
+          port: 9090,
+          protocol: 'TCP',
+        }],
+      }, {
+        from: [{
+          podSelector: {
+            matchLabels: {
               'app.kubernetes.io/name': 'grafana',
             },
           },

--- a/manifests/prometheus-networkPolicy.yaml
+++ b/manifests/prometheus-networkPolicy.yaml
@@ -25,6 +25,13 @@ spec:
   - from:
     - podSelector:
         matchLabels:
+          app.kubernetes.io/name: prometheus-adapter
+    ports:
+    - port: 9090
+      protocol: TCP
+  - from:
+    - podSelector:
+        matchLabels:
           app.kubernetes.io/name: grafana
     ports:
     - port: 9090


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

fix #1764 by add `prometheus-adapter` in prometheus's network policy to access it's 9090 port.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
add `prometheus-adapter` in prometheus's network policy, fix #1764 
```
