### PR TITLE
fix: drop `process_start_time_seconds` from Kubelet slis endpoint

### DIFF
--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -205,6 +205,8 @@ function(params) {
               sourceLabels: ['__metrics_path__'],
               targetLabel: 'metrics_path',
             },
+          ],
+          metricRelabelings: [
             {
               sourceLabels: ['__name__'],
               regex: 'process_start_time_seconds',

--- a/manifests/kubernetesControlPlane-serviceMonitorKubelet.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorKubelet.yaml
@@ -99,6 +99,11 @@ spec:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     honorLabels: true
     interval: 5s
+    metricRelabelings:
+    - action: drop
+      regex: process_start_time_seconds
+      sourceLabels:
+      - __name__
     path: /metrics/slis
     port: https-metrics
     relabelings:
@@ -106,10 +111,6 @@ spec:
       sourceLabels:
       - __metrics_path__
       targetLabel: metrics_path
-    - action: drop
-      regex: process_start_time_seconds
-      sourceLabels:
-      - __name__
     scheme: https
     tlsConfig:
       insecureSkipVerify: true


### PR DESCRIPTION
The drop action needs to happen in the metric relabeling configuration.

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
