### PR TITLE
Update grafana version to 9.3.16

### DIFF
--- a/jsonnet/kube-prometheus/versions.json
+++ b/jsonnet/kube-prometheus/versions.json
@@ -1,7 +1,7 @@
 {
   "alertmanager": "0.25.0",
   "blackboxExporter": "0.23.0",
-  "grafana": "9.3.2",
+  "grafana": "9.3.16",
   "kubeStateMetrics": "2.7.0",
   "nodeExporter": "1.5.0",
   "prometheus": "2.41.0",

--- a/manifests/grafana-config.yaml
+++ b/manifests/grafana-config.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 9.3.2
+    app.kubernetes.io/version: 9.3.16
   name: grafana-config
   namespace: monitoring
 stringData:

--- a/manifests/grafana-dashboardDatasources.yaml
+++ b/manifests/grafana-dashboardDatasources.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 9.3.2
+    app.kubernetes.io/version: 9.3.16
   name: grafana-datasources
   namespace: monitoring
 stringData:

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -600,7 +600,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-alertmanager-overview
     namespace: monitoring
 - apiVersion: v1
@@ -2361,7 +2361,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-apiserver
     namespace: monitoring
 - apiVersion: v1
@@ -4232,7 +4232,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-cluster-total
     namespace: monitoring
 - apiVersion: v1
@@ -5411,7 +5411,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-controller-manager
     namespace: monitoring
 - apiVersion: v1
@@ -6036,7 +6036,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-grafana-overview
     namespace: monitoring
 - apiVersion: v1
@@ -9113,7 +9113,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-k8s-resources-cluster
     namespace: monitoring
 - apiVersion: v1
@@ -11899,7 +11899,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-k8s-resources-namespace
     namespace: monitoring
 - apiVersion: v1
@@ -12914,7 +12914,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-k8s-resources-node
     namespace: monitoring
 - apiVersion: v1
@@ -15372,7 +15372,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-k8s-resources-pod
     namespace: monitoring
 - apiVersion: v1
@@ -17385,7 +17385,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-k8s-resources-workload
     namespace: monitoring
 - apiVersion: v1
@@ -19563,7 +19563,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-k8s-resources-workloads-namespace
     namespace: monitoring
 - apiVersion: v1
@@ -21806,7 +21806,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-kubelet
     namespace: monitoring
 - apiVersion: v1
@@ -23259,7 +23259,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-namespace-by-pod
     namespace: monitoring
 - apiVersion: v1
@@ -24984,7 +24984,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-namespace-by-workload
     namespace: monitoring
 - apiVersion: v1
@@ -26036,7 +26036,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-node-cluster-rsrc-use
     namespace: monitoring
 - apiVersion: v1
@@ -27114,7 +27114,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-node-rsrc-use
     namespace: monitoring
 - apiVersion: v1
@@ -28176,7 +28176,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-nodes-darwin
     namespace: monitoring
 - apiVersion: v1
@@ -29231,7 +29231,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-nodes
     namespace: monitoring
 - apiVersion: v1
@@ -29807,7 +29807,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-persistentvolumesusage
     namespace: monitoring
 - apiVersion: v1
@@ -31024,7 +31024,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-pod-total
     namespace: monitoring
 - apiVersion: v1
@@ -32683,7 +32683,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-prometheus-remote-write
     namespace: monitoring
 - apiVersion: v1
@@ -33907,7 +33907,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-prometheus
     namespace: monitoring
 - apiVersion: v1
@@ -35167,7 +35167,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-proxy
     namespace: monitoring
 - apiVersion: v1
@@ -36268,7 +36268,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-scheduler
     namespace: monitoring
 - apiVersion: v1
@@ -37695,7 +37695,7 @@ items:
       app.kubernetes.io/component: grafana
       app.kubernetes.io/name: grafana
       app.kubernetes.io/part-of: kube-prometheus
-      app.kubernetes.io/version: 9.3.2
+      app.kubernetes.io/version: 9.3.16
     name: grafana-dashboard-workload-total
     namespace: monitoring
 kind: ConfigMapList

--- a/manifests/grafana-dashboardSources.yaml
+++ b/manifests/grafana-dashboardSources.yaml
@@ -22,6 +22,6 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 9.3.2
+    app.kubernetes.io/version: 9.3.16
   name: grafana-dashboards
   namespace: monitoring

--- a/manifests/grafana-deployment.yaml
+++ b/manifests/grafana-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 9.3.2
+    app.kubernetes.io/version: 9.3.16
   name: grafana
   namespace: monitoring
 spec:
@@ -18,19 +18,19 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/grafana-config: adbde4cde1aa3ca57c408943af53e6f7
-        checksum/grafana-dashboardproviders: d8fb24844314114bed088b83042b1bdb
-        checksum/grafana-datasources: 0800bab7ea1e2d8ad5c09586d089e033
+        checksum/grafana-config: 8f789e9282d2c489627b7cc14331eeb5
+        checksum/grafana-dashboardproviders: c7085e546c9aa6fdaf5f4fdabcf41b7c
+        checksum/grafana-datasources: 73ffe398adc193d9836e41703c06f169
       labels:
         app.kubernetes.io/component: grafana
         app.kubernetes.io/name: grafana
         app.kubernetes.io/part-of: kube-prometheus
-        app.kubernetes.io/version: 9.3.2
+        app.kubernetes.io/version: 9.3.16
     spec:
       automountServiceAccountToken: false
       containers:
       - env: []
-        image: grafana/grafana:9.3.2
+        image: grafana/grafana:9.3.16
         name: grafana
         ports:
         - containerPort: 3000

--- a/manifests/grafana-networkPolicy.yaml
+++ b/manifests/grafana-networkPolicy.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 9.3.2
+    app.kubernetes.io/version: 9.3.16
   name: grafana
   namespace: monitoring
 spec:

--- a/manifests/grafana-prometheusRule.yaml
+++ b/manifests/grafana-prometheusRule.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 9.3.2
+    app.kubernetes.io/version: 9.3.16
     prometheus: k8s
     role: alert-rules
   name: grafana-rules

--- a/manifests/grafana-service.yaml
+++ b/manifests/grafana-service.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 9.3.2
+    app.kubernetes.io/version: 9.3.16
   name: grafana
   namespace: monitoring
 spec:

--- a/manifests/grafana-serviceAccount.yaml
+++ b/manifests/grafana-serviceAccount.yaml
@@ -6,6 +6,6 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 9.3.2
+    app.kubernetes.io/version: 9.3.16
   name: grafana
   namespace: monitoring

--- a/manifests/grafana-serviceMonitor.yaml
+++ b/manifests/grafana-serviceMonitor.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: grafana
     app.kubernetes.io/name: grafana
     app.kubernetes.io/part-of: kube-prometheus
-    app.kubernetes.io/version: 9.3.2
+    app.kubernetes.io/version: 9.3.16
   name: grafana
   namespace: monitoring
 spec:


### PR DESCRIPTION


<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This updates grafana to version 9.3.16, such that we can avoid CVE-2023-3128.

Fixes #2147 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._


<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Update grafana to version 9.3.16 to patch CVE-2023-3128.
```
