### PR TITLE
Patch 2

### DIFF
--- a/jsonnet/kube-prometheus/addons/windows-hostprocess.libsonnet
+++ b/jsonnet/kube-prometheus/addons/windows-hostprocess.libsonnet
@@ -8,7 +8,7 @@ local defaults = {
   name:: 'windows-exporter',
   namespace:: error 'must provide namespace',
   version:: error 'must provide version',
-  image:: error 'must provide version',
+  image:: error 'must provide image',
   resources:: {
     requests: { cpu: '300m', memory: '200Mi' },
     limits: { memory: '200Mi' },

--- a/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/blackbox-exporter.libsonnet
@@ -6,7 +6,7 @@ local defaults = {
   // If there is no CRD for the component, everything is hidden in defaults.
   namespace:: error 'must provide namespace',
   version:: error 'must provide version',
-  image:: error 'must provide version',
+  image:: error 'must provide image',
   resources:: {
     requests: { cpu: '10m', memory: '20Mi' },
     limits: { cpu: '20m', memory: '40Mi' },

--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -7,7 +7,7 @@ local defaults = {
   name:: 'node-exporter',
   namespace:: error 'must provide namespace',
   version:: error 'must provide version',
-  image:: error 'must provide version',
+  image:: error 'must provide image',
   kubeRbacProxyImage:: error 'must provide kubeRbacProxyImage',
   resources:: {
     requests: { cpu: '102m', memory: '180Mi' },


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Fix typo in the error message for a missing `image` config field for `node-exporter`, `blackbox-exporter`, and `windows-hostprocess`

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Fix typo in the error message for a missing `image` config field for `node-exporter`, `blackbox-exporter`, and `windows-hostprocess`
```
