### PR TITLE
Changing what should be cluster scoped resources from namespace scoped resources

### DIFF
--- a/manifests/blackboxExporter-clusterRoleBinding.yaml
+++ b/manifests/blackboxExporter-clusterRoleBinding.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.24.0
   name: blackbox-exporter
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/nodeExporter-clusterRole.yaml
+++ b/manifests/nodeExporter-clusterRole.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.6.0
   name: node-exporter
-  namespace: monitoring
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/manifests/nodeExporter-clusterRoleBinding.yaml
+++ b/manifests/nodeExporter-clusterRoleBinding.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.6.0
   name: node-exporter
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/prometheusAdapter-clusterRole.yaml
+++ b/manifests/prometheusAdapter-clusterRole.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.10.0
   name: prometheus-adapter
-  namespace: monitoring
 rules:
 - apiGroups:
   - ""

--- a/manifests/prometheusAdapter-clusterRoleAggregatedMetricsReader.yaml
+++ b/manifests/prometheusAdapter-clusterRoleAggregatedMetricsReader.yaml
@@ -10,7 +10,6 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: system:aggregated-metrics-reader
-  namespace: monitoring
 rules:
 - apiGroups:
   - metrics.k8s.io

--- a/manifests/prometheusAdapter-clusterRoleBinding.yaml
+++ b/manifests/prometheusAdapter-clusterRoleBinding.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.10.0
   name: prometheus-adapter
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/prometheusAdapter-clusterRoleBindingDelegator.yaml
+++ b/manifests/prometheusAdapter-clusterRoleBindingDelegator.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.10.0
   name: resource-metrics:system:auth-delegator
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/prometheusAdapter-clusterRoleServerResources.yaml
+++ b/manifests/prometheusAdapter-clusterRoleServerResources.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.10.0
   name: resource-metrics-server-resources
-  namespace: monitoring
 rules:
 - apiGroups:
   - metrics.k8s.io


### PR DESCRIPTION
Deploying this via gitops w/ error checking is causing this deployment to fail.  kubeadm 1.26 (likely other versions as well) fixes this and removes it anyways.

It is failing because it recognizes cluster scoped resources being namespaced.  Kubernetes will auto fix this and deploy it w/o the namespace.  This makes things more compatible/to what I believe correct.

I've simply removed the namespace label from cluster scoped resources.