### PR TITLE
allow customization without installing depedencies

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -165,6 +165,13 @@ be created successfully.
 
 Check the monitoring namespace (or the namespace you have specific in `namespace: `) and make sure the pods are running. Prometheus and Grafana should be up and running soon.
 
+## Containerized Installing and Compiling
+
+If you don't care to have jb nor jsonnet nor gojsontoyaml installed, then use ghcr.io/roelandvanbatenburg/kube-prometheus-builder container image. Do the following from this kube-prometheus directory:
+
+$ docker run --rm -v $(pwd):$(pwd) --workdir $(pwd) ghcr.io/roelandvanbatenburg/kube-prometheus-builder jb update
+$ docker run --rm -v $(pwd):$(pwd) --workdir $(pwd) ghcr.io/roelandvanbatenburg/kube-prometheus-builder ./build.sh example.jsonnet
+
 ## Minikube Example
 
 To use an easy to reproduce example, see [minikube.jsonnet](../examples/minikube.jsonnet), which uses the minikube setup as demonstrated in [Prerequisites](../README.md#prerequisites). Because we would like easy access to our Prometheus, Alertmanager and Grafana UIs, `minikube.jsonnet` exposes the services as NodePort type services.

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -18,7 +18,7 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "68e712276bb8a8f35f7f077add143b28422e8d66",
+      "version": "f5acd17796d39af0999fbb23df2e242dbc1b2066",
       "sum": "IXI3LQIT9NmTPJAk8WLUJd5+qZfcGpeNCyWIK7oEpws="
     },
     {
@@ -58,8 +58,8 @@
           "subdir": "gen/grafonnet-latest"
         }
       },
-      "version": "733beadbc8dab55c5fe1bcdcf0d8a2d215759a55",
-      "sum": "eyuJ0jOXeA4MrobbNgU4/v5a7ASDHslHZ0eS6hDdWoI="
+      "version": "1ce5aec95ce32336fe47c8881361847c475b5254",
+      "sum": "64fMUPI3frXGj4X1FqFd1t7r04w3CUSmXaDcJ23EYbQ="
     },
     {
       "source": {
@@ -68,18 +68,18 @@
           "subdir": "gen/grafonnet-v10.0.0"
         }
       },
-      "version": "733beadbc8dab55c5fe1bcdcf0d8a2d215759a55",
+      "version": "1ce5aec95ce32336fe47c8881361847c475b5254",
       "sum": "xdcrJPJlpkq4+5LpGwN4tPAuheNNLXZjE6tDcyvFjr0="
     },
     {
       "source": {
         "git": {
           "remote": "https://github.com/grafana/grafonnet.git",
-          "subdir": "gen/grafonnet-v11.0.0"
+          "subdir": "gen/grafonnet-v11.1.0"
         }
       },
-      "version": "733beadbc8dab55c5fe1bcdcf0d8a2d215759a55",
-      "sum": "0BvzR0i4bS4hc2O3xDv6i9m52z7mPrjvqxtcPrGhynA="
+      "version": "1ce5aec95ce32336fe47c8881361847c475b5254",
+      "sum": "41w7p/rwrNsITqNHMXtGSJAfAyKmnflg6rFhKBduUxM="
     },
     {
       "source": {
@@ -88,7 +88,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "349a4d4936014ab83ace72f500424d6ef098201e",
+      "version": "638ce5cdede46cb1a352fd8c9fa01127eb26b088",
       "sum": "yxqWcq/N3E/a/XreeU6EuE6X7kYPnG0AspAQFKOjASo="
     },
     {
@@ -98,7 +98,7 @@
           "subdir": "mixin-utils"
         }
       },
-      "version": "349a4d4936014ab83ace72f500424d6ef098201e",
+      "version": "638ce5cdede46cb1a352fd8c9fa01127eb26b088",
       "sum": "LoYq5QxJmUXEtqkEG8CFUBLBhhzDDaNANHc7Gz36ZdM="
     },
     {
@@ -128,8 +128,8 @@
           "subdir": ""
         }
       },
