### PR TITLE
allow customization without installing depedencies

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -165,6 +165,13 @@ be created successfully.
 
 Check the monitoring namespace (or the namespace you have specific in `namespace: `) and make sure the pods are running. Prometheus and Grafana should be up and running soon.
 
+## Containerized Installing and Compiling
+
+If you don't care to have jb nor jsonnet nor gojsontoyaml installed, then use ghcr.io/roelandvanbatenburg/kube-prometheus-builder container image. Do the following from this kube-prometheus directory:
+
+$ docker run --rm -v $(pwd):$(pwd) --workdir $(pwd) ghcr.io/roelandvanbatenburg/kube-prometheus-builder jb update
+$ docker run --rm -v $(pwd):$(pwd) --workdir $(pwd) ghcr.io/roelandvanbatenburg/kube-prometheus-builder ./build.sh example.jsonnet
+
 ## Minikube Example
 
 To use an easy to reproduce example, see [minikube.jsonnet](../examples/minikube.jsonnet), which uses the minikube setup as demonstrated in [Prerequisites](../README.md#prerequisites). Because we would like easy access to our Prometheus, Alertmanager and Grafana UIs, `minikube.jsonnet` exposes the services as NodePort type services.


### PR DESCRIPTION
## Description

After 0.10 the option to customize kube-prometheus without installing `jb`, `jsonnet` and `gojsontoyaml` was removed in https://github.com/prometheus-operator/kube-prometheus/pull/1728. Maybe due to the quay.io/coreos/jsonnet-ci having an older version of jsonnet.

We still used the old instructions and ran into issues: https://github.com/prometheus-operator/kube-prometheus/issues/2414

I created an up-to-date container image and copied the instructions from before, only replacing the image url.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- Add instructions on customizing kube-prometheus using a container image
```