### PR TITLE
AKS - Create dedicated kubernetes service to expose CoreDNS metrics

### DIFF
--- a/jsonnet/kube-prometheus/platforms/aks.libsonnet
+++ b/jsonnet/kube-prometheus/platforms/aks.libsonnet
@@ -12,7 +12,7 @@
   },
 
   kubernetesControlPlane+: {
-    kubeDnsPrometheusDiscoveryService: {
+    kubeDnsPrometheusStackService: {
       apiVersion: 'v1',
       kind: 'Service',
       metadata: {

--- a/jsonnet/kube-prometheus/platforms/aks.libsonnet
+++ b/jsonnet/kube-prometheus/platforms/aks.libsonnet
@@ -10,4 +10,23 @@
   prometheusAdapter+:: {
     apiService:: null,
   },
+
+  kubernetesControlPlane+: {
+    kubeDnsPrometheusDiscoveryService: {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: {
+        name: 'kube-prometheus-stack-coredns',
+        namespace: 'kube-system',
+        labels: { 'k8s-app': 'kube-dns' },
+      },
+      spec: {
+        ports: [
+          { name: 'metrics', port: 9153, targetPort: 9153 },
+        ],
+        selector: { 'k8s-app': 'kube-dns' },
+        clusterIP: 'None',
+      },
+    },
+  },
 }


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Currently the kube-prometheus-stack creates a ServiceMonitor to collect the coredns metrics of a Kubernetes Service which is not exposing them. This is caused by the fact that AKS is not exposing the metrics port by default on the kube-dns service.

In order not to have to patch the service manually, I suggest the creation of a dedicated service in case that the platform is set to aks.

AKS kube-dns service definition:
```
Name:              kube-dns
Namespace:         kube-system
Labels:            addonmanager.kubernetes.io/mode=Reconcile
                   k8s-app=kube-dns
                   kubernetes.io/cluster-service=true
                   kubernetes.io/name=CoreDNS
Annotations:       <none>
Selector:          k8s-app=kube-dns
Type:              ClusterIP
IP Family Policy:  SingleStack
IP Families:       IPv4
IP:                10.0.0.10
IPs:               10.0.0.10
Port:              dns  53/UDP
TargetPort:        53/UDP
Endpoints:         10.244.4.33:53,10.244.6.49:53
Port:              dns-tcp  53/TCP
TargetPort:        53/TCP
Endpoints:         10.244.4.33:53,10.244.6.49:53
Session Affinity:  None
Events:            <none>
```

Code section where we create the CoreDNS ServiceMonitor https://github.com/prometheus-operator/kube-prometheus/blob/c9e1145027df233fa3d1d7aed86cacbf6001d1f5/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet#L315

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [X] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Added kubernetes service creation for AKS platform to expose CoreDNS metrics

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
