### PR TITLE
allow configuration of secrets for alertmanager

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -60,6 +60,7 @@ local defaults = {
     ],
   },
   replicas: 3,
+  secrets: [],
   mixin:: {
     ruleLabels: {},
     _config: {
@@ -225,6 +226,7 @@ function(params) {
       },
       resources: am._config.resources,
       nodeSelector: { 'kubernetes.io/os': 'linux' },
+      secrets: am._config.secrets,
       serviceAccountName: am.serviceAccount.metadata.name,
       securityContext: {
         runAsUser: 1000,

--- a/manifests/alertmanager-alertmanager.yaml
+++ b/manifests/alertmanager-alertmanager.yaml
@@ -28,6 +28,7 @@ spec:
     requests:
       cpu: 4m
       memory: 100Mi
+  secrets: []
   securityContext:
     fsGroup: 2000
     runAsNonRoot: true


### PR DESCRIPTION
## Description

The alertmanager CRD allows for a `secrets` setting, but the jsonnet configuration does not support this yet (https://github.com/prometheus-operator/kube-prometheus/issues/2203). This PR fixes that.

## Type of change


- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- Add `secrets` to alertmanager configuration to support importing secrets to alertmanager.
```