### PR TITLE
build: Use sort -n for automated version bumps

### DIFF
--- a/scripts/generate-versions.sh
+++ b/scripts/generate-versions.sh
@@ -34,8 +34,8 @@ get_version() {
   fi
 
   # Use higher version from new version and current version
-  v=$(printf '%s\n' "$v" "$cv" | sort -r | head -n1)
-  
+  v=$(printf '%s\n' "$v" "$cv" | sort -n -r | head -n1)
+
   echo "$v"
 }
 


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Grafana isn't upgrading from 9 to 10. I assume due to sorting issues .

```sh
printf '%s\n' "10" "9" | sort -r
```

Will output 9 before 10. Add the `-n` flag which seems to fix it.

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

Waiting on the automated grafana update but nothing is being changed :smile: .

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
build: Use sort -n for automated version bumps
```