-      "version": "3cb7958a56688386e8f6cb0f1258bdb1234797d6",
-      "sum": "f+GOrDpxTRmyYkaZKy6CCwqGoCs9MMCmEGT1cTJ0m6k="
+      "version": "cb72d737459a655e7575c09f7859815ae3690981",
+      "sum": "JaPnO5N/KUBgA9v6qE7CYzp8OWDTpzjM0+l/SPqL4m4="
     },
     {
       "source": {
@@ -138,7 +138,7 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "f50205a4dfc81042bb140f289a3d2bc81a7557d0",
+      "version": "a9363414964759db050a6b9ca95fe060110dd77e",
       "sum": "lO7jUSzAIy8Yk9pOWJIWgPRhubkWzVh56W6wtYfbVH4="
     },
     {
@@ -148,7 +148,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "f50205a4dfc81042bb140f289a3d2bc81a7557d0",
+      "version": "a9363414964759db050a6b9ca95fe060110dd77e",
       "sum": "qclI7LwucTjBef3PkGBkKxF0mfZPbHnn4rlNWKGtR4c="
     },
     {
@@ -158,7 +158,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "7405049eb95fd85bd27acb552491146ca3074365",
+      "version": "d7238551702187164fd65c3de51278d99bf0986f",
       "sum": "gi+knjdxs2T715iIQIntrimbHRgHnpM8IFBJDD1gYfs=",
       "name": "prometheus-operator-mixin"
     },
@@ -169,8 +169,8 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "7405049eb95fd85bd27acb552491146ca3074365",
-      "sum": "orqSseZSFDyhRwMAKmGPgUkdGF/C8J+ZAFm0T5ivSrk="
+      "version": "d7238551702187164fd65c3de51278d99bf0986f",
+      "sum": "dzBCtpO20E+VN200+vSQBv68kgTdB4oNwi/Padgnrp8="
     },
     {
       "source": {
@@ -190,7 +190,7 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "11f93d3da1232ea26d89d72753fa454a56e228d8",
+      "version": "e6a9cfbdcdaa21bf9676c6cd37bef8160227f423",
       "sum": "cQCW+1N0Xae5yXecCWDK2oAlN0luBS/5GrwBYSlaFms="
     },
     {
@@ -200,7 +200,7 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "537c5dbbcf33b6d64494641466f438d8670eedd2",
+      "version": "90f7832447d2f26c181ad42fef757be68d0cb805",
       "sum": "dYLcLzGH4yF3qB7OGC/7z4nqeTNjv42L7Q3BENU8XJI=",
       "name": "prometheus"
     },
@@ -222,7 +222,7 @@
           "subdir": "mixin"
         }
       },
-      "version": "6ff5e1b3a2b3dd94886c62f5f76f0fcd7df35824",
+      "version": "f265c3b06212ab115b3411df7a875a26aad64d0c",
       "sum": "ieCD4eMgGbOlrI8GmckGPHBGQDcLasE1rULYq56W/bs=",
       "name": "thanos-mixin"
     },

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -638,7 +638,7 @@ items:
                   "options": {
                       "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only."
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "title": "Notice",
                   "type": "text"
               },
