### PR TITLE
Declarative Prometheus SA Token Secret

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -164,6 +164,18 @@ function(params) {
     automountServiceAccountToken: true,
   },
 
+  serviceAccountToken: {
+    apiVersion: 'v1',
+    kind: 'Secret',
+    metadata: p._metadata {
+      name: p._metadata.name + '-token',
+      annotations: {
+        'kubernetes.io/service-account.name': p.serviceAccount.metadata.name,
+      },
+    },
+    type: 'kubernetes.io/service-account-token',
+  },
+
   service: {
     apiVersion: 'v1',
     kind: 'Service',

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -62,6 +62,7 @@ resources:
 - ./manifests/prometheus-roleSpecificNamespaces.yaml
 - ./manifests/prometheus-service.yaml
 - ./manifests/prometheus-serviceAccount.yaml
+- ./manifests/prometheus-serviceAccountToken.yaml
 - ./manifests/prometheus-serviceMonitor.yaml
 - ./manifests/prometheusAdapter-apiService.yaml
 - ./manifests/prometheusAdapter-clusterRole.yaml

--- a/manifests/prometheus-serviceAccountToken.yaml
+++ b/manifests/prometheus-serviceAccountToken.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: prometheus-k8s
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
+    app.kubernetes.io/name: prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.47.0
+  name: prometheus-k8s-token
+  namespace: monitoring
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Since kubernetes 1.24 it is possible to declaratively configure Secret containing ServiceAccount token instead of only relying on kubernetes to create that Secret with generated name suffix. This in turn allows to reference the Secret (instead of using `bearerTokenFile` inside a container FS) from objects like ScrapeConfig to use for authentication against kubernetes API.

This is a prerequisite to migrate Kubelet ServiceMonitor to ScrapeConfig.

I am leaving this as a draft as I am still testing this out.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
