### PR TITLE
chore: use helm/kind-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,13 +92,14 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: ${{ env.golang-version }}
-    - name: Start KinD
-      uses: engineerd/setup-kind@v0.5.0
+    - name: Start kind cluster
+      uses: helm/kind-action@v1.7.0
       with:
         version: ${{ env.kind-version }}
-        image: ${{ matrix.kind-image }}
+        node_image: ${{ matrix.kind-image }}
         wait: 10s # Without default CNI, control-plane doesn't get ready until Cilium is installed
         config: .github/workflows/kind/config.yml
+        cluster_name: e2e
     - name: Install kube-router for NetworkPolicy support
       run: |
         kubectl apply -f .github/workflows/kind/kube-router.yaml


### PR DESCRIPTION


<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description
helm/kind-action seems to be more maintained than engineerd/setup-kind.


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