@@ -662,7 +662,7 @@ items:
                   },
                   "id": 2,
                   "interval": "1m",
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -708,7 +708,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -742,7 +742,7 @@ items:
                   },
                   "id": 4,
                   "interval": "1m",
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -840,7 +840,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -884,7 +884,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -927,7 +927,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -961,7 +961,7 @@ items:
                   },
                   "id": 8,
                   "interval": "1m",
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1059,7 +1059,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1103,7 +1103,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1146,7 +1146,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1189,7 +1189,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1232,7 +1232,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1278,7 +1278,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1320,7 +1320,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1363,7 +1363,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1405,7 +1405,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1536,7 +1536,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1582,7 +1582,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1653,7 +1653,7 @@ items:
                       "y": 9
                   },
                   "id": 3,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1818,7 +1818,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1864,7 +1864,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1910,7 +1910,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1956,7 +1956,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2002,7 +2002,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2048,7 +2048,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2094,7 +2094,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2140,7 +2140,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2186,7 +2186,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2232,7 +2232,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2339,7 +2339,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2390,7 +2390,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2441,7 +2441,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2492,7 +2492,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2543,7 +2543,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2618,7 +2618,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2669,7 +2669,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2720,7 +2720,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2771,7 +2771,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2822,7 +2822,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3568,7 +3568,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3603,7 +3603,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3638,7 +3638,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3673,7 +3673,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3708,7 +3708,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3743,7 +3743,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3793,7 +3793,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3852,7 +3852,7 @@ items:
                       "y": 12
                   },
                   "id": 8,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4009,7 +4009,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4104,7 +4104,7 @@ items:
                       "y": 24
                   },
                   "id": 10,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4281,7 +4281,7 @@ items:
                       "y": 30
                   },
                   "id": 11,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4425,7 +4425,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4476,7 +4476,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4527,7 +4527,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4578,7 +4578,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4629,7 +4629,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4680,7 +4680,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4731,7 +4731,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4782,7 +4782,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4833,7 +4833,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4884,7 +4884,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4955,7 +4955,7 @@ items:
                       "y": 96
                   },
                   "id": 22,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5155,7 +5155,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5190,7 +5190,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5225,7 +5225,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5260,7 +5260,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5295,7 +5295,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5330,7 +5330,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5375,7 +5375,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5434,7 +5434,7 @@ items:
                       "y": 2
                   },
                   "id": 8,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5560,7 +5560,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5622,7 +5622,7 @@ items:
                       "y": 4
                   },
                   "id": 10,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5796,7 +5796,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5831,7 +5831,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5866,7 +5866,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5901,7 +5901,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6003,7 +6003,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6078,7 +6078,7 @@ items:
                       "y": 14
                   },
                   "id": 6,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6261,7 +6261,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6339,7 +6339,7 @@ items:
                       "y": 28
                   },
                   "id": 8,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6529,7 +6529,7 @@ items:
                       "y": 35
                   },
                   "id": 9,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6673,7 +6673,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6724,7 +6724,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6775,7 +6775,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6826,7 +6826,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6877,7 +6877,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6928,7 +6928,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6979,7 +6979,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -7030,7 +7030,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -7101,7 +7101,7 @@ items:
                       "y": 70
                   },
                   "id": 18,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -7373,14 +7373,14 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
                               "type": "prometheus",
                               "uid": "${datasource}"
                           },
-                          "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"cpu\"})",
+                          "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", job=\"kube-state-metrics\", node=~\"$node\", resource=\"cpu\"})",
                           "legendFormat": "max capacity"
                       },
                       {
@@ -7440,7 +7440,7 @@ items:
                       "y": 6
                   },
                   "id": 2,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -7602,14 +7602,14 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
                               "type": "prometheus",
                               "uid": "${datasource}"
                           },
