### PR TITLE
Add securityContext items and add pod security labels

### DIFF
--- a/jsonnet/kube-prometheus/addons/pyrra.libsonnet
+++ b/jsonnet/kube-prometheus/addons/pyrra.libsonnet
@@ -82,7 +82,7 @@
           readOnlyRootFilesystem: true,
           runAsNonRoot: true,
           capabilities: { drop: ['ALL'] },
-          seccompProfile: { type: 'RuntimeDefault' },  
+          seccompProfile: { type: 'RuntimeDefault' },
         },
       };
 

--- a/jsonnet/kube-prometheus/addons/pyrra.libsonnet
+++ b/jsonnet/kube-prometheus/addons/pyrra.libsonnet
@@ -80,6 +80,9 @@
         securityContext: {
           allowPrivilegeEscalation: false,
           readOnlyRootFilesystem: true,
+          runAsNonRoot: true,
+          capabilities: { drop: ['ALL'] },
+          seccompProfile: { type: 'RuntimeDefault' },  
         },
       };
 

--- a/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet
+++ b/jsonnet/kube-prometheus/components/kube-rbac-proxy.libsonnet
@@ -63,5 +63,6 @@ function(params) {
     allowPrivilegeEscalation: false,
     readOnlyRootFilesystem: true,
     capabilities: { drop: ['ALL'] },
+    seccompProfile: { type: 'RuntimeDefault' },
   },
 }

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -280,7 +280,9 @@ function(params) {
       securityContext: {
         allowPrivilegeEscalation: false,
         readOnlyRootFilesystem: true,
+        runAsNonRoot: true,
         capabilities: { drop: ['ALL'] },
+        seccompProfile: { type: 'RuntimeDefault' },
       },
     };
 

--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -150,6 +150,10 @@ local utils = import './lib/utils.libsonnet';
       kind: 'Namespace',
       metadata: {
         name: $.values.common.namespace,
+        labels: {
+          'pod-security.kubernetes.io/warn': 'privileged',
+          'pod-security.kubernetes.io/warn-version': 'latest',
+        },
       },
     },
   },

--- a/manifests/blackboxExporter-deployment.yaml
+++ b/manifests/blackboxExporter-deployment.yaml
@@ -105,6 +105,8 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: blackbox-exporter

--- a/manifests/kubeStateMetrics-deployment.yaml
+++ b/manifests/kubeStateMetrics-deployment.yaml
@@ -76,6 +76,8 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
       - args:
         - --secure-listen-address=:9443
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
@@ -101,6 +103,8 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
       nodeSelector:
         kubernetes.io/os: linux
       serviceAccountName: kube-state-metrics

--- a/manifests/nodeExporter-daemonset.yaml
+++ b/manifests/nodeExporter-daemonset.yaml
@@ -94,6 +94,8 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
       hostNetwork: true
       hostPID: true
       nodeSelector:

--- a/manifests/prometheusAdapter-deployment.yaml
+++ b/manifests/prometheusAdapter-deployment.yaml
@@ -70,6 +70,9 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         startupProbe:
           failureThreshold: 18
           httpGet:

--- a/manifests/prometheusOperator-deployment.yaml
+++ b/manifests/prometheusOperator-deployment.yaml
@@ -73,6 +73,8 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+          seccompProfile:
+            type: RuntimeDefault
       nodeSelector:
         kubernetes.io/os: linux
       securityContext:

--- a/manifests/setup/namespace.yaml
+++ b/manifests/setup/namespace.yaml
@@ -1,4 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
   name: monitoring


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This adds some more securityContext options to prometheus, prometheus-adapter, pyrra and kube-rbac-proxy. 
Additionally, adding some `pod-security.kubernetes.io` warning labels to the namespace. These will inform the cluster admin about warnings but not block the deployment entirely. 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add securityContext items and add pod security labels 
```
