### PR TITLE
[FEAT] Prometheus Adapter reload

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -300,7 +300,12 @@ function(params) {
           },
         },
         template: {
-          metadata: { labels: pa._config.commonLabels },
+          metadata: {
+            annotations: {
+              'checksum.config/md5': std.md5(pa.config.ConfigMap)
+            },
+            labels: pa._config.commonLabels
+          },
           spec: {
             containers: [c],
             serviceAccountName: $.serviceAccount.metadata.name,

--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -302,9 +302,9 @@ function(params) {
         template: {
           metadata: {
             annotations: {
-              'checksum.config/md5': std.md5(pa.config.ConfigMap)
+              'checksum.config/md5': std.md5(std.manifestYamlDoc(pa._config.config)),
             },
-            labels: pa._config.commonLabels
+            labels: pa._config.commonLabels,
           },
           spec: {
             containers: [c],

--- a/manifests/prometheusAdapter-deployment.yaml
+++ b/manifests/prometheusAdapter-deployment.yaml
@@ -21,6 +21,8 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
+      annotations:
+        checksum.config/md5: 3b1ebf7df0232d1675896f67b66373db
       labels:
         app.kubernetes.io/component: metrics-adapter
         app.kubernetes.io/name: prometheus-adapter


### PR DESCRIPTION
## Description

This PR aims to add a reload mechanism in Prometheus Adapter deployment every time its ConfigMap changes, as suggested in this issue https://github.com/prometheus-operator/kube-prometheus/issues/302.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Adds a reload mechanism in Prometheus Adapter deployment based on ConfigMap changes.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

- Add md5 hash of the ConfigMap in Prometheus Adapter Deployment Annotations to force its recreation based on changes in the ConfigMap.

```
