### PR TITLE
Fix custom-metrics addon compilation

### DIFF
--- a/jsonnet/kube-prometheus/addons/custom-metrics.libsonnet
+++ b/jsonnet/kube-prometheus/addons/custom-metrics.libsonnet
@@ -4,7 +4,6 @@
 {
   values+:: {
     prometheusAdapter+: {
-      namespace: $.values.prometheusAdapter.namespace,
       // Rules for custom-metrics
       config+:: {
         rules+: [


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

The custom-metrics addon couldn't compile anymore after https://github.com/prometheus-operator/kube-prometheus/commit/80d04a1d53376ec31b3924b23d2fc1604bd0c952 because it was trying to get the value of `$.values.prometheusAdapter.namespace` inside of the field itself.

```
RUNTIME ERROR: max stack frames exceeded.
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	...
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/addons/custom-metrics.libsonnet:7:18-54	object <anonymous>
	vendor/kube-prometheus/components/prometheus-adapter.libsonnet:142:20-40	object <anonymous>
	Field "namespace"	
	Field "service"	
	Field "spec"	
	Field "prometheus-adapter-apiService"	
	During manifestation
```

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix a compilation error when building the custom-metrics addon
```
