### PR TITLE
Drop process start time from SLI endpoints

### DIFF
--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -86,6 +86,13 @@ function(params) {
           path: '/metrics/slis',
           bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
           tlsConfig: { insecureSkipVerify: true },
+          metricRelabelings: [
+            {
+              sourceLabels: ['__name__'],
+              regex: 'process_start_time_seconds',
+              action: 'drop',
+            },
+          ],
         },
       ],
       selector: {
@@ -192,11 +199,18 @@ function(params) {
           honorLabels: true,
           tlsConfig: { insecureSkipVerify: true },
           bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
-          relabelings: [{
-            action: 'replace',
-            sourceLabels: ['__metrics_path__'],
-            targetLabel: 'metrics_path',
-          }],
+          relabelings: [
+            {
+              action: 'replace',
+              sourceLabels: ['__metrics_path__'],
+              targetLabel: 'metrics_path',
+            },
+            {
+              sourceLabels: ['__name__'],
+              regex: 'process_start_time_seconds',
+              action: 'drop',
+            },
+          ],
         },
       ],
       selector: {
@@ -243,6 +257,13 @@ function(params) {
           tlsConfig: {
             insecureSkipVerify: true,
           },
+          metricRelabelings: [
+            {
+              sourceLabels: ['__name__'],
+              regex: 'process_start_time_seconds',
+              action: 'drop',
+            },
+          ],
         },
       ],
       selector: {
@@ -315,6 +336,13 @@ function(params) {
             serverName: 'kubernetes',
           },
           bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+          metricRelabelings: [
+            {
+              sourceLabels: ['__name__'],
+              regex: 'process_start_time_seconds',
+              action: 'drop',
+            },
+          ],
         },
       ],
     },

--- a/manifests/kubernetesControlPlane-serviceMonitorApiserver.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorApiserver.yaml
@@ -67,6 +67,11 @@ spec:
       serverName: kubernetes
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 5s
+    metricRelabelings:
+    - action: drop
+      regex: process_start_time_seconds
+      sourceLabels:
+      - __name__
     path: /metrics/slis
     port: https
     scheme: https

--- a/manifests/kubernetesControlPlane-serviceMonitorKubeControllerManager.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorKubeControllerManager.yaml
@@ -53,6 +53,11 @@ spec:
       insecureSkipVerify: true
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 5s
+    metricRelabelings:
+    - action: drop
+      regex: process_start_time_seconds
+      sourceLabels:
+      - __name__
     path: /metrics/slis
     port: https-metrics
     scheme: https

--- a/manifests/kubernetesControlPlane-serviceMonitorKubeScheduler.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorKubeScheduler.yaml
@@ -16,6 +16,11 @@ spec:
       insecureSkipVerify: true
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     interval: 5s
+    metricRelabelings:
+    - action: drop
+      regex: process_start_time_seconds
+      sourceLabels:
+      - __name__
     path: /metrics/slis
     port: https-metrics
     scheme: https

--- a/manifests/kubernetesControlPlane-serviceMonitorKubelet.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorKubelet.yaml
@@ -106,6 +106,10 @@ spec:
       sourceLabels:
       - __metrics_path__
       targetLabel: metrics_path
+    - action: drop
+      regex: process_start_time_seconds
+      sourceLabels:
+      - __name__
     scheme: https
     tlsConfig:
       insecureSkipVerify: true


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Drop `process_start_time_seconds` from the /metrics/slis endpoints to avoid conflict with the metrics from the Kubernetes components /metrics endpont.

I'll try to get the metric remove from the endpoint completely upstream, but in the meantime, let's just drop it at scrape time.

Fixes #2500 

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fixed a conflict when scraping the new /metrics/slis endpoint from Kubernetes components.
```
