### PR TITLE
fix: non-namespaced resources incorrectly have namespace

### DIFF
--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -147,7 +147,10 @@ function(params) {
   clusterRoleBinding: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
-    metadata: bb._metadata,
+    metadata: {
+      name: 'blackbox-exporter',
+      labels: bb._config.commonLabels,
+    },
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
       kind: 'ClusterRole',

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -92,7 +92,10 @@ function(params) {
   clusterRoleBinding: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
-    metadata: ne._metadata,
+    metadata: {
+      name: ne._config.name,
+      labels: ne._config.commonLabels,
+    },
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
       kind: 'ClusterRole',
@@ -108,7 +111,10 @@ function(params) {
   clusterRole: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
-    metadata: ne._metadata,
+    metadata: {
+      name: ne._config.name,
+      labels: ne._config.commonLabels,
+    },
     rules: [
       {
         apiGroups: ['authentication.k8s.io'],

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -133,6 +133,11 @@ function(params) {
     labels: pa._config.commonLabels,
   },
 
+  _metadata_no_ns:: {
+    name: pa._config.name,
+    labels: pa._config.commonLabels,
+  },
+
   apiService: {
     apiVersion: 'apiregistration.k8s.io/v1',
     kind: 'APIService',
@@ -322,7 +327,7 @@ function(params) {
   clusterRole: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
-    metadata: pa._metadata,
+    metadata: pa._metadata_no_ns,
     rules: [{
       apiGroups: [''],
       resources: ['nodes', 'namespaces', 'pods', 'services'],
@@ -333,7 +338,7 @@ function(params) {
   clusterRoleBinding: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
-    metadata: pa._metadata,
+    metadata: pa._metadata_no_ns,
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',
       kind: 'ClusterRole',
@@ -349,7 +354,7 @@ function(params) {
   clusterRoleBindingDelegator: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
-    metadata: pa._metadata {
+    metadata: pa._metadata_no_ns {
       name: 'resource-metrics:system:auth-delegator',
     },
     roleRef: {
@@ -367,7 +372,7 @@ function(params) {
   clusterRoleServerResources: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
-    metadata: pa._metadata {
+    metadata: pa._metadata_no_ns {
       name: 'resource-metrics-server-resources',
     },
     rules: [{
@@ -380,7 +385,7 @@ function(params) {
   clusterRoleAggregatedMetricsReader: {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRole',
-    metadata: pa._metadata {
+    metadata: pa._metadata_no_ns {
       name: 'system:aggregated-metrics-reader',
       labels+: {
         'rbac.authorization.k8s.io/aggregate-to-admin': 'true',

--- a/manifests/blackboxExporter-clusterRoleBinding.yaml
+++ b/manifests/blackboxExporter-clusterRoleBinding.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.24.0
   name: blackbox-exporter
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/nodeExporter-clusterRole.yaml
+++ b/manifests/nodeExporter-clusterRole.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.6.0
   name: node-exporter
-  namespace: monitoring
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/manifests/nodeExporter-clusterRoleBinding.yaml
+++ b/manifests/nodeExporter-clusterRoleBinding.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 1.6.0
   name: node-exporter
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/prometheusAdapter-clusterRole.yaml
+++ b/manifests/prometheusAdapter-clusterRole.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.10.0
   name: prometheus-adapter
-  namespace: monitoring
 rules:
 - apiGroups:
   - ""

--- a/manifests/prometheusAdapter-clusterRoleAggregatedMetricsReader.yaml
+++ b/manifests/prometheusAdapter-clusterRoleAggregatedMetricsReader.yaml
@@ -10,7 +10,6 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: system:aggregated-metrics-reader
-  namespace: monitoring
 rules:
 - apiGroups:
   - metrics.k8s.io

--- a/manifests/prometheusAdapter-clusterRoleBinding.yaml
+++ b/manifests/prometheusAdapter-clusterRoleBinding.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.10.0
   name: prometheus-adapter
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/prometheusAdapter-clusterRoleBindingDelegator.yaml
+++ b/manifests/prometheusAdapter-clusterRoleBindingDelegator.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.10.0
   name: resource-metrics:system:auth-delegator
-  namespace: monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/prometheusAdapter-clusterRoleServerResources.yaml
+++ b/manifests/prometheusAdapter-clusterRoleServerResources.yaml
@@ -7,7 +7,6 @@ metadata:
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.10.0
   name: resource-metrics-server-resources
-  namespace: monitoring
 rules:
 - apiGroups:
   - metrics.k8s.io


### PR DESCRIPTION
## Description

Fixes #2016 where non-namespaced resources such as ClusterRole have a namespace set which prevents deployment.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Fix namespace specified in manifest non-namespaced resources
```