-                          "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", node=~\"$node\", resource=\"memory\"})",
+                          "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", job=\"kube-state-metrics\", node=~\"$node\", resource=\"memory\"})",
                           "legendFormat": "max capacity"
                       },
                       {
@@ -7672,7 +7672,7 @@ items:
                       "y": 18
                   },
                   "id": 4,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -7959,7 +7959,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8065,7 +8065,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8107,7 +8107,7 @@ items:
                       "y": 14
                   },
                   "id": 3,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8290,7 +8290,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8351,7 +8351,7 @@ items:
                       "y": 28
                   },
                   "id": 5,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8521,7 +8521,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8572,7 +8572,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8623,7 +8623,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8674,7 +8674,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8725,7 +8725,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8776,7 +8776,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8827,7 +8827,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8886,7 +8886,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8945,7 +8945,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8996,7 +8996,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9050,7 +9050,7 @@ items:
                       "y": 70
                   },
                   "id": 16,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9291,7 +9291,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9350,7 +9350,7 @@ items:
                       "y": 7
                   },
                   "id": 2,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9481,7 +9481,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9543,7 +9543,7 @@ items:
                       "y": 21
                   },
                   "id": 4,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9694,7 +9694,7 @@ items:
                       "y": 28
                   },
                   "id": 5,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9838,7 +9838,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9889,7 +9889,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9940,7 +9940,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9991,7 +9991,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10042,7 +10042,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10093,7 +10093,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10144,7 +10144,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10195,7 +10195,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10409,7 +10409,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10496,7 +10496,7 @@ items:
                       "y": 7
                   },
                   "id": 2,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10704,7 +10704,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10794,7 +10794,7 @@ items:
                       "y": 21
                   },
                   "id": 4,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10970,7 +10970,7 @@ items:
                       "y": 28
                   },
                   "id": 5,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11114,7 +11114,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11165,7 +11165,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11216,7 +11216,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11267,7 +11267,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11318,7 +11318,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11369,7 +11369,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11420,7 +11420,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11471,7 +11471,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11605,7 +11605,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11640,7 +11640,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11675,7 +11675,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11710,7 +11710,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11745,7 +11745,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11780,7 +11780,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11831,7 +11831,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11882,7 +11882,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11933,7 +11933,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11984,7 +11984,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12043,7 +12043,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12102,7 +12102,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12153,7 +12153,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12204,7 +12204,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12255,7 +12255,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12306,7 +12306,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12357,7 +12357,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12408,7 +12408,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12459,7 +12459,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12510,7 +12510,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12585,7 +12585,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12636,7 +12636,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12687,7 +12687,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12738,7 +12738,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12876,7 +12876,7 @@ items:
                       "y": 0
                   },
                   "id": 1,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12929,7 +12929,7 @@ items:
                       "y": 0
                   },
                   "id": 2,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13000,7 +13000,7 @@ items:
                       "y": 9
                   },
                   "id": 3,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13139,7 +13139,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13185,7 +13185,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13231,7 +13231,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13277,7 +13277,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13323,7 +13323,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13369,7 +13369,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13500,7 +13500,7 @@ items:
                       "displayMode": "basic",
                       "showUnfilled": false
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13539,7 +13539,7 @@ items:
                       "displayMode": "basic",
                       "showUnfilled": false
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13610,7 +13610,7 @@ items:
                       "y": 9
                   },
                   "id": 3,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13796,7 +13796,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13847,7 +13847,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13898,7 +13898,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13949,7 +13949,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -14000,7 +14000,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -14051,7 +14051,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -14102,7 +14102,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -14153,7 +14153,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -19678,7 +19678,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -19740,7 +19740,7 @@ items:
                   },
                   "id": 2,
                   "interval": "1m",
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -19790,7 +19790,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -19852,7 +19852,7 @@ items:
                   },
                   "id": 4,
                   "interval": "1m",
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -20003,7 +20003,7 @@ items:
                       "y": 0
                   },
                   "id": 1,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -20056,7 +20056,7 @@ items:
                       "y": 0
                   },
                   "id": 2,
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -20102,7 +20102,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -20148,7 +20148,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -20194,7 +20194,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -20240,7 +20240,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -20286,7 +20286,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -20332,7 +20332,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23377,7 +23377,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23428,7 +23428,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23479,7 +23479,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23530,7 +23530,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23581,7 +23581,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23632,7 +23632,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23707,7 +23707,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23758,7 +23758,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23809,7 +23809,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23860,7 +23860,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23911,7 +23911,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24032,7 +24032,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24083,7 +24083,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24158,7 +24158,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24233,7 +24233,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24308,7 +24308,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24359,7 +24359,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24410,7 +24410,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24461,7 +24461,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24512,7 +24512,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24637,7 +24637,7 @@ items:
                       "displayMode": "basic",
                       "showUnfilled": false
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24676,7 +24676,7 @@ items:
                       "displayMode": "basic",
                       "showUnfilled": false
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24715,7 +24715,7 @@ items:
                       "displayMode": "basic",
                       "showUnfilled": false
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24754,7 +24754,7 @@ items:
                       "displayMode": "basic",
                       "showUnfilled": false
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24805,7 +24805,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24856,7 +24856,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24907,7 +24907,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24958,7 +24958,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -25009,7 +25009,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {
@@ -25060,7 +25060,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.0.0",
+                  "pluginVersion": "v11.1.0",
                   "targets": [
                       {
                           "datasource": {

--- a/manifests/setup/0alertmanagerCustomResourceDefinition.yaml
+++ b/manifests/setup/0alertmanagerCustomResourceDefinition.yaml
@@ -3352,6 +3352,59 @@ spec:
                   - name
                   type: object
                 type: array
+              dnsConfig:
+                description: Defines the DNS configuration for the pods.
+                properties:
+                  nameservers:
+                    description: |-
+                      A list of DNS name server IP addresses.
+                      This will be appended to the base nameservers generated from DNSPolicy.
+                    items:
+                      minLength: 1
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  options:
+                    description: |-
+                      A list of DNS resolver options.
+                      This will be merged with the base options generated from DNSPolicy.
+                      Resolution options given in Options
+                      will override those that appear in the base DNSPolicy.
+                    items:
+                      description: PodDNSConfigOption defines DNS resolver options of a pod.
+                      properties:
+                        name:
+                          description: Name is required and must be unique.
+                          minLength: 1
+                          type: string
+                        value:
+                          description: Value is optional.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  searches:
+                    description: |-
+                      A list of DNS search domains for host-name lookup.
+                      This will be appended to the base search paths generated from DNSPolicy.
+                    items:
+                      minLength: 1
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+              dnsPolicy:
+                description: Defines the DNS policy for the pods.
+                enum:
+                - ClusterFirstWithHostNet
+                - ClusterFirst
+                - Default
+                - None
+                type: string
               enableFeatures:
                 description: |-
                   Enable access to Alertmanager feature flags. By default, no features are enabled.

--- a/manifests/setup/0prometheusCustomResourceDefinition.yaml
+++ b/manifests/setup/0prometheusCustomResourceDefinition.yaml
@@ -3364,6 +3364,59 @@ spec:
               disableCompaction:
                 description: When true, the Prometheus compaction is disabled.
                 type: boolean
+              dnsConfig:
+                description: Defines the DNS configuration for the pods.
+                properties:
+                  nameservers:
+                    description: |-
+                      A list of DNS name server IP addresses.
+                      This will be appended to the base nameservers generated from DNSPolicy.
+                    items:
+                      minLength: 1
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  options:
+                    description: |-
+                      A list of DNS resolver options.
+                      This will be merged with the base options generated from DNSPolicy.
+                      Resolution options given in Options
+                      will override those that appear in the base DNSPolicy.
+                    items:
+                      description: PodDNSConfigOption defines DNS resolver options of a pod.
+                      properties:
+                        name:
+                          description: Name is required and must be unique.
+                          minLength: 1
+                          type: string
+                        value:
+                          description: Value is optional.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  searches:
+                    description: |-
+                      A list of DNS search domains for host-name lookup.
+                      This will be appended to the base search paths generated from DNSPolicy.
+                    items:
+                      minLength: 1
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+              dnsPolicy:
+                description: Defines the DNS policy for the pods.
+                enum:
+                - ClusterFirstWithHostNet
+                - ClusterFirst
+                - Default
+                - None
+                type: string
               enableAdminAPI:
                 description: |-
                   Enables access to the Prometheus web admin API.
@@ -7350,6 +7403,12 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              ruleQueryOffset:
+                description: |-
+                  Defines the offset the rule evaluation timestamp of this particular group by the specified duration into the past.
+                  It requires Prometheus >= v2.53.0.
+                pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                type: string
               ruleSelector:
                 description: |-
                   PrometheusRule objects to be selected for rule evaluation. An empty

--- a/manifests/setup/0prometheusagentCustomResourceDefinition.yaml
+++ b/manifests/setup/0prometheusagentCustomResourceDefinition.yaml
@@ -2724,6 +2724,59 @@ spec:
                   - name
                   type: object
                 type: array
+              dnsConfig:
+                description: Defines the DNS configuration for the pods.
+                properties:
+                  nameservers:
+                    description: |-
+                      A list of DNS name server IP addresses.
+                      This will be appended to the base nameservers generated from DNSPolicy.
+                    items:
+                      minLength: 1
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  options:
+                    description: |-
+                      A list of DNS resolver options.
+                      This will be merged with the base options generated from DNSPolicy.
+                      Resolution options given in Options
+                      will override those that appear in the base DNSPolicy.
+                    items:
+                      description: PodDNSConfigOption defines DNS resolver options of a pod.
+                      properties:
+                        name:
+                          description: Name is required and must be unique.
+                          minLength: 1
+                          type: string
+                        value:
+                          description: Value is optional.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  searches:
+                    description: |-
+                      A list of DNS search domains for host-name lookup.
+                      This will be appended to the base search paths generated from DNSPolicy.
+                    items:
+                      minLength: 1
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+              dnsPolicy:
+                description: Defines the DNS policy for the pods.
+                enum:
+                - ClusterFirstWithHostNet
+                - ClusterFirst
+                - Default
+                - None
+                type: string
               enableFeatures:
                 description: |-
                   Enable access to Prometheus feature flags. By default, no features are enabled.

--- a/manifests/setup/0prometheusruleCustomResourceDefinition.yaml
+++ b/manifests/setup/0prometheusruleCustomResourceDefinition.yaml
@@ -72,6 +72,14 @@ spec:
                         More info: https://github.com/thanos-io/thanos/blob/main/docs/components/rule.md#partial-response
                       pattern: ^(?i)(abort|warn)?$
                       type: string
+                    query_offset:
+                      description: |-
+                        Defines the offset the rule evaluation timestamp of this particular group by the specified duration into the past.
+
+                        It requires Prometheus >= v2.53.0.
+                        It is not supported for ThanosRuler.
+                      pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                      type: string
                     rules:
                       description: List of alerting and recording rules.
                       items:

--- a/manifests/setup/0thanosrulerCustomResourceDefinition.yaml
+++ b/manifests/setup/0thanosrulerCustomResourceDefinition.yaml
@@ -2431,6 +2431,59 @@ spec:
                   - name
                   type: object
                 type: array
+              dnsConfig:
+                description: Defines the DNS configuration for the pods.
+                properties:
+                  nameservers:
+                    description: |-
+                      A list of DNS name server IP addresses.
+                      This will be appended to the base nameservers generated from DNSPolicy.
+                    items:
+                      minLength: 1
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                  options:
+                    description: |-
+                      A list of DNS resolver options.
+                      This will be merged with the base options generated from DNSPolicy.
+                      Resolution options given in Options
+                      will override those that appear in the base DNSPolicy.
+                    items:
+                      description: PodDNSConfigOption defines DNS resolver options of a pod.
+                      properties:
+                        name:
+                          description: Name is required and must be unique.
+                          minLength: 1
+                          type: string
+                        value:
+                          description: Value is optional.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  searches:
+                    description: |-
+                      A list of DNS search domains for host-name lookup.
+                      This will be appended to the base search paths generated from DNSPolicy.
+                    items:
+                      minLength: 1
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: set
+                type: object
+              dnsPolicy:
+                description: Defines the DNS policy for the pods.
+                enum:
+                - ClusterFirstWithHostNet
+                - ClusterFirst
+                - Default
+                - None
+                type: string
               enforcedNamespaceLabel:
                 description: |-
                   EnforcedNamespaceLabel enforces adding a namespace label of origin for each alert


### PR DESCRIPTION
## Description

After 0.10 the option to customize kube-prometheus without installing `jb`, `jsonnet` and `gojsontoyaml` was removed in https://github.com/prometheus-operator/kube-prometheus/pull/1728. Maybe due to the quay.io/coreos/jsonnet-ci having an older version of jsonnet.

We still used the old instructions and ran into issues: https://github.com/prometheus-operator/kube-prometheus/issues/2414

I created an up-to-date container image and copied the instructions from before, only replacing the image url.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- Add instructions on customizing kube-prometheus using a container image
```