### PR TITLE
Allow specifying which node exporter collectors to exclude

### DIFF
--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -21,6 +21,7 @@ local defaults = {
   },
   listenAddress:: '127.0.0.1',
   filesystemMountPointsExclude:: '^/(dev|proc|sys|run/k3s/containerd/.+|var/lib/docker/.+|var/lib/kubelet/pods/.+)($|/)',
+  exportersExclude:: ['wifi', 'btrfs', 'hwmon'],
   // NOTE: ignore veth network interface associated with containers.
   // OVN renames veth.* to <rand-hex>@if<X> where X is /sys/class/net/<if>/ifindex
   // thus [a-z0-9] regex below
@@ -214,13 +215,10 @@ function(params) {
         '--path.sysfs=/host/sys',
         '--path.rootfs=/host/root',
         '--path.udev.data=/host/root/run/udev/data',
-        '--no-collector.wifi',
-        '--no-collector.hwmon',
-        '--no-collector.btrfs',
         '--collector.filesystem.mount-points-exclude=' + ne._config.filesystemMountPointsExclude,
         '--collector.netclass.ignored-devices=' + ne._config.ignoredNetworkDevices,
         '--collector.netdev.device-exclude=' + ne._config.ignoredNetworkDevices,
-      ],
+      ] + std.map (function (x) std.format ( '--no-collector.%s', x), ne._config.exportersExclude),
       volumeMounts: [
         { name: 'sys', mountPath: '/host/sys', mountPropagation: 'HostToContainer', readOnly: true },
         { name: 'root', mountPath: '/host/root', mountPropagation: 'HostToContainer', readOnly: true },


### PR DESCRIPTION
## Description

Allow specifying which collectors to exclude from node-exporter. 

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Parameter for customizing which collectors to disable in node-exporter.

```release-note
- Add jsonnet parameter to allow customizing which node-exporter collectors to disable. 
```
