### PR TITLE
add monitor and rules resources to user-facing roles

### DIFF
--- a/jsonnet/kube-prometheus/addons/user-facing-roles.libsonnet
+++ b/jsonnet/kube-prometheus/addons/user-facing-roles.libsonnet
@@ -1,0 +1,67 @@
+// user facing roles for monitors, probe, and rules
+// ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+{
+  prometheusOperator+: {
+    local po = self,
+    clusterRoleView: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
+      metadata: po._metadata {
+        name: 'monitoring-view',
+        namespace:: null,
+        labels+: {
+          'rbac.authorization.k8s.io/aggregate-to-view': 'true',
+        },
+      },
+      rules: [
+        {
+          apiGroups: [
+            'monitoring.coreos.com',
+          ],
+          resources: [
+            'podmonitors',
+            'probes',
+            'prometheusrules',
+            'servicemonitors',
+          ],
+          verbs: [
+            'get',
+            'list',
+            'watch',
+          ],
+        },
+      ],
+    },
+    clusterRoleEdit: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
+      metadata: po._metadata {
+        name: 'monitoring-edit',
+        namespace:: null,
+        labels+: {
+          'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
+        },
+      },
+      rules: [
+        {
+          apiGroups: [
+            'monitoring.coreos.com',
+          ],
+          resources: [
+            'podmonitors',
+            'probes',
+            'prometheusrules',
+            'servicemonitors',
+          ],
+          verbs: [
+            'create',
+            'delete',
+            'deletecollection',
+            'patch',
+            'update',
+          ],
+        },
+      ],
+    },
+  },
+}


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

in cluster with separation between (cluster) admin and (namespaced) users, it allows the namespaced users to create monitor and rules in their namespaces according to the default k8s model of user-facing roles.

defined as an addon to have the feature disabled by default and simple to enable.

ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- add monitor and rules resources to user-facing roles (addon)
```
