### PR TITLE
node-exporter: use correct procfs location

### DIFF
--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -213,6 +213,7 @@ function(params) {
         '--web.listen-address=' + std.join(':', [ne._config.listenAddress, std.toString(ne._config.port)]),
         '--path.sysfs=/host/sys',
         '--path.rootfs=/host/root',
+        '--path.procfs=/host/root/proc',
         '--path.udev.data=/host/root/run/udev/data',
         '--no-collector.wifi',
         '--no-collector.hwmon',

--- a/manifests/nodeExporter-daemonset.yaml
+++ b/manifests/nodeExporter-daemonset.yaml
@@ -30,6 +30,7 @@ spec:
         - --web.listen-address=127.0.0.1:9100
         - --path.sysfs=/host/sys
         - --path.rootfs=/host/root
+        - --path.procfs=/host/root/proc
         - --path.udev.data=/host/root/run/udev/data
         - --no-collector.wifi
         - --no-collector.hwmon


### PR DESCRIPTION
this sets the procfs location in node-exporter to /host/root/proc since the host fs is mounted at /host/root

Fixes #2548

## Description

As per issue #2548 this changes the configuration of node-exporter so it uses `/host/root/proc` as the location of the proc fs

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

```release-note
- Update node-exporter configuration to use `/host/root/proc` as the procfs location
```
