### PR TITLE
Fix duplicate grafana config entries

### DIFF
--- a/jsonnet/kube-prometheus/components/grafana.libsonnet
+++ b/jsonnet/kube-prometheus/components/grafana.libsonnet
@@ -39,7 +39,6 @@ function(params)
 
   kubernetesGrafana(config) {
     local g = self,
-    _config+:: config,
     _metadata:: {
       name: 'grafana',
       namespace: g._config.namespace,


### PR DESCRIPTION
## Description

Fixes custom Grafana datasources being rendered twice.
Fixes #2277 

I have only validated this for datasources and am not sure whether this change leads to issues with other configurations. Hoping to get a review by someone with more experience with this project and jsonnet as I'm pretty new to it ;)



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Fixes custom Grafana datasources being rendered twice.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Fixes custom Grafana datasources being rendered twice.
```
