### PR TITLE
prometheus-adapter: remove deprecated argument

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -238,7 +238,6 @@ function(params) {
       args: [
         '--cert-dir=/var/run/serving-cert',
         '--config=/etc/adapter/config.yaml',
-        '--logtostderr=true',
         '--metrics-relist-interval=1m',
         '--prometheus-url=' + pa._config.prometheusURL,
         '--secure-port=6443',

--- a/manifests/prometheusAdapter-deployment.yaml
+++ b/manifests/prometheusAdapter-deployment.yaml
@@ -32,7 +32,6 @@ spec:
       - args:
         - --cert-dir=/var/run/serving-cert
         - --config=/etc/adapter/config.yaml
-        - --logtostderr=true
         - --metrics-relist-interval=1m
         - --prometheus-url=http://prometheus-k8s.monitoring.svc:9090/
         - --secure-port=6443


### PR DESCRIPTION

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description
The `--logtostderr` argument has been deprecated in v0.10.0 and removed in v0.11.0. It is then required to upgrade to v0.11.0.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [X] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Remove deprecated `--logtostderr` argument of prometheus-adapter.
```
