### PR TITLE
script/generate-versions: fix versions sort

### DIFF
--- a/scripts/generate-versions.sh
+++ b/scripts/generate-versions.sh
@@ -34,7 +34,7 @@ get_version() {
   fi
 
   # Use higher version from new version and current version
-  v=$(printf '%s\n' "$v" "$cv" | sort -n -r | head -n1)
+  v=$(printf '%s\n' "$v" "$cv" | sort -V -r | head -n1)
 
   echo "$v"
 }


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

I was wondering why kube-state-metrics wasn't updated from v2.9.2 to v2.10.z despite these new releases out for a couple a few months, and it seems that the script was buggy.

Instead of using `-n` option we should use `-V` which is meant for sorting versions.

```sh
➜  ~ printf '%s\n' "9" "10" | sort -V -r 
10
9
➜  ~ printf '%s\n' "2.9.2" "2.10.1" | sort -V -r
2.10.1
2.9.2
```

This new version also fixes the problem reported in https://github.com/prometheus-operator/kube-prometheus/pull/2261.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
