### PR TITLE
Get latest version by tag if no release exists

### DIFF
--- a/docs/blackbox-exporter.md
+++ b/docs/blackbox-exporter.md
@@ -30,7 +30,7 @@ The `prometheus-operator` defines a `Probe` resource type that can be used to de
 * `_config.namespace`: the namespace where the various generated resources (`ConfigMap`, `Deployment`, `Service`, `ServiceAccount` and `ServiceMonitor`) will reside. This does not affect where you can place `Probe` objects; that is determined by the configuration of the `Prometheus` resource. This option is shared with other `kube-prometheus` components; defaults to `default`.
 * `_config.imageRepos.blackboxExporter`: the name of the blackbox exporter image to deploy. Defaults to `quay.io/prometheus/blackbox-exporter`.
 * `_config.versions.blackboxExporter`: the tag of the blackbox exporter image to deploy. Defaults to the version `kube-prometheus` was tested with.
-* `_config.imageRepos.configmapReloader`: the name of the ConfigMap reloader image to deploy. Defaults to `jimmidyson/configmap-reload`.
+* `_config.imageRepos.configmapReloader`: the name of the ConfigMap reloader image to deploy. Defaults to `ghcr.io/jimmidyson/configmap-reload`.
 * `_config.versions.configmapReloader`: the tag of the ConfigMap reloader image to deploy. Defaults to the version `kube-prometheus` was tested with.
 * `_config.resources.blackbox-exporter.requests`: the requested resources; this is used for each container. Defaults to `10m` CPU and `20Mi` RAM. See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for details.
 * `_config.resources.blackbox-exporter.limits`: the resource limits; this is used for each container. Defaults to `20m` CPU and `40Mi` RAM. See https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for details.

--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -47,7 +47,7 @@ local utils = import './lib/utils.libsonnet';
         prometheusOperator: 'quay.io/prometheus-operator/prometheus-operator:v' + $.values.common.versions.prometheusOperator,
         prometheusOperatorReloader: 'quay.io/prometheus-operator/prometheus-config-reloader:v' + $.values.common.versions.prometheusOperator,
         kubeRbacProxy: 'quay.io/brancz/kube-rbac-proxy:v' + $.values.common.versions.kubeRbacProxy,
-        configmapReload: 'jimmidyson/configmap-reload:v' + $.values.common.versions.configmapReload,
+        configmapReload: 'ghcr.io/jimmidyson/configmap-reload:v' + $.values.common.versions.configmapReload,
       },
     },
     alertmanager: {

--- a/manifests/blackboxExporter-deployment.yaml
+++ b/manifests/blackboxExporter-deployment.yaml
@@ -58,7 +58,7 @@ spec:
       - args:
         - --webhook-url=http://localhost:19115/-/reload
         - --volume-dir=/etc/blackbox_exporter/
-        image: jimmidyson/configmap-reload:v0.5.0
+        image: ghcr.io/jimmidyson/configmap-reload:v0.5.0
         name: module-configmap-reloader
         resources:
           limits:

--- a/scripts/generate-versions.sh
+++ b/scripts/generate-versions.sh
@@ -5,7 +5,12 @@ set -euo pipefail
 # Get component version from GitHub API
 get_latest_version() {
   echo >&2 "Checking release version for ${1}"
-  curl --retry 5 --silent --fail -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${1}/releases/latest" | jq '.tag_name' | tr -d '"v'
+  v=$(curl --retry 5 --silent --fail -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${1}/releases/latest" | jq '.tag_name' | tr -d '"v')
+  if [ "${v}" == "" ]; then
+    # Get latest tag if no release is generated
+    v=$(curl --retry 5 --silent --fail -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/${1}/tags" | jq '.[].name' | head -n1 | tr -d '"v')
+  fi
+  echo "$v"
 }
 
 # Get component version from version file


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

The https://github.com/jimmidyson/configmap-reload project is no longer generating releases. As a result, we are still using version 0.5.0, which contains several vulnerabilities, while version 0.13.0 has been released as a tag. Additionally, the image location has changed from Docker Hub to GitHub.

I have added a section to the generate version script to obtain the latest tag if no release is generated. Furthermore, I have updated the image location accordingly.


## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Get latest version by tag if not release exists
```
