### PR TITLE
docs: Add the default Grafana password set by the Helm chart 

### DIFF
--- a/docs/access-ui.md
+++ b/docs/access-ui.md
@@ -18,7 +18,7 @@ Then access via [http://localhost:9090](http://localhost:9090)
 $ kubectl --namespace monitoring port-forward svc/grafana 3000
 ```
 
-Then access via [http://localhost:3000](http://localhost:3000) and use the default grafana user:password of `admin:admin`.
+Then access via [http://localhost:3000](http://localhost:3000) with the user `admin`, and password `admin`. If you used the Helm chart instead, the password is set by grafana.adminPassword and defaults to `prom-operator`.
 
 ## Alert Manager
 


### PR DESCRIPTION
## Description

Fixes https://github.com/prometheus-operator/kube-prometheus/issues/2092, https://github.com/prometheus-community/helm-charts/issues/2444

Adds documentation that explains what the default password is when using the Helm chart.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Add docs about the default Grafana password set by the Helm chart 
```