### PR TITLE
Prometheus role change

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -215,11 +215,6 @@ function(params) {
     },
     rules: [
       {
-        apiGroups: [''],
-        resources: ['nodes/metrics'],
-        verbs: ['get'],
-      },
-      {
         nonResourceURLs: ['/metrics'],
         verbs: ['get'],
       },
@@ -285,7 +280,7 @@ function(params) {
       rules: [
         {
           apiGroups: [''],
-          resources: ['services', 'endpoints', 'pods'],
+          resources: ['services', 'endpoints', 'pods', 'nodes'],
           verbs: ['get', 'list', 'watch'],
         },
         {

--- a/manifests/prometheus-clusterRole.yaml
+++ b/manifests/prometheus-clusterRole.yaml
@@ -9,12 +9,6 @@ metadata:
     app.kubernetes.io/version: 2.47.0
   name: prometheus-k8s
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes/metrics
-  verbs:
-  - get
 - nonResourceURLs:
   - /metrics
   verbs:

--- a/manifests/prometheus-roleSpecificNamespaces.yaml
+++ b/manifests/prometheus-roleSpecificNamespaces.yaml
@@ -18,6 +18,7 @@ items:
     - services
     - endpoints
     - pods
+    - nodes
     verbs:
     - get
     - list
@@ -56,6 +57,7 @@ items:
     - services
     - endpoints
     - pods
+    - nodes
     verbs:
     - get
     - list
@@ -94,6 +96,7 @@ items:
     - services
     - endpoints
     - pods
+    - nodes
     verbs:
     - get
     - list


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

When using ScrapeConfig, prometheus cannot get Node information from KubeAPI due to:

```
ts=2023-10-07T10:28:44.996Z caller=klog.go:116 level=error component=k8s_client_runtime func=ErrorDepth msg="pkg/mod/k8s.io/client-go@v0.27.3/tools/cache/reflector.go:231: Failed to watch *v1.Node: failed to list *v1.Node: nodes is forbidden: User \"system:serviceaccount:monitoring:prometheus-k8s\" cannot list resource \"nodes\" in API group \"\" at the cluster scope"
```

This PR is an attempt to resolve this problem.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
