### PR TITLE
Include reference to Prometheus Operator docs for user journey

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ be created successfully.
 kubectl delete --ignore-not-found=true -f manifests/ -f manifests/setup
 ```
 
-The [official documentation](https://prometheus-operator.dev/docs/prologue/quick-start/) contains the full version of this Quickstart guide, and includes instructions on how to access Prometheus, Alertmanager, and Grafana from here. 
+The [official documentation](https://prometheus-operator.dev/docs/prologue/quick-start/) contains the full version of this quick-start guide, and includes instructions on how to access Prometheus, AlertManager, and Grafana. 
 
 ### minikube
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ be created successfully.
 kubectl delete --ignore-not-found=true -f manifests/ -f manifests/setup
 ```
 
+The [official documentation](https://prometheus-operator.dev/docs/prologue/quick-start/) contains the full version of this Quickstart guide, and includes instructions on how to access Prometheus, Alertmanager, and Grafana from here. 
+
 ### minikube
 
 To try out this stack, start [minikube](https://github.com/kubernetes/minikube) with the following command:


### PR DESCRIPTION
## Description

Currently, reading through solely the README for this project leaves users wondering how they can access services. It's a great resource for beginners, so the documentation should clearly denote this as well - on both the official docs *and* the GitHub README.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

```release-note
- Include reference to Prometheus Operator docs for user journey
```
