### PR TITLE
Added an alert about average node memory utilization

### DIFF
--- a/manifests/nodeExporter-prometheusRule.yaml
+++ b/manifests/nodeExporter-prometheusRule.yaml
@@ -134,6 +134,28 @@ spec:
       for: 1h
       labels:
         severity: critical
+
+    - alert: NodesMemoryFillingUp
+      annotations:
+        description: Average nodes memory utilization is {{ printf "%.2f" $value }}% and is filling up.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodesmemoryfillingup
+        summary: Average nodes memory utilization is high.
+      expr: |
+        ((Sum(node_memory_MemTotal_bytes) - Sum(node_memory_MemAvailable_bytes)) / Sum(node_memory_MemAvailable_bytes) * 100) > 80
+      for: 15m
+      labels:
+        severity: warning
+    - alert: NodesMemoryFillingUp
+      annotations:
+        description: Average nodes memory utilization is {{ printf "%.2f" $value }}% and is filling up.
+        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodesmemoryfillingup
+        summary: Average nodes memory utilization is high.
+      expr: |
+        ((Sum(node_memory_MemTotal_bytes) - Sum(node_memory_MemAvailable_bytes)) / Sum(node_memory_MemAvailable_bytes) * 100) > 90
+      for: 15m
+      labels:
+        severity: critical
+
     - alert: NodeNetworkReceiveErrs
       annotations:
         description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} receive errors in the last two minutes.'


### PR DESCRIPTION
<!--
Added an alert about average nodes memory utilization-->

## Description

Right now the existing `kube-prometheus-stack` doesn't have any alerts where average nodes memory utilization goes above a certain threshold value. I think this alert will be really helpful. 
In one of our clusters we do a manual scaling of nodes - so we have no way to know when we actually go ahead and scale the nodes. But, with the help of this alert, we can know that the time has come to scale the nodes.

Also, even if we do autoscaling of nodes - this alert will help us to verify the logic of autoscaling if that's happening correctly or not.

Apart for scaling point of view, i think adding this alert really makes sense.


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
- Add an alert about average nodes memory utilization.
-->

```release-note

```
