### PR TITLE
jsonnet/components/prometheus: Fix thanos-sidecar metrics access

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -175,7 +175,10 @@ function(params) {
              ] +
              (
                if p._config.thanos != null then
-                 [{ name: 'grpc', port: 10901, targetPort: 10901 }]
+                 [
+                   { name: 'grpc', port: 10901, targetPort: 10901 },
+                   { name: 'http', port: 10902, targetPort: 10902 },
+                 ]
                else []
              ),
       selector: p._config.selectorLabels,


### PR DESCRIPTION
## Description

When enabled, the thanos-sidecar opens an HTTP listener on port 10902, which is what's used to scrape metrics.  This port wasn't being added to the Prometheus Service, so wasn't added to the NetworkPolicy causing scraping to fail from Prometheus instances other than the local one.

This adds the port to the Service and NetworkPolicy.

Fixes: #2006



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add thanos-sidecar metrics port to Prometheus Service and NetworkPolicy.
```
