### PR TITLE
fix: use names from resources directly

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -248,11 +248,11 @@ function(params) {
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
       kind: 'Role',
-      name: p._metadata.name + '-config',
+      name: p.roleConfig.metadata.name,
     },
     subjects: [{
       kind: 'ServiceAccount',
-      name: p._metadata.name,
+      name: p.serviceAccount.metadata.name,
       namespace: p._config.namespace,
     }],
   },
@@ -266,11 +266,11 @@ function(params) {
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
       kind: 'ClusterRole',
-      name: p._metadata.name,
+      name: p.clusterRole.metadata.name,
     },
     subjects: [{
       kind: 'ServiceAccount',
-      name: p._metadata.name,
+      name: p.serviceAccount.metadata.name,
       namespace: p._config.namespace,
     }],
   },


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Currently, if you override for any reason Prometheus' ServiceAccount name, the related `subject` name will not change.

The workaround is to override `subject` alongside with overriding ServiceAccount name, which is not ideal.
```
          serviceAccount+: {
            metadata+: {
              name: 'my-serviceaccount-name',
            },
          },
...
          clusterRoleBinding+: {
            subjects: [{
              kind: 'ServiceAccount',
              name: 'my-serviceaccount-name',
              namespace: 'my-namespace',
            }],

```

The same for Role and ClusterRole name in RoleBinding and ClusterRoleBinding accordingly.

This patch fixes this behaviour and you will be able to override


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Use ServiceAccount, Role and ClusterRole names in RoleBinding and ClusterRoleBinding referencing from the according resources instead of generating on the spot.
```
