### PR TITLE
Update grafana-dashboardDatasources.yaml 

### DIFF
--- a/manifests/grafana-dashboardDatasources.yaml
+++ b/manifests/grafana-dashboardDatasources.yaml
@@ -19,7 +19,7 @@ stringData:
                 "name": "prometheus",
                 "orgId": 1,
                 "type": "prometheus",
-                "url": "http://prometheus-k8s.monitoring.svc:9090",
+                "url": "http://prometheus-operated.monitoring.svc:9090",
                 "version": 1
             }
         ]


### PR DESCRIPTION
<!--
Fix Prometheus data source URL for Grafana configuration
-->

## Description

This pull request addresses an issue where the Prometheus data source does not work out of the box when Grafana is configured with the URL http://prometheus-k8s.monitoring.svc:9090. The data source works correctly when using the URL http://prometheus-operated.monitoring.svc:9090. This change ensures that the correct service URL is used for the Prometheus data source in Grafana, improving the out-of-the-box experience.


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)



