### PR TITLE
Example used incorrect syntax that resulted in all rules being removed

### DIFF
--- a/examples/changing-default-rules.libsonnet
+++ b/examples/changing-default-rules.libsonnet
@@ -1,6 +1,6 @@
 local filter = {
   kubernetesControlPlane+: {
-    prometheusRule+:: {
+    prometheusRule+: {
       spec+: {
         groups: std.map(
           function(group)
@@ -22,7 +22,7 @@ local filter = {
 };
 local update = {
   kubernetesControlPlane+: {
-    prometheusRule+:: {
+    prometheusRule+: {
       spec+: {
         groups: std.map(
           function(group)


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

The current example that explains how to change the default rules does not work, instead of applying the changes from the example (filter rules, modify rules and add rules) it results in all existing rule files being removed.

This is caused by a syntax error in the example.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [X] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Modify existing rules example resulted in all rule files being removed due to a syntax error
```
