### PR TITLE
Fixes #2522: Incorrect Pod Memory Usage (WSS) Graph Behaviour

### DIFF
--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -8297,8 +8297,8 @@ items:
                               "type": "prometheus",
                               "uid": "${datasource}"
                           },
-                          "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container)",
-                          "legendFormat": "__auto"
+                          "expr": "sum(container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (container, name)",
+                          "legendFormat": "{{container}}"
                       },
                       {
                           "datasource": {


### PR DESCRIPTION
## Description

This PR addresses an issue where, upon restarting a pod, the query aggregates memory usage data from both the old and new containers. This results in temporary spikes in the displayed memory consumption, potentially causing the dashboard to show memory usage that exceeds the pod's memory limit, even though actual usage remains within the limit.

Current behaviour:
<img width="1607" alt="Screenshot 2024-09-20 at 15 41 23" src="https://github.com/user-attachments/assets/d2bb13c6-7ca5-4447-83c4-c27b8fbab08c">

Updated behaviour:
<img width="1607" alt="Screenshot 2024-09-20 at 15 42 28" src="https://github.com/user-attachments/assets/63ba37d1-ce61-45fa-82a1-6bdb583ca942">


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

```release-note
- Fix Grafana Pod dashboard showing incorrect Pod Memory Usage (WSS) due to memory data from restarted containers being combined.
```
