### PR TITLE
Update deprecated github action command

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -33,7 +33,7 @@ jobs:
         mv /tmp/versions.json jsonnet/kube-prometheus/versions.json
         # Get the links to the changelogs of the updated versions and make them
         # available to the reviewers
-        echo ::set-output name=new_changelogs::$(scripts/get-new-changelogs.sh)
+        echo "new_changelogs=$(scripts/get-new-changelogs.sh)" >> $GITHUB_OUTPUT
       if: matrix.branch == 'main'
     - name: Update jsonnet dependencies
       run: |


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

The save-state and set-output commands in github action have been deprecated.
They are recommending a fix as they will be deprecated soon.

For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
