### PR TITLE
Adds startupProbe to prometheus-adapter

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -236,13 +236,21 @@ function(params) {
         '--tls-cipher-suites=' + std.join(',', pa._config.tlsCipherSuites),
       ],
       resources: pa._config.resources,
+      startupProbe: {
+        httpGet: {
+          path: '/livez',
+          port: 'https',
+          scheme: 'HTTPS',
+        },
+        periodSeconds: 10,
+        failureThreshold: 18,
+      },
       readinessProbe: {
         httpGet: {
           path: '/readyz',
           port: 'https',
           scheme: 'HTTPS',
         },
-        initialDelaySeconds: 30,
         periodSeconds: 5,
         failureThreshold: 5,
       },
@@ -252,7 +260,6 @@ function(params) {
           port: 'https',
           scheme: 'HTTPS',
         },
-        initialDelaySeconds: 30,
         periodSeconds: 5,
         failureThreshold: 5,
       },

--- a/manifests/prometheusAdapter-deployment.yaml
+++ b/manifests/prometheusAdapter-deployment.yaml
@@ -44,7 +44,6 @@ spec:
             path: /livez
             port: https
             scheme: HTTPS
-          initialDelaySeconds: 30
           periodSeconds: 5
         name: prometheus-adapter
         ports:
@@ -56,7 +55,6 @@ spec:
             path: /readyz
             port: https
             scheme: HTTPS
-          initialDelaySeconds: 30
           periodSeconds: 5
         resources:
           limits:
@@ -71,6 +69,13 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+        startupProbe:
+          failureThreshold: 18
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /tmp
           name: tmpfs


### PR DESCRIPTION
## Description

Issue: https://issues.redhat.com/browse/OCPBUGS-7694

Problem: in clusters with a large nb of CRDs deployed prom-adapter takes too long to discover all of them which makes it fail the livenessProbe

Solution: introduce a startupProbe that gives 3 minutes and 30 seconds for prom-adapter to initialize

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Add startupProbe to prometheus-adapter
```
