### PR TITLE
Improve ArgoCD support

### DIFF
--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -105,6 +105,7 @@ function(params) {
           bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
           metricRelabelings: relabelings,
           relabelings: [{
+            action: 'replace',
             sourceLabels: ['__metrics_path__'],
             targetLabel: 'metrics_path',
           }],
@@ -121,6 +122,7 @@ function(params) {
           },
           bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
           relabelings: [{
+            action: 'replace',
             sourceLabels: ['__metrics_path__'],
             targetLabel: 'metrics_path',
           }],
@@ -166,6 +168,7 @@ function(params) {
           tlsConfig: { insecureSkipVerify: true },
           bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
           relabelings: [{
+            action: 'replace',
             sourceLabels: ['__metrics_path__'],
             targetLabel: 'metrics_path',
           }],

--- a/manifests/kubernetesControlPlane-serviceMonitorKubelet.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorKubelet.yaml
@@ -46,7 +46,8 @@ spec:
       - __name__
     port: https-metrics
     relabelings:
-    - sourceLabels:
+    - action: replace
+      sourceLabels:
       - __metrics_path__
       targetLabel: metrics_path
     scheme: https
@@ -75,7 +76,8 @@ spec:
     path: /metrics/cadvisor
     port: https-metrics
     relabelings:
-    - sourceLabels:
+    - action: replace
+      sourceLabels:
       - __metrics_path__
       targetLabel: metrics_path
     scheme: https
@@ -87,7 +89,8 @@ spec:
     path: /metrics/probes
     port: https-metrics
     relabelings:
-    - sourceLabels:
+    - action: replace
+      sourceLabels:
       - __metrics_path__
       targetLabel: metrics_path
     scheme: https


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

The `relabelings` block of the `serviceMonitor` configuration for the k8s-control-plane component does not include the `action` field.

The default value for action is `replace`.
- https://github.com/prometheus-operator/prometheus-operator/blob/e2ce57ad6c383a886a7d5fb518a677e1dd6a6115/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml#L179-L189
- https://github.com/prometheus-operator/prometheus-operator/blob/e2ce57ad6c383a886a7d5fb518a677e1dd6a6115/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml#L360-L373

Having this field undefined makes [ArgoCD](https://argo-cd.readthedocs.io/en/stable/) to be always unsynced. 

The definitions in this repo code lack the `action` field, but when the object is created in Kubernetes, the field is written in the Kubernetes object with the default value (`replace`). Then, ArgoCD compares with the code in the repo and tries to sync again (removing the `action` field). This causes an infinite loop of adding and removing the `action` field.

Setting the `action` field to the default value (`replace`) in the code solves this problem and does not change the behavior of `serviceMonitor`.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry
```
Modifies k8s-control-plane's serviceMonitors to be compatible with [ArgoCD](https://argo-cd.readthedocs.io/en/stable/)
```
<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

