### PR TITLE
chore: Add instance label information to the prometheusrule description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,12 @@ crdschemas/
 
 developer-workspace/gitpod/_output
 developer-workspace/codespaces/kind 
+
+# editor and IDE paraphernalia
+.idea
+*.swp
+*.swo
+*~
+
+# macOS
+.DS_Store

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -18,7 +18,7 @@
           "subdir": "contrib/mixin"
         }
       },
-      "version": "3d46df15f74d381273423229d9fa3136584bec78",
+      "version": "e30a4abc75c9e0b9fe5d06ce4ddd32689b49968d",
       "sum": "IXI3LQIT9NmTPJAk8WLUJd5+qZfcGpeNCyWIK7oEpws="
     },
     {
@@ -44,22 +44,12 @@
     {
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/grafonnet-lib.git",
-          "subdir": "grafonnet-7.0"
-        }
-      },
-      "version": "a1d61cce1da59c71409b99b5c7568511fec661ea",
-      "sum": "gCtR9s/4D5fxU9aKXg0Bru+/njZhA0YjLjPiASc61FM="
-    },
-    {
-      "source": {
-        "git": {
           "remote": "https://github.com/grafana/grafonnet.git",
           "subdir": "gen/grafonnet-latest"
         }
       },
-      "version": "82a19822e54a0a12a51e24dbd48fcde717dc0864",
-      "sum": "64fMUPI3frXGj4X1FqFd1t7r04w3CUSmXaDcJ23EYbQ="
+      "version": "d20e609202733790caf5b554c9945d049f243ae3",
+      "sum": "V9vAj21qJOc2DlMPDgB1eEjSQU4A+sAA4AXuJ6bd4xc="
     },
     {
       "source": {
@@ -68,18 +58,18 @@
           "subdir": "gen/grafonnet-v10.0.0"
         }
       },
-      "version": "82a19822e54a0a12a51e24dbd48fcde717dc0864",
+      "version": "d20e609202733790caf5b554c9945d049f243ae3",
       "sum": "xdcrJPJlpkq4+5LpGwN4tPAuheNNLXZjE6tDcyvFjr0="
     },
     {
       "source": {
         "git": {
           "remote": "https://github.com/grafana/grafonnet.git",
-          "subdir": "gen/grafonnet-v11.1.0"
+          "subdir": "gen/grafonnet-v11.4.0"
         }
       },
-      "version": "82a19822e54a0a12a51e24dbd48fcde717dc0864",
-      "sum": "41w7p/rwrNsITqNHMXtGSJAfAyKmnflg6rFhKBduUxM="
+      "version": "d20e609202733790caf5b554c9945d049f243ae3",
+      "sum": "aVAX09paQYNOoCSKVpuk1exVIyBoMt/C50QJI+Q/3nA="
     },
     {
       "source": {
@@ -88,7 +78,7 @@
           "subdir": "grafana-builder"
         }
       },
-      "version": "57b0b85dc1d7ed5e30c2e41f3bd26744b8aef519",
+      "version": "e13a89c9d775bc253a559df9bb693be07b5ef65e",
       "sum": "yxqWcq/N3E/a/XreeU6EuE6X7kYPnG0AspAQFKOjASo="
     },
     {
@@ -98,8 +88,8 @@
           "subdir": "mixin-utils"
         }
       },
-      "version": "57b0b85dc1d7ed5e30c2e41f3bd26744b8aef519",
-      "sum": "LoYq5QxJmUXEtqkEG8CFUBLBhhzDDaNANHc7Gz36ZdM="
+      "version": "e13a89c9d775bc253a559df9bb693be07b5ef65e",
+      "sum": "SRElwa/XrKAN8aZA9zvdRUx8iebl2It7KNQ7VFvMcBA="
     },
     {
       "source": {
@@ -118,8 +108,8 @@
           "subdir": ""
         }
       },
-      "version": "63d430b69a95741061c2f7fc9d84b1a778511d9c",
-      "sum": "qiZi3axUSXCVzKUF83zSAxklwrnitMmrDK4XAfjPMdE="
+      "version": "1199b50e9d2ff53d4bb5fb2304ad1fb69d38e609",
+      "sum": "LfbgcJbilu4uBdKYZSvmkoOTPwEAzg10L3/VqKAIWtA="
     },
     {
       "source": {
@@ -128,8 +118,8 @@
           "subdir": ""
         }
       },
-      "version": "a3fbf21977deb89b7d843eb8371170c011ea6835",
-      "sum": "57zW2IGJ9zbYd8BI0qe6JkoWTRSMNiBUWC6+YcnEsWo="
+      "version": "1087458a5ddc5d4686c19a630465801eb73aecb5",
+      "sum": "0a9iuWzL19GUxRqqb7VkGKTzujbmGjhvAQZLT4dOIQ4="
     },
     {
       "source": {
@@ -138,7 +128,7 @@
           "subdir": "jsonnet/kube-state-metrics"
         }
       },
-      "version": "32e7727ff4613b0f55dfc18aff15afb8c04d03c5",
+      "version": "d3f0c1853f11b387d7dc2c89bd5e52760f65079c",
       "sum": "lO7jUSzAIy8Yk9pOWJIWgPRhubkWzVh56W6wtYfbVH4="
     },
     {
@@ -148,7 +138,7 @@
           "subdir": "jsonnet/kube-state-metrics-mixin"
         }
       },
-      "version": "32e7727ff4613b0f55dfc18aff15afb8c04d03c5",
+      "version": "d3f0c1853f11b387d7dc2c89bd5e52760f65079c",
       "sum": "qclI7LwucTjBef3PkGBkKxF0mfZPbHnn4rlNWKGtR4c="
     },
     {
@@ -158,7 +148,7 @@
           "subdir": "jsonnet/mixin"
         }
       },
-      "version": "88e9db83e649cd5126a59b9bde4fd8cca6e452f7",
+      "version": "0b7a9746b1b6b7750bcf5e1532ef841d86b2c52d",
       "sum": "gi+knjdxs2T715iIQIntrimbHRgHnpM8IFBJDD1gYfs=",
       "name": "prometheus-operator-mixin"
     },
@@ -169,8 +159,8 @@
           "subdir": "jsonnet/prometheus-operator"
         }
       },
-      "version": "88e9db83e649cd5126a59b9bde4fd8cca6e452f7",
-      "sum": "z0/lCiMusMHTqntsosMVGYkVcSZjCpyZBmUMVUsK5nA="
+      "version": "0b7a9746b1b6b7750bcf5e1532ef841d86b2c52d",
+      "sum": "+V0hy+nn699RhjzI4XCwhNqjH4ZMxEPaks/RhyAMDlo="
     },
     {
       "source": {
@@ -179,7 +169,7 @@
           "subdir": "doc/alertmanager-mixin"
         }
       },
-      "version": "eb7aba4e304ea55bdea9de78e1333423ea3da98b",
+      "version": "3b61ae81a7b859ae4e9ddd34c88d71b4c1691a9e",
       "sum": "Mf4h1BYLle2nrgjf/HXrBbl0Zk8N+xaoEM017o0BC+k=",
       "name": "alertmanager"
     },
@@ -190,8 +180,8 @@
           "subdir": "docs/node-mixin"
         }
       },
-      "version": "cf8c6891cc610e54f70383addd4bb6079f0add35",
-      "sum": "cQCW+1N0Xae5yXecCWDK2oAlN0luBS/5GrwBYSlaFms="
+      "version": "b8aac7c92e2d7f3dea56b2d4802d4ef3ee29c3cc",
+      "sum": "xYj6VYFT/eafsbleNlC+Z2VfLy1CndyYrJs9BcTmnX8="
     },
     {
       "source": {
@@ -200,7 +190,7 @@
           "subdir": "documentation/prometheus-mixin"
         }
       },
-      "version": "cd1f8ac129a289be8e7d98b6de57a9ba5814c406",
+      "version": "5e7f804eeb76bbba3819460f6f9a9d32f5f637de",
       "sum": "OYT5u3S8DbamuJV/v3gbWSteOvFzMeNwMj+u4Apk7jM=",
       "name": "prometheus"
     },
@@ -222,7 +212,7 @@
           "subdir": "mixin"
         }
       },
-      "version": "51fddeb28d78ffcc67e38117c5f6294932800ec9",
+      "version": "c5025b79af122970478a702ca3a74b4613f0a2b6",
       "sum": "ieCD4eMgGbOlrI8GmckGPHBGQDcLasE1rULYq56W/bs=",
       "name": "thanos-mixin"
     },

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -54,7 +54,7 @@ items:
                           "mode": "multi"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -102,7 +102,7 @@ items:
                           "mode": "multi"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -174,7 +174,7 @@ items:
                           "mode": "multi"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "repeat": "integration",
                   "targets": [
                       {
@@ -232,7 +232,7 @@ items:
                           "mode": "multi"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "repeat": "integration",
                   "targets": [
                       {
@@ -398,7 +398,7 @@ items:
                   "options": {
                       "content": "The SLO (service level objective) and other metrics displayed on this dashboard are for informational purposes only."
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "title": "Notice",
                   "type": "text"
               },
@@ -422,7 +422,7 @@ items:
                   },
                   "id": 2,
                   "interval": "1m",
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -468,7 +468,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -502,7 +502,7 @@ items:
                   },
                   "id": 4,
                   "interval": "1m",
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -600,7 +600,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -644,7 +644,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -687,7 +687,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -721,7 +721,7 @@ items:
                   },
                   "id": 8,
                   "interval": "1m",
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -819,7 +819,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -863,7 +863,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -906,7 +906,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -949,7 +949,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -992,7 +992,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1038,7 +1038,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1080,7 +1080,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1123,7 +1123,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1165,7 +1165,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1296,7 +1296,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1342,7 +1342,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1413,7 +1413,7 @@ items:
                       "y": 9
                   },
                   "id": 3,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1578,7 +1578,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1624,7 +1624,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1670,7 +1670,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1716,7 +1716,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1762,7 +1762,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1808,7 +1808,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1854,7 +1854,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1900,7 +1900,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1946,7 +1946,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -1992,7 +1992,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2099,7 +2099,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2150,7 +2150,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2201,7 +2201,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2252,7 +2252,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2303,7 +2303,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2378,7 +2378,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2429,7 +2429,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2480,7 +2480,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2531,7 +2531,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -2582,7 +2582,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3328,7 +3328,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3363,7 +3363,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3398,7 +3398,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3433,7 +3433,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3468,7 +3468,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3503,7 +3503,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3553,7 +3553,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3612,7 +3612,7 @@ items:
                       "y": 12
                   },
                   "id": 8,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3769,7 +3769,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -3864,7 +3864,7 @@ items:
                       "y": 24
                   },
                   "id": 10,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4041,7 +4041,7 @@ items:
                       "y": 30
                   },
                   "id": 11,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4185,7 +4185,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4236,7 +4236,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4287,7 +4287,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4338,7 +4338,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4389,7 +4389,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4440,7 +4440,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4491,7 +4491,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4542,7 +4542,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4593,7 +4593,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4644,7 +4644,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4715,7 +4715,7 @@ items:
                       "y": 96
                   },
                   "id": 22,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4915,7 +4915,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4950,7 +4950,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -4985,7 +4985,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5020,7 +5020,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5055,7 +5055,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5090,7 +5090,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5135,7 +5135,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5194,7 +5194,7 @@ items:
                       "y": 2
                   },
                   "id": 8,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5320,7 +5320,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5382,7 +5382,7 @@ items:
                       "y": 4
                   },
                   "id": 10,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5556,7 +5556,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5591,7 +5591,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5626,7 +5626,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5661,7 +5661,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5763,7 +5763,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -5838,7 +5838,7 @@ items:
                       "y": 14
                   },
                   "id": 6,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6021,7 +6021,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6099,7 +6099,7 @@ items:
                       "y": 28
                   },
                   "id": 8,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6289,7 +6289,7 @@ items:
                       "y": 35
                   },
                   "id": 9,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6433,7 +6433,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6484,7 +6484,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6535,7 +6535,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6586,7 +6586,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6637,7 +6637,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6688,7 +6688,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6739,7 +6739,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6790,7 +6790,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -6861,7 +6861,7 @@ items:
                       "y": 70
                   },
                   "id": 18,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -7133,7 +7133,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -7200,7 +7200,7 @@ items:
                       "y": 6
                   },
                   "id": 2,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -7362,7 +7362,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -7378,6 +7378,109 @@ items:
                               "uid": "${datasource}"
                           },
                           "expr": "sum(node_namespace_pod_container:container_memory_working_set_bytes{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
+                          "legendFormat": "{{pod}}"
+                      }
+                  ],
+                  "title": "Memory Usage (w/cache)",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "datasource",
+                      "uid": "-- Mixed --"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 10,
+                              "showPoints": "never",
+                              "spanNulls": true,
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "bytes"
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "max capacity"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "color",
+                                      "value": {
+                                          "fixedColor": "red",
+                                          "mode": "fixed"
+                                      }
+                                  },
+                                  {
+                                      "id": "custom.stacking",
+                                      "value": {
+                                          "mode": "none"
+                                      }
+                                  },
+                                  {
+                                      "id": "custom.hideFrom",
+                                      "value": {
+                                          "legend": false,
+                                          "tooltip": true,
+                                          "viz": false
+                                      }
+                                  },
+                                  {
+                                      "id": "custom.lineStyle",
+                                      "value": {
+                                          "dash": [
+                                              10,
+                                              10
+                                          ],
+                                          "fill": "dash"
+                                      }
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 6,
+                      "w": 24,
+                      "x": 0,
+                      "y": 18
+                  },
+                  "id": 4,
+                  "interval": "1m",
+                  "options": {
+                      "legend": {
+                          "asTable": true,
+                          "calcs": [
+                              "lastNotNull"
+                          ],
+                          "displayMode": "table",
+                          "placement": "right",
+                          "showLegend": true
+                      },
+                      "tooltip": {
+                          "mode": "single"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "${datasource}"
+                          },
+                          "expr": "sum(kube_node_status_capacity{cluster=\"$cluster\", job=\"kube-state-metrics\", node=~\"$node\", resource=\"memory\"})",
+                          "legendFormat": "max capacity"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "${datasource}"
+                          },
+                          "expr": "sum(node_namespace_pod_container:container_memory_rss{cluster=\"$cluster\", node=~\"$node\", container!=\"\"}) by (pod)",
                           "legendFormat": "{{pod}}"
                       }
                   ],
@@ -7429,10 +7532,10 @@ items:
                       "h": 6,
                       "w": 24,
                       "x": 0,
-                      "y": 18
+                      "y": 24
                   },
-                  "id": 4,
-                  "pluginVersion": "v11.1.0",
+                  "id": 5,
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -7719,7 +7822,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -7825,7 +7928,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -7867,7 +7970,7 @@ items:
                       "y": 14
                   },
                   "id": 3,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8050,7 +8153,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8111,7 +8214,7 @@ items:
                       "y": 28
                   },
                   "id": 5,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8281,7 +8384,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8332,7 +8435,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8383,7 +8486,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8434,7 +8537,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8485,7 +8588,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8536,7 +8639,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8587,7 +8690,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8646,7 +8749,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8705,7 +8808,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8756,7 +8859,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -8810,7 +8913,7 @@ items:
                       "y": 70
                   },
                   "id": 16,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9051,7 +9154,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9110,7 +9213,7 @@ items:
                       "y": 7
                   },
                   "id": 2,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9241,7 +9344,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9303,7 +9406,7 @@ items:
                       "y": 21
                   },
                   "id": 4,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9454,7 +9557,7 @@ items:
                       "y": 28
                   },
                   "id": 5,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9598,7 +9701,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9649,7 +9752,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9700,7 +9803,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9751,7 +9854,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9802,7 +9905,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9853,7 +9956,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9904,7 +10007,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -9955,7 +10058,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10169,7 +10272,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10256,7 +10359,7 @@ items:
                       "y": 7
                   },
                   "id": 2,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10464,7 +10567,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10554,7 +10657,7 @@ items:
                       "y": 21
                   },
                   "id": 4,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10730,7 +10833,7 @@ items:
                       "y": 28
                   },
                   "id": 5,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10874,7 +10977,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10925,7 +11028,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -10976,7 +11079,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11027,7 +11130,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11078,7 +11181,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11129,7 +11232,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11180,7 +11283,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11231,7 +11334,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11365,7 +11468,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11400,7 +11503,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11435,7 +11538,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11470,7 +11573,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11505,7 +11608,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11540,7 +11643,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11591,7 +11694,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11642,7 +11745,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11693,7 +11796,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11744,7 +11847,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11803,7 +11906,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11862,7 +11965,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11913,7 +12016,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -11964,7 +12067,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12015,7 +12118,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12066,7 +12169,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12117,7 +12220,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12168,7 +12271,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12219,7 +12322,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12270,7 +12373,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12345,7 +12448,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12396,7 +12499,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12447,7 +12550,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12498,7 +12601,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12636,7 +12739,7 @@ items:
                       "y": 0
                   },
                   "id": 1,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12689,7 +12792,7 @@ items:
                       "y": 0
                   },
                   "id": 2,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12760,7 +12863,7 @@ items:
                       "y": 9
                   },
                   "id": 3,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12899,7 +13002,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12945,7 +13048,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -12991,7 +13094,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13037,7 +13140,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13083,7 +13186,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13129,7 +13232,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13260,7 +13363,7 @@ items:
                       "displayMode": "basic",
                       "showUnfilled": false
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13299,7 +13402,7 @@ items:
                       "displayMode": "basic",
                       "showUnfilled": false
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13370,7 +13473,7 @@ items:
                       "y": 9
                   },
                   "id": 3,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13556,7 +13659,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13607,7 +13710,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13658,7 +13761,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13709,7 +13812,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13760,7 +13863,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13811,7 +13914,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13862,7 +13965,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -13913,7 +14016,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -14016,1009 +14119,583 @@ items:
   data:
     node-cluster-rsrc-use.json: |-
       {
-          "__inputs": [
-
-          ],
-          "__requires": [
-
-          ],
-          "annotations": {
-              "list": [
-
-              ]
-          },
-          "editable": false,
-          "gnetId": null,
           "graphTooltip": 1,
-          "hideControls": false,
-          "id": null,
-          "links": [
-
-          ],
-          "refresh": "30s",
-          "rows": [
+          "panels": [
               {
-                  "collapse": false,
                   "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 0
+                  },
+                  "id": 1,
                   "panels": [
-                      {
-                          "aliasColors": {
 
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 2,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "((\n  instance:node_cpu_utilisation:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}\n  *\n  instance:node_num_cpu:sum{job=\"node-exporter\", cluster=\"$cluster\"}\n) != 0 )\n/ scalar(sum(instance:node_num_cpu:sum{job=\"node-exporter\", cluster=\"$cluster\"}))\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{ instance }}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "CPU Utilisation",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
-                      },
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 3,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "(\n  instance:node_load1_per_cpu:ratio{job=\"node-exporter\", cluster=\"$cluster\"}\n  / scalar(count(instance:node_load1_per_cpu:ratio{job=\"node-exporter\", cluster=\"$cluster\"}))\n)  != 0\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{instance}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "CPU Saturation (Load1 per CPU)",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
-                      }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
                   "title": "CPU",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 4,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "(\n  instance:node_memory_utilisation:ratio{job=\"node-exporter\", cluster=\"$cluster\"}\n  / scalar(count(instance:node_memory_utilisation:ratio{job=\"node-exporter\", cluster=\"$cluster\"}))\n) != 0\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{instance}}",
-                                  "refId": "A"
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
                               }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Memory Utilisation",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
                           },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 1
+                  },
+                  "id": 2,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
                       },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 5,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "instance:node_vmstat_pgmajfault:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{instance}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Memory Saturation (Major Page Faults)",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "rds",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "rds",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "((\n  instance:node_cpu_utilisation:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}\n  *\n  instance:node_num_cpu:sum{job=\"node-exporter\", cluster=\"$cluster\"}\n) != 0 )\n/ scalar(sum(instance:node_num_cpu:sum{job=\"node-exporter\", cluster=\"$cluster\"}))\n",
+                          "legendFormat": "{{ instance }}"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "CPU Utilisation",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 1
+                  },
+                  "id": 3,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "(\n  instance:node_load1_per_cpu:ratio{job=\"node-exporter\", cluster=\"$cluster\"}\n  / scalar(count(instance:node_load1_per_cpu:ratio{job=\"node-exporter\", cluster=\"$cluster\"}))\n)  != 0\n",
+                          "legendFormat": "{{ instance }}"
+                      }
+                  ],
+                  "title": "CPU Saturation (Load1 per CPU)",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 8
+                  },
+                  "id": 4,
+                  "panels": [
+
+                  ],
                   "title": "Memory",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 6,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-                              {
-                                  "alias": "/Receive/",
-                                  "stack": "A"
-                              },
-                              {
-                                  "alias": "/Transmit/",
-                                  "stack": "B",
-                                  "transform": "negative-Y"
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
                               }
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "instance:node_network_receive_bytes_excluding_lo:rate5m{job=\"node-exporter\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{instance}} Receive",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "instance:node_network_transmit_bytes_excluding_lo:rate5m{job=\"node-exporter\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{instance}} Transmit",
-                                  "refId": "B"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Network Utilisation (Bytes Receive/Transmit)",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
                           },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "Bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "Bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 9
+                  },
+                  "id": 5,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
                       },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 7,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-                              {
-                                  "alias": "/ Receive/",
-                                  "stack": "A"
-                              },
-                              {
-                                  "alias": "/ Transmit/",
-                                  "stack": "B",
-                                  "transform": "negative-Y"
-                              }
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "instance:node_network_receive_drop_excluding_lo:rate5m{job=\"node-exporter\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{instance}} Receive",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "instance:node_network_transmit_drop_excluding_lo:rate5m{job=\"node-exporter\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{instance}} Transmit",
-                                  "refId": "B"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Network Saturation (Drops Receive/Transmit)",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "Bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "Bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "(\n  instance:node_memory_utilisation:ratio{job=\"node-exporter\", cluster=\"$cluster\"}\n  / scalar(count(instance:node_memory_utilisation:ratio{job=\"node-exporter\", cluster=\"$cluster\"}))\n) != 0\n",
+                          "legendFormat": "{{ instance }}"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "Memory Utilisation",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "rds"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 9
+                  },
+                  "id": 6,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "instance:node_vmstat_pgmajfault:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}",
+                          "legendFormat": "{{ instance }}"
+                      }
+                  ],
+                  "title": "Memory Saturation (Major Page Faults)",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 16
+                  },
+                  "id": 7,
+                  "panels": [
+
+                  ],
                   "title": "Network",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 8,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "(\n  instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}\n  / scalar(count(instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}))\n) != 0\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{instance}} {{device}}",
-                                  "refId": "A"
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
                               }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Disk IO Utilisation",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
                           },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
+                          "unit": "Bps"
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/Transmit/"
                               },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                              "properties": [
+                                  {
+                                      "id": "custom.transform",
+                                      "value": "negative-Y"
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 17
+                  },
+                  "id": 8,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "instance:node_network_receive_bytes_excluding_lo:rate5m{job=\"node-exporter\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "{{ instance }} Receive"
                       },
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 9,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "(\n  instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}\n  / scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}))\n) != 0\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{instance}} {{device}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Disk IO Saturation",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "instance:node_network_transmit_bytes_excluding_lo:rate5m{job=\"node-exporter\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "{{ instance }} Transmit"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "Network Utilisation (Bytes Receive/Transmit)",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "Bps"
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/Transmit/"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.transform",
+                                      "value": "negative-Y"
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 17
+                  },
+                  "id": 9,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "instance:node_network_receive_drop_excluding_lo:rate5m{job=\"node-exporter\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "{{ instance }} Receive"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "instance:node_network_transmit_drop_excluding_lo:rate5m{job=\"node-exporter\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "{{ instance }} Transmit"
+                      }
+                  ],
+                  "title": "Network Saturation (Drops Receive/Transmit)",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 24
+                  },
+                  "id": 10,
+                  "panels": [
+
+                  ],
                   "title": "Disk IO",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 25
+                  },
+                  "id": 11,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 10,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 12,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "sum without (device) (\n  max without (fstype, mountpoint) ((\n    node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\", mountpoint!=\"\", cluster=\"$cluster\"}\n    -\n    node_filesystem_avail_bytes{job=\"node-exporter\", fstype!=\"\", mountpoint!=\"\", cluster=\"$cluster\"}\n  ) != 0)\n)\n/ scalar(sum(max without (fstype, mountpoint) (node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\", mountpoint!=\"\", cluster=\"$cluster\"})))\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{instance}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Disk Space Utilisation",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}\n/ scalar(count(instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}))\n",
+                          "legendFormat": "{{ instance }} {{device}}"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "Disk IO Utilisation",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 25
+                  },
+                  "id": 12,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}\n/ scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\", cluster=\"$cluster\"}))\n",
+                          "legendFormat": "{{ instance }} {{device}}"
+                      }
+                  ],
+                  "title": "Disk IO Saturation",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 34
+                  },
+                  "id": 13,
+                  "panels": [
+
+                  ],
                   "title": "Disk Space",
-                  "titleSize": "h6",
                   "type": "row"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 24,
+                      "x": 0,
+                      "y": 35
+                  },
+                  "id": 14,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sum without (device) (\n  max without (fstype, mountpoint) ((\n    node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\", mountpoint!=\"\", cluster=\"$cluster\"}\n    -\n    node_filesystem_avail_bytes{job=\"node-exporter\", fstype!=\"\", mountpoint!=\"\", cluster=\"$cluster\"}\n  ) != 0)\n)\n/ scalar(sum(max without (fstype, mountpoint) (node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\", mountpoint!=\"\", cluster=\"$cluster\"})))\n",
+                          "legendFormat": "{{ instance }}"
+                      }
+                  ],
+                  "title": "Disk Space Utilisation",
+                  "type": "timeseries"
               }
           ],
-          "schemaVersion": 14,
-          "style": "dark",
+          "refresh": "30s",
+          "schemaVersion": 39,
           "tags": [
               "node-exporter-mixin"
           ],
           "templating": {
               "list": [
                   {
-                      "current": {
-                          "text": "default",
-                          "value": "default"
-                      },
-                      "hide": 0,
-                      "label": "Data Source",
                       "name": "datasource",
-                      "options": [
-
-                      ],
                       "query": "prometheus",
-                      "refresh": 1,
-                      "regex": "",
                       "type": "datasource"
                   },
                   {
-                      "allValue": null,
-                      "current": {
-                          "text": "",
-                          "value": ""
+                      "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
                       },
-                      "datasource": "$datasource",
                       "hide": 2,
                       "includeAll": false,
-                      "label": null,
-                      "multi": false,
                       "name": "cluster",
-                      "options": [
-
-                      ],
                       "query": "label_values(node_time_seconds, cluster)",
                       "refresh": 2,
-                      "regex": "",
                       "sort": 1,
-                      "tagValuesQuery": "",
-                      "tags": [
-
-                      ],
-                      "tagsQuery": "",
-                      "type": "query",
-                      "useTags": false
+                      "type": "query"
+                  },
+                  {
+                      "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                      },
+                      "refresh": 2,
+                      "sort": 1
                   }
               ]
           },
@@ -15026,35 +14703,9 @@ items:
               "from": "now-1h",
               "to": "now"
           },
-          "timepicker": {
-              "refresh_intervals": [
-                  "5s",
-                  "10s",
-                  "30s",
-                  "1m",
-                  "5m",
-                  "15m",
-                  "30m",
-                  "1h",
-                  "2h",
-                  "1d"
-              ],
-              "time_options": [
-                  "5m",
-                  "15m",
-                  "1h",
-                  "6h",
-                  "12h",
-                  "24h",
-                  "2d",
-                  "7d",
-                  "30d"
-              ]
-          },
           "timezone": "utc",
           "title": "Node Exporter / USE Method / Cluster",
-          "uid": "3e97d1d02672cdd0861f4c97c64f89b2",
-          "version": 0
+          "uid": "3e97d1d02672cdd0861f4c97c64f89b2"
       }
   kind: ConfigMap
   metadata:
@@ -15069,1035 +14720,586 @@ items:
   data:
     node-rsrc-use.json: |-
       {
-          "__inputs": [
-
-          ],
-          "__requires": [
-
-          ],
-          "annotations": {
-              "list": [
-
-              ]
-          },
-          "editable": false,
-          "gnetId": null,
           "graphTooltip": 1,
-          "hideControls": false,
-          "id": null,
-          "links": [
-
-          ],
-          "refresh": "30s",
-          "rows": [
+          "panels": [
               {
-                  "collapse": false,
                   "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 0
+                  },
+                  "id": 1,
                   "panels": [
-                      {
-                          "aliasColors": {
 
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 2,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "instance:node_cpu_utilisation:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Utilisation",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "CPU Utilisation",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
-                      },
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 3,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "instance:node_load1_per_cpu:ratio{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Saturation",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "CPU Saturation (Load1 per CPU)",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
-                      }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
                   "title": "CPU",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 4,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "instance:node_memory_utilisation:ratio{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Utilisation",
-                                  "refId": "A"
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
                               }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Memory Utilisation",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
                           },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 1
+                  },
+                  "id": 2,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
                       },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 5,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "instance:node_vmstat_pgmajfault:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Major page Faults",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Memory Saturation (Major Page Faults)",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "rds",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "rds",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "instance:node_cpu_utilisation:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "Utilisation"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "CPU Utilisation",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 1
+                  },
+                  "id": 3,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "instance:node_load1_per_cpu:ratio{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "Saturation"
+                      }
+                  ],
+                  "title": "CPU Saturation (Load1 per CPU)",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 8
+                  },
+                  "id": 4,
+                  "panels": [
+
+                  ],
                   "title": "Memory",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 6,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-                              {
-                                  "alias": "/Receive/",
-                                  "stack": "A"
-                              },
-                              {
-                                  "alias": "/Transmit/",
-                                  "stack": "B",
-                                  "transform": "negative-Y"
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
                               }
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "instance:node_network_receive_bytes_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Receive",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "instance:node_network_transmit_bytes_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Transmit",
-                                  "refId": "B"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Network Utilisation (Bytes Receive/Transmit)",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
                           },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "Bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "Bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 9
+                  },
+                  "id": 5,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
                       },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 7,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-                              {
-                                  "alias": "/ Receive/",
-                                  "stack": "A"
-                              },
-                              {
-                                  "alias": "/ Transmit/",
-                                  "stack": "B",
-                                  "transform": "negative-Y"
-                              }
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "instance:node_network_receive_drop_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Receive",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "instance:node_network_transmit_drop_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Transmit",
-                                  "refId": "B"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Network Saturation (Drops Receive/Transmit)",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "Bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "Bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "instance:node_memory_utilisation:ratio{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "Utilisation"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "Memory Utilisation",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "rds"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 9
+                  },
+                  "id": 6,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "instance:node_vmstat_pgmajfault:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "Major page Faults"
+                      }
+                  ],
+                  "title": "Memory Saturation (Major Page Faults)",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 16
+                  },
+                  "id": 7,
+                  "panels": [
+
+                  ],
                   "title": "Network",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 8,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{device}}",
-                                  "refId": "A"
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
                               }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Disk IO Utilisation",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
                           },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
+                          "unit": "Bps"
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/Transmit/"
                               },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                              "properties": [
+                                  {
+                                      "id": "custom.transform",
+                                      "value": "negative-Y"
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 17
+                  },
+                  "id": 8,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "instance:node_network_receive_bytes_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "Receive"
                       },
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 9,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{device}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Disk IO Saturation",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "instance:node_network_transmit_bytes_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "Transmit"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "Network Utilisation (Bytes Receive/Transmit)",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "Bps"
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/Transmit/"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.transform",
+                                      "value": "negative-Y"
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 17
+                  },
+                  "id": 9,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "instance:node_network_receive_drop_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "Receive"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "instance:node_network_transmit_drop_excluding_lo:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "Transmit"
+                      }
+                  ],
+                  "title": "Network Saturation (Drops Receive/Transmit)",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 24
+                  },
+                  "id": 10,
+                  "panels": [
+
+                  ],
                   "title": "Disk IO",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 25
+                  },
+                  "id": 11,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 10,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 10,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": false,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 12,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "sort_desc(1 -\n  (\n   max without (mountpoint, fstype) (node_filesystem_avail_bytes{job=\"node-exporter\", fstype!=\"\", instance=\"$instance\", cluster=\"$cluster\"})\n   /\n   max without (mountpoint, fstype) (node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\", instance=\"$instance\", cluster=\"$cluster\"})\n  ) != 0\n)\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "{{device}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Disk Space Utilisation",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 2,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "{{device}}"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "Disk IO Utilisation",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 25
+                  },
+                  "id": 12,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} != 0",
+                          "legendFormat": "{{device}}"
+                      }
+                  ],
+                  "title": "Disk IO Saturation",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 34
+                  },
+                  "id": 13,
+                  "panels": [
+
+                  ],
                   "title": "Disk Space",
-                  "titleSize": "h6",
                   "type": "row"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 24,
+                      "x": 0,
+                      "y": 35
+                  },
+                  "id": 14,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sort_desc(1 -\n  (\n    max without (mountpoint, fstype) (node_filesystem_avail_bytes{job=\"node-exporter\", fstype!=\"\", instance=\"$instance\", cluster=\"$cluster\"})\n    /\n    max without (mountpoint, fstype) (node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\", instance=\"$instance\", cluster=\"$cluster\"})\n  ) != 0\n)\n",
+                          "legendFormat": "{{device}}"
+                      }
+                  ],
+                  "title": "Disk Space Utilisation",
+                  "type": "timeseries"
               }
           ],
-          "schemaVersion": 14,
-          "style": "dark",
+          "refresh": "30s",
+          "schemaVersion": 39,
           "tags": [
               "node-exporter-mixin"
           ],
           "templating": {
               "list": [
                   {
-                      "current": {
-                          "text": "default",
-                          "value": "default"
-                      },
-                      "hide": 0,
-                      "label": "Data Source",
                       "name": "datasource",
-                      "options": [
-
-                      ],
                       "query": "prometheus",
-                      "refresh": 1,
-                      "regex": "",
                       "type": "datasource"
                   },
                   {
-                      "allValue": null,
-                      "current": {
-                          "text": "",
-                          "value": ""
+                      "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
                       },
-                      "datasource": "$datasource",
                       "hide": 2,
                       "includeAll": false,
-                      "label": null,
-                      "multi": false,
                       "name": "cluster",
-                      "options": [
-
-                      ],
                       "query": "label_values(node_time_seconds, cluster)",
                       "refresh": 2,
-                      "regex": "",
                       "sort": 1,
-                      "tagValuesQuery": "",
-                      "tags": [
-
-                      ],
-                      "tagsQuery": "",
-                      "type": "query",
-                      "useTags": false
+                      "type": "query"
                   },
                   {
-                      "allValue": null,
-                      "current": {
-
+                      "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
                       },
-                      "datasource": "$datasource",
-                      "hide": 0,
-                      "includeAll": false,
-                      "label": null,
-                      "multi": false,
                       "name": "instance",
-                      "options": [
-
-                      ],
                       "query": "label_values(node_exporter_build_info{job=\"node-exporter\", cluster=\"$cluster\"}, instance)",
                       "refresh": 2,
-                      "regex": "",
                       "sort": 1,
-                      "tagValuesQuery": "",
-                      "tags": [
-
-                      ],
-                      "tagsQuery": "",
-                      "type": "query",
-                      "useTags": false
+                      "type": "query"
                   }
               ]
           },
@@ -16105,35 +15307,9 @@ items:
               "from": "now-1h",
               "to": "now"
           },
-          "timepicker": {
-              "refresh_intervals": [
-                  "5s",
-                  "10s",
-                  "30s",
-                  "1m",
-                  "5m",
-                  "15m",
-                  "30m",
-                  "1h",
-                  "2h",
-                  "1d"
-              ],
-              "time_options": [
-                  "5m",
-                  "15m",
-                  "1h",
-                  "6h",
-                  "12h",
-                  "24h",
-                  "2d",
-                  "7d",
-                  "30d"
-              ]
-          },
           "timezone": "utc",
           "title": "Node Exporter / USE Method / Node",
-          "uid": "fac67cfbe174d3ef53eb473d73d9212f",
-          "version": 0
+          "uid": "fac67cfbe174d3ef53eb473d73d9212f"
       }
   kind: ConfigMap
   metadata:
@@ -16148,1024 +15324,705 @@ items:
   data:
     nodes-aix.json: |-
       {
-          "__inputs": [
-
-          ],
-          "__requires": [
-
-          ],
-          "annotations": {
-              "list": [
-
-              ]
-          },
-          "editable": false,
-          "gnetId": null,
           "graphTooltip": 1,
-          "hideControls": false,
-          "id": null,
-          "links": [
-
-          ],
-          "refresh": "30s",
-          "rows": [
+          "panels": [
               {
-                  "collapse": false,
                   "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 0
+                  },
+                  "id": 1,
                   "panels": [
-                      {
-                          "aliasColors": {
 
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 1,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 2,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "(\n  (1 - sum without (mode) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=~\"idle|iowait|steal\", instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval])))\n/ ignoring(cpu) group_left\n  count without (cpu, mode) (node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", instance=\"$instance\", cluster=\"$cluster\"})\n)\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 5,
-                                  "legendFormat": "{{cpu}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "CPU Usage",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": 1,
-                                  "min": 0,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": 1,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
-                      },
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 0,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 3,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "node_load1{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "1m load average",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "node_load5{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "5m load average",
-                                  "refId": "B"
-                              },
-                              {
-                                  "expr": "node_load15{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "15m load average",
-                                  "refId": "C"
-                              },
-                              {
-                                  "expr": "count(node_cpu_seconds_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", mode=\"idle\"})",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "logical cores",
-                                  "refId": "D"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Load Average",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "short",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              },
-                              {
-                                  "format": "short",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
-                      }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
                   "title": "CPU",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 10,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "max": 1,
+                          "min": 0,
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 1
+                  },
+                  "id": 2,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 1,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 4,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 9,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "node_memory_total_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Physical Memory",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "(\n    node_memory_total_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} -\n    node_memory_available_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n)\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Memory Used",
-                                  "refId": "B"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Memory Usage",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "bytes",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              },
-                              {
-                                  "format": "bytes",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
-                      },
-                      {
-                          "datasource": "$datasource",
-                          "fieldConfig": {
-                              "defaults": {
-                                  "max": 100,
-                                  "min": 0,
-                                  "thresholds": {
-                                      "mode": "absolute",
-                                      "steps": [
-                                          {
-                                              "color": "rgba(50, 172, 45, 0.97)"
-                                          },
-                                          {
-                                              "color": "rgba(237, 129, 40, 0.89)",
-                                              "value": 80
-                                          },
-                                          {
-                                              "color": "rgba(245, 54, 54, 0.9)",
-                                              "value": 90
-                                          }
-                                      ]
-                                  },
-                                  "unit": "percent"
-                              }
-                          },
-                          "gridPos": {
-
-                          },
-                          "id": 5,
-                          "span": 3,
-                          "targets": [
-                              {
-                                  "expr": "100 -\n(\n  avg(node_memory_available_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}) /\n  avg(node_memory_total_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"})\n  * 100\n)\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": ""
-                              }
-                          ],
-                          "title": "Memory Usage",
-                          "transparent": false,
-                          "type": "gauge"
+                          "expr": "(\n  (1 - sum without (mode) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=~\"idle|iowait|steal\", instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval])))\n/ ignoring(cpu) group_left\n  count without (cpu, mode) (node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", instance=\"$instance\", cluster=\"$cluster\"})\n)\n",
+                          "intervalFactor": 5,
+                          "legendFormat": "{{cpu}}"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "CPU Usage",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 0,
+                              "showPoints": "never"
+                          },
+                          "min": 0,
+                          "unit": "short"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 1
+                  },
+                  "id": 3,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_load1{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "1m load average"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_load5{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "5m load average"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_load15{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "15m load average"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "count(node_cpu_seconds_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", mode=\"idle\"})",
+                          "legendFormat": "logical cores"
+                      }
+                  ],
+                  "title": "Load Average",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 8
+                  },
+                  "id": 4,
                   "title": "Memory",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 10,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "none"
+                              }
+                          },
+                          "min": 0,
+                          "unit": "bytes"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 18,
+                      "x": 0,
+                      "y": 9
+                  },
+                  "id": 5,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 0,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 6,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-                              {
-                                  "alias": "/ read| written/",
-                                  "yaxis": 1
-                              },
-                              {
-                                  "alias": "/ io time/",
-                                  "yaxis": 2
-                              }
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "rate(node_disk_read_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}} read",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "rate(node_disk_written_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}} written",
-                                  "refId": "B"
-                              },
-                              {
-                                  "expr": "rate(node_disk_io_time_seconds_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}} io time",
-                                  "refId": "C"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Disk I/O",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "Bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "node_memory_total_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "Physical Memory"
                       },
                       {
-                          "datasource": "$datasource",
-                          "fieldConfig": {
-                              "defaults": {
-                                  "custom": {
-
-                                  },
-                                  "thresholds": {
-                                      "mode": "absolute",
-                                      "steps": [
-                                          {
-                                              "color": "green"
-                                          },
-                                          {
-                                              "color": "yellow",
-                                              "value": 0.8
-                                          },
-                                          {
-                                              "color": "red",
-                                              "value": 0.9
-                                          }
-                                      ]
-                                  },
-                                  "unit": "decbytes"
-                              },
-                              "overrides": [
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "(\n    node_memory_total_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} -\n    node_memory_available_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n)\n",
+                          "legendFormat": "Memory Used"
+                      }
+                  ],
+                  "title": "Memory Usage",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "max": 100,
+                          "min": 0,
+                          "thresholds": {
+                              "steps": [
                                   {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Mounted on"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "custom.width",
-                                              "value": 260
-                                          }
-                                      ]
+                                      "color": "rgba(50, 172, 45, 0.97)"
                                   },
                                   {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Size"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "custom.width",
-                                              "value": 93
-                                          }
-                                      ]
+                                      "color": "rgba(237, 129, 40, 0.89)",
+                                      "value": 80
                                   },
                                   {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Used"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "custom.width",
-                                              "value": 72
-                                          }
-                                      ]
-                                  },
-                                  {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Available"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "custom.width",
-                                              "value": 88
-                                          }
-                                      ]
-                                  },
-                                  {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Used, %"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "unit",
-                                              "value": "percentunit"
-                                          },
-                                          {
-                                              "id": "custom.displayMode",
-                                              "value": "gradient-gauge"
-                                          },
-                                          {
-                                              "id": "max",
-                                              "value": 1
-                                          },
-                                          {
-                                              "id": "min",
-                                              "value": 0
-                                          }
-                                      ]
+                                      "color": "rgba(245, 54, 54, 0.9)",
+                                      "value": 90
                                   }
                               ]
                           },
-                          "gridPos": {
-
+                          "unit": "percent"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 6,
+                      "x": 18,
+                      "y": 9
+                  },
+                  "id": 6,
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "id": 7,
-                          "span": 6,
-                          "targets": [
-                              {
-                                  "expr": "max by (mountpoint) (node_filesystem_size_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", fstype!=\"\", mountpoint!=\"\"})\n",
-                                  "format": "table",
-                                  "instant": true,
-                                  "intervalFactor": 2,
-                                  "legendFormat": ""
-                              },
-                              {
-                                  "expr": "max by (mountpoint) (node_filesystem_avail_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", fstype!=\"\", mountpoint!=\"\"})\n",
-                                  "format": "table",
-                                  "instant": true,
-                                  "intervalFactor": 2,
-                                  "legendFormat": ""
-                              }
-                          ],
-                          "title": "Disk Space Usage",
-                          "transformations": [
-                              {
-                                  "id": "groupBy",
-                                  "options": {
-                                      "fields": {
-                                          "Value #A": {
-                                              "aggregations": [
-                                                  "lastNotNull"
-                                              ],
-                                              "operation": "aggregate"
-                                          },
-                                          "Value #B": {
-                                              "aggregations": [
-                                                  "lastNotNull"
-                                              ],
-                                              "operation": "aggregate"
-                                          },
-                                          "mountpoint": {
-                                              "aggregations": [
-
-                                              ],
-                                              "operation": "groupby"
-                                          }
-                                      }
-                                  }
-                              },
-                              {
-                                  "id": "merge",
-                                  "options": {
-
-                                  }
-                              },
-                              {
-                                  "id": "calculateField",
-                                  "options": {
-                                      "alias": "Used",
-                                      "binary": {
-                                          "left": "Value #A (lastNotNull)",
-                                          "operator": "-",
-                                          "reducer": "sum",
-                                          "right": "Value #B (lastNotNull)"
-                                      },
-                                      "mode": "binary",
-                                      "reduce": {
-                                          "reducer": "sum"
-                                      }
-                                  }
-                              },
-                              {
-                                  "id": "calculateField",
-                                  "options": {
-                                      "alias": "Used, %",
-                                      "binary": {
-                                          "left": "Used",
-                                          "operator": "/",
-                                          "reducer": "sum",
-                                          "right": "Value #A (lastNotNull)"
-                                      },
-                                      "mode": "binary",
-                                      "reduce": {
-                                          "reducer": "sum"
-                                      }
-                                  }
-                              },
-                              {
-                                  "id": "organize",
-                                  "options": {
-                                      "excludeByName": {
-
-                                      },
-                                      "indexByName": {
-
-                                      },
-                                      "renameByName": {
-                                          "Value #A (lastNotNull)": "Size",
-                                          "Value #B (lastNotNull)": "Available",
-                                          "mountpoint": "Mounted on"
-                                      }
-                                  }
-                              },
-                              {
-                                  "id": "sortBy",
-                                  "options": {
-                                      "fields": {
-
-                                      },
-                                      "sort": [
-                                          {
-                                              "field": "Mounted on"
-                                          }
-                                      ]
-                                  }
-                              }
-                          ],
-                          "transparent": false,
-                          "type": "table"
+                          "expr": "100 -\n(\n  avg(node_memory_available_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}) /\n  avg(node_memory_total_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"})\n  * 100\n)\n"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "Memory Usage",
+                  "type": "gauge"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 18
+                  },
+                  "id": 7,
+                  "panels": [
+
+                  ],
                   "title": "Disk",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
-                      {
-                          "aliasColors": {
-
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 0,
+                              "showPoints": "never"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "description": "Network received (bits/s)",
-                          "fill": 0,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 8,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "rate(node_network_receive_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device!=\"lo\"}[$__rate_interval]) * 8",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Network Received",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
+                          "min": 0
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/ read| written/"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "unit",
+                                      "value": "Bps"
+                                  }
                               ]
                           },
-                          "yaxes": [
-                              {
-                                  "format": "bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
+                          {
+                              "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/ io time/"
                               },
-                              {
-                                  "format": "bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
+                              "properties": [
+                                  {
+                                      "id": "unit",
+                                      "value": "percentunit"
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 19
+                  },
+                  "id": 8,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "rate(node_disk_read_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}} read"
                       },
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "description": "Network transmitted (bits/s)",
-                          "fill": 0,
-                          "fillGradient": 0,
-                          "gridPos": {
-
+                          "expr": "rate(node_disk_written_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}} written"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "id": 9,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "rate(node_network_transmit_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device!=\"lo\"}[$__rate_interval]) * 8",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Network Transmitted",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              },
-                              {
-                                  "format": "bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "rate(node_disk_io_time_seconds_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}} io time"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "Disk I/O",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "thresholds": {
+                              "steps": [
+                                  {
+                                      "color": "green"
+                                  },
+                                  {
+                                      "color": "yellow",
+                                      "value": 0.8
+                                  },
+                                  {
+                                      "color": "red",
+                                      "value": 0.9
+                                  }
+                              ]
+                          },
+                          "unit": "decbytes"
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Mounted on"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.width",
+                                      "value": 260
+                                  }
+                              ]
+                          },
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Size"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.width",
+                                      "value": 93
+                                  }
+                              ]
+                          },
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Used"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.width",
+                                      "value": 72
+                                  }
+                              ]
+                          },
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Available"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.width",
+                                      "value": 88
+                                  }
+                              ]
+                          },
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Used, %"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "unit",
+                                      "value": "percentunit"
+                                  },
+                                  {
+                                      "id": "custom.cellOptions",
+                                      "value": {
+                                          "type": "gauge"
+                                      }
+                                  },
+                                  {
+                                      "id": "max",
+                                      "value": 1
+                                  },
+                                  {
+                                      "id": "min",
+                                      "value": 0
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 19
+                  },
+                  "id": 9,
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "max by (mountpoint) (node_filesystem_size_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", fstype!=\"\", mountpoint!=\"\"})\n",
+                          "format": "table",
+                          "instant": true,
+                          "legendFormat": ""
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "max by (mountpoint) (node_filesystem_avail_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", fstype!=\"\", mountpoint!=\"\"})\n",
+                          "format": "table",
+                          "instant": true,
+                          "legendFormat": ""
+                      }
+                  ],
+                  "title": "Disk Space Usage",
+                  "transformations": [
+                      {
+                          "id": "groupBy",
+                          "options": {
+                              "fields": {
+                                  "Value #A": {
+                                      "aggregations": [
+                                          "lastNotNull"
+                                      ],
+                                      "operation": "aggregate"
+                                  },
+                                  "Value #B": {
+                                      "aggregations": [
+                                          "lastNotNull"
+                                      ],
+                                      "operation": "aggregate"
+                                  },
+                                  "mountpoint": {
+                                      "aggregations": [
+
+                                      ],
+                                      "operation": "groupby"
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "id": "merge"
+                      },
+                      {
+                          "id": "calculateField",
+                          "options": {
+                              "alias": "Used",
+                              "binary": {
+                                  "left": "Value #A (lastNotNull)",
+                                  "operator": "-",
+                                  "reducer": "sum",
+                                  "right": "Value #B (lastNotNull)"
+                              },
+                              "mode": "binary",
+                              "reduce": {
+                                  "reducer": "sum"
+                              }
+                          }
+                      },
+                      {
+                          "id": "calculateField",
+                          "options": {
+                              "alias": "Used, %",
+                              "binary": {
+                                  "left": "Used",
+                                  "operator": "/",
+                                  "reducer": "sum",
+                                  "right": "Value #A (lastNotNull)"
+                              },
+                              "mode": "binary",
+                              "reduce": {
+                                  "reducer": "sum"
+                              }
+                          }
+                      },
+                      {
+                          "id": "organize",
+                          "options": {
+                              "excludeByName": {
+
+                              },
+                              "indexByName": {
+
+                              },
+                              "renameByName": {
+                                  "Value #A (lastNotNull)": "Size",
+                                  "Value #B (lastNotNull)": "Available",
+                                  "mountpoint": "Mounted on"
+                              }
+                          }
+                      },
+                      {
+                          "id": "sortBy",
+                          "options": {
+                              "fields": {
+
+                              },
+                              "sort": [
+                                  {
+                                      "field": "Mounted on"
+                                  }
+                              ]
+                          }
+                      }
+                  ],
+                  "type": "table"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 26
+                  },
+                  "id": 10,
+                  "panels": [
+
+                  ],
                   "title": "Network",
-                  "titleSize": "h6",
                   "type": "row"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "description": "Network received (bits/s)",
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 0,
+                              "showPoints": "never"
+                          },
+                          "min": 0,
+                          "unit": "bps"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 27
+                  },
+                  "id": 11,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "rate(node_network_receive_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device!=\"lo\"}[$__rate_interval]) * 8",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}}"
+                      }
+                  ],
+                  "title": "Network Received",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "description": "Network transmitted (bits/s)",
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 0
+                          },
+                          "min": 0,
+                          "unit": "bps"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 27
+                  },
+                  "id": 12,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "rate(node_network_transmit_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device!=\"lo\"}[$__rate_interval]) * 8",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}}"
+                      }
+                  ],
+                  "title": "Network Transmitted",
+                  "type": "timeseries"
               }
           ],
-          "schemaVersion": 14,
-          "style": "dark",
+          "refresh": "30s",
+          "schemaVersion": 39,
           "tags": [
               "node-exporter-mixin"
           ],
           "templating": {
               "list": [
                   {
-                      "current": {
-                          "text": "default",
-                          "value": "default"
-                      },
-                      "hide": 0,
-                      "label": "Data Source",
                       "name": "datasource",
-                      "options": [
-
-                      ],
                       "query": "prometheus",
-                      "refresh": 1,
-                      "regex": "",
                       "type": "datasource"
                   },
                   {
-                      "allValue": null,
-                      "current": {
-
+                      "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
                       },
-                      "datasource": "$datasource",
                       "hide": 2,
-                      "includeAll": false,
                       "label": "Cluster",
-                      "multi": false,
                       "name": "cluster",
-                      "options": [
-
-                      ],
                       "query": "label_values(node_uname_info{job=\"node-exporter\", sysname!=\"Darwin\"}, cluster)",
                       "refresh": 2,
-                      "regex": "",
-                      "sort": 0,
-                      "tagValuesQuery": "",
-                      "tags": [
-
-                      ],
-                      "tagsQuery": "",
-                      "type": "query",
-                      "useTags": false
+                      "type": "query"
                   },
                   {
-                      "allValue": null,
-                      "current": {
-
+                      "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
                       },
-                      "datasource": "$datasource",
-                      "hide": 0,
-                      "includeAll": false,
                       "label": "Instance",
-                      "multi": false,
                       "name": "instance",
-                      "options": [
-
-                      ],
                       "query": "label_values(node_uname_info{job=\"node-exporter\", cluster=\"$cluster\", sysname!=\"Darwin\"}, instance)",
                       "refresh": 2,
-                      "regex": "",
-                      "sort": 0,
-                      "tagValuesQuery": "",
-                      "tags": [
-
-                      ],
-                      "tagsQuery": "",
-                      "type": "query",
-                      "useTags": false
+                      "type": "query"
                   }
               ]
           },
@@ -17173,35 +16030,9 @@ items:
               "from": "now-1h",
               "to": "now"
           },
-          "timepicker": {
-              "refresh_intervals": [
-                  "5s",
-                  "10s",
-                  "30s",
-                  "1m",
-                  "5m",
-                  "15m",
-                  "30m",
-                  "1h",
-                  "2h",
-                  "1d"
-              ],
-              "time_options": [
-                  "5m",
-                  "15m",
-                  "1h",
-                  "6h",
-                  "12h",
-                  "24h",
-                  "2d",
-                  "7d",
-                  "30d"
-              ]
-          },
           "timezone": "utc",
           "title": "Node Exporter / AIX",
-          "uid": "7e0a61e486f727d763fb1d86fdd629c2",
-          "version": 0
+          "uid": "7e0a61e486f727d763fb1d86fdd629c2"
       }
   kind: ConfigMap
   metadata:
@@ -17216,1045 +16047,729 @@ items:
   data:
     nodes-darwin.json: |-
       {
-          "__inputs": [
-
-          ],
-          "__requires": [
-
-          ],
-          "annotations": {
-              "list": [
-
-              ]
-          },
-          "editable": false,
-          "gnetId": null,
           "graphTooltip": 1,
-          "hideControls": false,
-          "id": null,
-          "links": [
-
-          ],
-          "refresh": "30s",
-          "rows": [
+          "panels": [
               {
-                  "collapse": false,
                   "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 0
+                  },
+                  "id": 1,
                   "panels": [
-                      {
-                          "aliasColors": {
 
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 1,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 2,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "(\n  (1 - sum without (mode) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=~\"idle|iowait|steal\", instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval])))\n/ ignoring(cpu) group_left\n  count without (cpu, mode) (node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", instance=\"$instance\", cluster=\"$cluster\"})\n)\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 5,
-                                  "legendFormat": "{{cpu}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "CPU Usage",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": 1,
-                                  "min": 0,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": 1,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
-                      },
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 0,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 3,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "node_load1{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "1m load average",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "node_load5{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "5m load average",
-                                  "refId": "B"
-                              },
-                              {
-                                  "expr": "node_load15{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "15m load average",
-                                  "refId": "C"
-                              },
-                              {
-                                  "expr": "count(node_cpu_seconds_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", mode=\"idle\"})",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "logical cores",
-                                  "refId": "D"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Load Average",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "short",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              },
-                              {
-                                  "format": "short",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
-                      }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
                   "title": "CPU",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 10,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "max": 1,
+                          "min": 0,
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 1
+                  },
+                  "id": 2,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 1,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 4,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 9,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "node_memory_total_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Physical Memory",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "(\n    node_memory_internal_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} -\n    node_memory_purgeable_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} +\n    node_memory_wired_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} +\n    node_memory_compressed_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n)\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Memory Used",
-                                  "refId": "B"
-                              },
-                              {
-                                  "expr": "(\n    node_memory_internal_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} -\n    node_memory_purgeable_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n)\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "App Memory",
-                                  "refId": "C"
-                              },
-                              {
-                                  "expr": "node_memory_wired_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Wired Memory",
-                                  "refId": "D"
-                              },
-                              {
-                                  "expr": "node_memory_compressed_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "Compressed",
-                                  "refId": "E"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Memory Usage",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "bytes",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              },
-                              {
-                                  "format": "bytes",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
-                      },
-                      {
-                          "datasource": "$datasource",
-                          "fieldConfig": {
-                              "defaults": {
-                                  "max": 100,
-                                  "min": 0,
-                                  "thresholds": {
-                                      "mode": "absolute",
-                                      "steps": [
-                                          {
-                                              "color": "rgba(50, 172, 45, 0.97)"
-                                          },
-                                          {
-                                              "color": "rgba(237, 129, 40, 0.89)",
-                                              "value": 80
-                                          },
-                                          {
-                                              "color": "rgba(245, 54, 54, 0.9)",
-                                              "value": 90
-                                          }
-                                      ]
-                                  },
-                                  "unit": "percent"
-                              }
-                          },
-                          "gridPos": {
-
-                          },
-                          "id": 5,
-                          "span": 3,
-                          "targets": [
-                              {
-                                  "expr": "(\n    (\n      avg(node_memory_internal_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}) -\n      avg(node_memory_purgeable_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}) +\n      avg(node_memory_wired_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}) +\n      avg(node_memory_compressed_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"})\n    ) /\n    avg(node_memory_total_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"})\n)\n*\n100\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": ""
-                              }
-                          ],
-                          "title": "Memory Usage",
-                          "transparent": false,
-                          "type": "gauge"
+                          "expr": "(\n  (1 - sum without (mode) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=~\"idle|iowait|steal\", instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval])))\n/ ignoring(cpu) group_left\n  count without (cpu, mode) (node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", instance=\"$instance\", cluster=\"$cluster\"})\n)\n",
+                          "intervalFactor": 5,
+                          "legendFormat": "{{cpu}}"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "CPU Usage",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 0,
+                              "showPoints": "never"
+                          },
+                          "min": 0,
+                          "unit": "short"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 1
+                  },
+                  "id": 3,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_load1{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "1m load average"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_load5{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "5m load average"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_load15{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "15m load average"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "count(node_cpu_seconds_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", mode=\"idle\"})",
+                          "legendFormat": "logical cores"
+                      }
+                  ],
+                  "title": "Load Average",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 8
+                  },
+                  "id": 4,
                   "title": "Memory",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 10,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "none"
+                              }
+                          },
+                          "min": 0,
+                          "unit": "bytes"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 18,
+                      "x": 0,
+                      "y": 9
+                  },
+                  "id": 5,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 0,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 6,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-                              {
-                                  "alias": "/ read| written/",
-                                  "yaxis": 1
-                              },
-                              {
-                                  "alias": "/ io time/",
-                                  "yaxis": 2
-                              }
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "rate(node_disk_read_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}} read",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "rate(node_disk_written_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}} written",
-                                  "refId": "B"
-                              },
-                              {
-                                  "expr": "rate(node_disk_io_time_seconds_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}} io time",
-                                  "refId": "C"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Disk I/O",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "Bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "node_memory_total_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "Physical Memory"
                       },
                       {
-                          "datasource": "$datasource",
-                          "fieldConfig": {
-                              "defaults": {
-                                  "custom": {
-
-                                  },
-                                  "thresholds": {
-                                      "mode": "absolute",
-                                      "steps": [
-                                          {
-                                              "color": "green"
-                                          },
-                                          {
-                                              "color": "yellow",
-                                              "value": 0.8
-                                          },
-                                          {
-                                              "color": "red",
-                                              "value": 0.9
-                                          }
-                                      ]
-                                  },
-                                  "unit": "decbytes"
-                              },
-                              "overrides": [
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "(\n    node_memory_internal_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} -\n    node_memory_purgeable_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} +\n    node_memory_wired_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} +\n    node_memory_compressed_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n)\n",
+                          "legendFormat": "Memory Used"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "(\n    node_memory_internal_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"} -\n    node_memory_purgeable_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n)\n",
+                          "legendFormat": "App Memory"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_memory_wired_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "Wired Memory"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_memory_compressed_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "Compressed"
+                      }
+                  ],
+                  "title": "Memory Usage",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "max": 100,
+                          "min": 0,
+                          "thresholds": {
+                              "steps": [
                                   {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Mounted on"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "custom.width",
-                                              "value": 260
-                                          }
-                                      ]
-                                  },
-                                  {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Size"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "custom.width",
-                                              "value": 93
-                                          }
-                                      ]
-                                  },
-                                  {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Used"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "custom.width",
-                                              "value": 72
-                                          }
-                                      ]
+                                      "color": "rgba(50, 172, 45, 0.97)"
                                   },
                                   {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Available"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "custom.width",
-                                              "value": 88
-                                          }
-                                      ]
+                                      "color": "rgba(237, 129, 40, 0.89)",
+                                      "value": 80
                                   },
                                   {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Used, %"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "unit",
-                                              "value": "percentunit"
-                                          },
-                                          {
-                                              "id": "custom.displayMode",
-                                              "value": "gradient-gauge"
-                                          },
-                                          {
-                                              "id": "max",
-                                              "value": 1
-                                          },
-                                          {
-                                              "id": "min",
-                                              "value": 0
-                                          }
-                                      ]
+                                      "color": "rgba(245, 54, 54, 0.9)",
+                                      "value": 90
                                   }
                               ]
                           },
-                          "gridPos": {
-
+                          "unit": "percent"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 6,
+                      "x": 18,
+                      "y": 9
+                  },
+                  "id": 6,
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "id": 7,
-                          "span": 6,
-                          "targets": [
-                              {
-                                  "expr": "max by (mountpoint) (node_filesystem_size_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", fstype!=\"\", mountpoint!=\"\"})\n",
-                                  "format": "table",
-                                  "instant": true,
-                                  "intervalFactor": 2,
-                                  "legendFormat": ""
-                              },
-                              {
-                                  "expr": "max by (mountpoint) (node_filesystem_avail_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", fstype!=\"\", mountpoint!=\"\"})\n",
-                                  "format": "table",
-                                  "instant": true,
-                                  "intervalFactor": 2,
-                                  "legendFormat": ""
-                              }
-                          ],
-                          "title": "Disk Space Usage",
-                          "transformations": [
-                              {
-                                  "id": "groupBy",
-                                  "options": {
-                                      "fields": {
-                                          "Value #A": {
-                                              "aggregations": [
-                                                  "lastNotNull"
-                                              ],
-                                              "operation": "aggregate"
-                                          },
-                                          "Value #B": {
-                                              "aggregations": [
-                                                  "lastNotNull"
-                                              ],
-                                              "operation": "aggregate"
-                                          },
-                                          "mountpoint": {
-                                              "aggregations": [
-
-                                              ],
-                                              "operation": "groupby"
-                                          }
-                                      }
-                                  }
-                              },
-                              {
-                                  "id": "merge",
-                                  "options": {
-
-                                  }
-                              },
-                              {
-                                  "id": "calculateField",
-                                  "options": {
-                                      "alias": "Used",
-                                      "binary": {
-                                          "left": "Value #A (lastNotNull)",
-                                          "operator": "-",
-                                          "reducer": "sum",
-                                          "right": "Value #B (lastNotNull)"
-                                      },
-                                      "mode": "binary",
-                                      "reduce": {
-                                          "reducer": "sum"
-                                      }
-                                  }
-                              },
-                              {
-                                  "id": "calculateField",
-                                  "options": {
-                                      "alias": "Used, %",
-                                      "binary": {
-                                          "left": "Used",
-                                          "operator": "/",
-                                          "reducer": "sum",
-                                          "right": "Value #A (lastNotNull)"
-                                      },
-                                      "mode": "binary",
-                                      "reduce": {
-                                          "reducer": "sum"
-                                      }
-                                  }
-                              },
-                              {
-                                  "id": "organize",
-                                  "options": {
-                                      "excludeByName": {
-
-                                      },
-                                      "indexByName": {
-
-                                      },
-                                      "renameByName": {
-                                          "Value #A (lastNotNull)": "Size",
-                                          "Value #B (lastNotNull)": "Available",
-                                          "mountpoint": "Mounted on"
-                                      }
-                                  }
-                              },
-                              {
-                                  "id": "sortBy",
-                                  "options": {
-                                      "fields": {
-
-                                      },
-                                      "sort": [
-                                          {
-                                              "field": "Mounted on"
-                                          }
-                                      ]
-                                  }
-                              }
-                          ],
-                          "transparent": false,
-                          "type": "table"
+                          "expr": "(\n    (\n      avg(node_memory_internal_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}) -\n      avg(node_memory_purgeable_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}) +\n      avg(node_memory_wired_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}) +\n      avg(node_memory_compressed_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"})\n    ) /\n    avg(node_memory_total_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"})\n)\n*\n100\n"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "Memory Usage",
+                  "type": "gauge"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 18
+                  },
+                  "id": 7,
+                  "panels": [
+
+                  ],
                   "title": "Disk",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
-                      {
-                          "aliasColors": {
-
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 0,
+                              "showPoints": "never"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "description": "Network received (bits/s)",
-                          "fill": 0,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 8,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "rate(node_network_receive_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device!=\"lo\"}[$__rate_interval]) * 8",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Network Received",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
+                          "min": 0
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/ read| written/"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "unit",
+                                      "value": "Bps"
+                                  }
                               ]
                           },
-                          "yaxes": [
-                              {
-                                  "format": "bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
+                          {
+                              "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/ io time/"
                               },
-                              {
-                                  "format": "bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
+                              "properties": [
+                                  {
+                                      "id": "unit",
+                                      "value": "percentunit"
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 19
+                  },
+                  "id": 8,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "rate(node_disk_read_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}} read"
                       },
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "description": "Network transmitted (bits/s)",
-                          "fill": 0,
-                          "fillGradient": 0,
-                          "gridPos": {
-
+                          "expr": "rate(node_disk_written_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}} written"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "id": 9,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "rate(node_network_transmit_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device!=\"lo\"}[$__rate_interval]) * 8",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Network Transmitted",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              },
-                              {
-                                  "format": "bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "rate(node_disk_io_time_seconds_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}} io time"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "Disk I/O",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "thresholds": {
+                              "steps": [
+                                  {
+                                      "color": "green"
+                                  },
+                                  {
+                                      "color": "yellow",
+                                      "value": 0.8
+                                  },
+                                  {
+                                      "color": "red",
+                                      "value": 0.9
+                                  }
+                              ]
+                          },
+                          "unit": "decbytes"
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Mounted on"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.width",
+                                      "value": 260
+                                  }
+                              ]
+                          },
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Size"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.width",
+                                      "value": 93
+                                  }
+                              ]
+                          },
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Used"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.width",
+                                      "value": 72
+                                  }
+                              ]
+                          },
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Available"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.width",
+                                      "value": 88
+                                  }
+                              ]
+                          },
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Used, %"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "unit",
+                                      "value": "percentunit"
+                                  },
+                                  {
+                                      "id": "custom.cellOptions",
+                                      "value": {
+                                          "type": "gauge"
+                                      }
+                                  },
+                                  {
+                                      "id": "max",
+                                      "value": 1
+                                  },
+                                  {
+                                      "id": "min",
+                                      "value": 0
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 19
+                  },
+                  "id": 9,
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "max by (mountpoint) (node_filesystem_size_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", fstype!=\"\", mountpoint!=\"\"})\n",
+                          "format": "table",
+                          "instant": true,
+                          "legendFormat": ""
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "max by (mountpoint) (node_filesystem_avail_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", fstype!=\"\", mountpoint!=\"\"})\n",
+                          "format": "table",
+                          "instant": true,
+                          "legendFormat": ""
+                      }
+                  ],
+                  "title": "Disk Space Usage",
+                  "transformations": [
+                      {
+                          "id": "groupBy",
+                          "options": {
+                              "fields": {
+                                  "Value #A": {
+                                      "aggregations": [
+                                          "lastNotNull"
+                                      ],
+                                      "operation": "aggregate"
+                                  },
+                                  "Value #B": {
+                                      "aggregations": [
+                                          "lastNotNull"
+                                      ],
+                                      "operation": "aggregate"
+                                  },
+                                  "mountpoint": {
+                                      "aggregations": [
+
+                                      ],
+                                      "operation": "groupby"
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "id": "merge"
+                      },
+                      {
+                          "id": "calculateField",
+                          "options": {
+                              "alias": "Used",
+                              "binary": {
+                                  "left": "Value #A (lastNotNull)",
+                                  "operator": "-",
+                                  "reducer": "sum",
+                                  "right": "Value #B (lastNotNull)"
+                              },
+                              "mode": "binary",
+                              "reduce": {
+                                  "reducer": "sum"
+                              }
+                          }
+                      },
+                      {
+                          "id": "calculateField",
+                          "options": {
+                              "alias": "Used, %",
+                              "binary": {
+                                  "left": "Used",
+                                  "operator": "/",
+                                  "reducer": "sum",
+                                  "right": "Value #A (lastNotNull)"
+                              },
+                              "mode": "binary",
+                              "reduce": {
+                                  "reducer": "sum"
+                              }
+                          }
+                      },
+                      {
+                          "id": "organize",
+                          "options": {
+                              "excludeByName": {
+
+                              },
+                              "indexByName": {
+
+                              },
+                              "renameByName": {
+                                  "Value #A (lastNotNull)": "Size",
+                                  "Value #B (lastNotNull)": "Available",
+                                  "mountpoint": "Mounted on"
+                              }
+                          }
+                      },
+                      {
+                          "id": "sortBy",
+                          "options": {
+                              "fields": {
+
+                              },
+                              "sort": [
+                                  {
+                                      "field": "Mounted on"
+                                  }
+                              ]
+                          }
+                      }
+                  ],
+                  "type": "table"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 26
+                  },
+                  "id": 10,
+                  "panels": [
+
+                  ],
                   "title": "Network",
-                  "titleSize": "h6",
                   "type": "row"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "description": "Network received (bits/s)",
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 0,
+                              "showPoints": "never"
+                          },
+                          "min": 0,
+                          "unit": "bps"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 27
+                  },
+                  "id": 11,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "rate(node_network_receive_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device!=\"lo\"}[$__rate_interval]) * 8",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}}"
+                      }
+                  ],
+                  "title": "Network Received",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "description": "Network transmitted (bits/s)",
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 0
+                          },
+                          "min": 0,
+                          "unit": "bps"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 27
+                  },
+                  "id": 12,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "rate(node_network_transmit_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device!=\"lo\"}[$__rate_interval]) * 8",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}}"
+                      }
+                  ],
+                  "title": "Network Transmitted",
+                  "type": "timeseries"
               }
           ],
-          "schemaVersion": 14,
-          "style": "dark",
+          "refresh": "30s",
+          "schemaVersion": 39,
           "tags": [
               "node-exporter-mixin"
           ],
           "templating": {
               "list": [
                   {
-                      "current": {
-                          "text": "default",
-                          "value": "default"
-                      },
-                      "hide": 0,
-                      "label": "Data Source",
                       "name": "datasource",
-                      "options": [
-
-                      ],
                       "query": "prometheus",
-                      "refresh": 1,
-                      "regex": "",
                       "type": "datasource"
                   },
                   {
-                      "allValue": null,
-                      "current": {
-
+                      "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
                       },
-                      "datasource": "$datasource",
                       "hide": 2,
-                      "includeAll": false,
                       "label": "Cluster",
-                      "multi": false,
                       "name": "cluster",
-                      "options": [
-
-                      ],
-                      "query": "label_values(node_uname_info{job=\"node-exporter\", sysname=\"Darwin\"}, cluster)",
+                      "query": "label_values(node_uname_info{job=\"node-exporter\", sysname=\"Darwin\"},  cluster)",
                       "refresh": 2,
-                      "regex": "",
-                      "sort": 0,
-                      "tagValuesQuery": "",
-                      "tags": [
-
-                      ],
-                      "tagsQuery": "",
-                      "type": "query",
-                      "useTags": false
+                      "type": "query"
                   },
                   {
-                      "allValue": null,
-                      "current": {
-
+                      "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
                       },
-                      "datasource": "$datasource",
-                      "hide": 0,
-                      "includeAll": false,
                       "label": "Instance",
-                      "multi": false,
                       "name": "instance",
-                      "options": [
-
-                      ],
                       "query": "label_values(node_uname_info{job=\"node-exporter\", cluster=\"$cluster\", sysname=\"Darwin\"}, instance)",
                       "refresh": 2,
-                      "regex": "",
-                      "sort": 0,
-                      "tagValuesQuery": "",
-                      "tags": [
-
-                      ],
-                      "tagsQuery": "",
-                      "type": "query",
-                      "useTags": false
+                      "type": "query"
                   }
               ]
           },
@@ -18262,35 +16777,9 @@ items:
               "from": "now-1h",
               "to": "now"
           },
-          "timepicker": {
-              "refresh_intervals": [
-                  "5s",
-                  "10s",
-                  "30s",
-                  "1m",
-                  "5m",
-                  "15m",
-                  "30m",
-                  "1h",
-                  "2h",
-                  "1d"
-              ],
-              "time_options": [
-                  "5m",
-                  "15m",
-                  "1h",
-                  "6h",
-                  "12h",
-                  "24h",
-                  "2d",
-                  "7d",
-                  "30d"
-              ]
-          },
           "timezone": "utc",
           "title": "Node Exporter / MacOS",
-          "uid": "629701ea43bf69291922ea45f4a87d37",
-          "version": 0
+          "uid": "629701ea43bf69291922ea45f4a87d37"
       }
   kind: ConfigMap
   metadata:
@@ -18305,1038 +16794,721 @@ items:
   data:
     nodes.json: |-
       {
-          "__inputs": [
-
-          ],
-          "__requires": [
-
-          ],
-          "annotations": {
-              "list": [
-
-              ]
-          },
-          "editable": false,
-          "gnetId": null,
           "graphTooltip": 1,
-          "hideControls": false,
-          "id": null,
-          "links": [
-
-          ],
-          "refresh": "30s",
-          "rows": [
+          "panels": [
               {
-                  "collapse": false,
                   "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 0
+                  },
+                  "id": 1,
                   "panels": [
-                      {
-                          "aliasColors": {
 
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 1,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 2,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "(\n  (1 - sum without (mode) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=~\"idle|iowait|steal\", instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval])))\n/ ignoring(cpu) group_left\n  count without (cpu, mode) (node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", instance=\"$instance\", cluster=\"$cluster\"})\n)\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 5,
-                                  "legendFormat": "{{cpu}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "CPU Usage",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": 1,
-                                  "min": 0,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": 1,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
-                      },
-                      {
-                          "aliasColors": {
-
-                          },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 0,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 3,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "node_load1{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "1m load average",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "node_load5{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "5m load average",
-                                  "refId": "B"
-                              },
-                              {
-                                  "expr": "node_load15{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "15m load average",
-                                  "refId": "C"
-                              },
-                              {
-                                  "expr": "count(node_cpu_seconds_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", mode=\"idle\"})",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "logical cores",
-                                  "refId": "D"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Load Average",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "short",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              },
-                              {
-                                  "format": "short",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
-                      }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
                   "title": "CPU",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 10,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "max": 1,
+                          "min": 0,
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 1
+                  },
+                  "id": 2,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 1,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 4,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 9,
-                          "stack": true,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "(\n  node_memory_MemTotal_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n-\n  node_memory_MemFree_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n-\n  node_memory_Buffers_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n-\n  node_memory_Cached_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n)\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "memory used",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "node_memory_Buffers_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "memory buffers",
-                                  "refId": "B"
-                              },
-                              {
-                                  "expr": "node_memory_Cached_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "memory cached",
-                                  "refId": "C"
-                              },
-                              {
-                                  "expr": "node_memory_MemFree_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": "memory free",
-                                  "refId": "D"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Memory Usage",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "bytes",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              },
-                              {
-                                  "format": "bytes",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
-                      },
-                      {
-                          "datasource": "$datasource",
-                          "fieldConfig": {
-                              "defaults": {
-                                  "max": 100,
-                                  "min": 0,
-                                  "thresholds": {
-                                      "mode": "absolute",
-                                      "steps": [
-                                          {
-                                              "color": "rgba(50, 172, 45, 0.97)"
-                                          },
-                                          {
-                                              "color": "rgba(237, 129, 40, 0.89)",
-                                              "value": 80
-                                          },
-                                          {
-                                              "color": "rgba(245, 54, 54, 0.9)",
-                                              "value": 90
-                                          }
-                                      ]
-                                  },
-                                  "unit": "percent"
-                              }
-                          },
-                          "gridPos": {
-
-                          },
-                          "id": 5,
-                          "span": 3,
-                          "targets": [
-                              {
-                                  "expr": "100 -\n(\n  avg(node_memory_MemAvailable_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}) /\n  avg(node_memory_MemTotal_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"})\n* 100\n)\n",
-                                  "format": "time_series",
-                                  "intervalFactor": 2,
-                                  "legendFormat": ""
-                              }
-                          ],
-                          "title": "Memory Usage",
-                          "transparent": false,
-                          "type": "gauge"
+                          "expr": "(\n  (1 - sum without (mode) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=~\"idle|iowait|steal\", instance=\"$instance\", cluster=\"$cluster\"}[$__rate_interval])))\n/ ignoring(cpu) group_left\n  count without (cpu, mode) (node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", instance=\"$instance\", cluster=\"$cluster\"})\n)\n",
+                          "intervalFactor": 5,
+                          "legendFormat": "{{cpu}}"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "CPU Usage",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 0,
+                              "showPoints": "never"
+                          },
+                          "min": 0,
+                          "unit": "short"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 1
+                  },
+                  "id": 3,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_load1{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "1m load average"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_load5{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "5m load average"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_load15{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "15m load average"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "count(node_cpu_seconds_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", mode=\"idle\"})",
+                          "legendFormat": "logical cores"
+                      }
+                  ],
+                  "title": "Load Average",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 8
+                  },
+                  "id": 4,
                   "title": "Memory",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 10,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "min": 0,
+                          "unit": "bytes"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 18,
+                      "x": 0,
+                      "y": 9
+                  },
+                  "id": 5,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "fill": 0,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 6,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-                              {
-                                  "alias": "/ read| written/",
-                                  "yaxis": 1
-                              },
-                              {
-                                  "alias": "/ io time/",
-                                  "yaxis": 2
-                              }
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "rate(node_disk_read_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}} read",
-                                  "refId": "A"
-                              },
-                              {
-                                  "expr": "rate(node_disk_written_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}} written",
-                                  "refId": "B"
-                              },
-                              {
-                                  "expr": "rate(node_disk_io_time_seconds_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}} io time",
-                                  "refId": "C"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Disk I/O",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "Bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              },
-                              {
-                                  "format": "percentunit",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": null,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "(\n  node_memory_MemTotal_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n-\n  node_memory_MemFree_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n-\n  node_memory_Buffers_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n-\n  node_memory_Cached_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}\n)\n",
+                          "legendFormat": "memory used"
                       },
                       {
-                          "datasource": "$datasource",
-                          "fieldConfig": {
-                              "defaults": {
-                                  "custom": {
-
-                                  },
-                                  "thresholds": {
-                                      "mode": "absolute",
-                                      "steps": [
-                                          {
-                                              "color": "green"
-                                          },
-                                          {
-                                              "color": "yellow",
-                                              "value": 0.8
-                                          },
-                                          {
-                                              "color": "red",
-                                              "value": 0.9
-                                          }
-                                      ]
-                                  },
-                                  "unit": "decbytes"
-                              },
-                              "overrides": [
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_memory_Buffers_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "memory buffers"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_memory_Cached_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "memory cached"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "node_memory_MemFree_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}",
+                          "legendFormat": "memory free"
+                      }
+                  ],
+                  "title": "Memory Usage",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "max": 100,
+                          "min": 0,
+                          "thresholds": {
+                              "steps": [
                                   {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Mounted on"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "custom.width",
-                                              "value": 260
-                                          }
-                                      ]
-                                  },
-                                  {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Size"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "custom.width",
-                                              "value": 93
-                                          }
-                                      ]
+                                      "color": "rgba(50, 172, 45, 0.97)"
                                   },
                                   {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Used"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "custom.width",
-                                              "value": 72
-                                          }
-                                      ]
+                                      "color": "rgba(237, 129, 40, 0.89)",
+                                      "value": 80
                                   },
                                   {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Available"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "custom.width",
-                                              "value": 88
-                                          }
-                                      ]
-                                  },
-                                  {
-                                      "matcher": {
-                                          "id": "byName",
-                                          "options": "Used, %"
-                                      },
-                                      "properties": [
-                                          {
-                                              "id": "unit",
-                                              "value": "percentunit"
-                                          },
-                                          {
-                                              "id": "custom.displayMode",
-                                              "value": "gradient-gauge"
-                                          },
-                                          {
-                                              "id": "max",
-                                              "value": 1
-                                          },
-                                          {
-                                              "id": "min",
-                                              "value": 0
-                                          }
-                                      ]
+                                      "color": "rgba(245, 54, 54, 0.9)",
+                                      "value": 90
                                   }
                               ]
                           },
-                          "gridPos": {
-
+                          "unit": "percent"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 6,
+                      "x": 18,
+                      "y": 9
+                  },
+                  "id": 6,
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "id": 7,
-                          "span": 6,
-                          "targets": [
-                              {
-                                  "expr": "max by (mountpoint) (node_filesystem_size_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", fstype!=\"\", mountpoint!=\"\"})\n",
-                                  "format": "table",
-                                  "instant": true,
-                                  "intervalFactor": 2,
-                                  "legendFormat": ""
-                              },
-                              {
-                                  "expr": "max by (mountpoint) (node_filesystem_avail_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", fstype!=\"\", mountpoint!=\"\"})\n",
-                                  "format": "table",
-                                  "instant": true,
-                                  "intervalFactor": 2,
-                                  "legendFormat": ""
-                              }
-                          ],
-                          "title": "Disk Space Usage",
-                          "transformations": [
-                              {
-                                  "id": "groupBy",
-                                  "options": {
-                                      "fields": {
-                                          "Value #A": {
-                                              "aggregations": [
-                                                  "lastNotNull"
-                                              ],
-                                              "operation": "aggregate"
-                                          },
-                                          "Value #B": {
-                                              "aggregations": [
-                                                  "lastNotNull"
-                                              ],
-                                              "operation": "aggregate"
-                                          },
-                                          "mountpoint": {
-                                              "aggregations": [
-
-                                              ],
-                                              "operation": "groupby"
-                                          }
-                                      }
-                                  }
-                              },
-                              {
-                                  "id": "merge",
-                                  "options": {
-
-                                  }
-                              },
-                              {
-                                  "id": "calculateField",
-                                  "options": {
-                                      "alias": "Used",
-                                      "binary": {
-                                          "left": "Value #A (lastNotNull)",
-                                          "operator": "-",
-                                          "reducer": "sum",
-                                          "right": "Value #B (lastNotNull)"
-                                      },
-                                      "mode": "binary",
-                                      "reduce": {
-                                          "reducer": "sum"
-                                      }
-                                  }
-                              },
-                              {
-                                  "id": "calculateField",
-                                  "options": {
-                                      "alias": "Used, %",
-                                      "binary": {
-                                          "left": "Used",
-                                          "operator": "/",
-                                          "reducer": "sum",
-                                          "right": "Value #A (lastNotNull)"
-                                      },
-                                      "mode": "binary",
-                                      "reduce": {
-                                          "reducer": "sum"
-                                      }
-                                  }
-                              },
-                              {
-                                  "id": "organize",
-                                  "options": {
-                                      "excludeByName": {
-
-                                      },
-                                      "indexByName": {
-
-                                      },
-                                      "renameByName": {
-                                          "Value #A (lastNotNull)": "Size",
-                                          "Value #B (lastNotNull)": "Available",
-                                          "mountpoint": "Mounted on"
-                                      }
-                                  }
-                              },
-                              {
-                                  "id": "sortBy",
-                                  "options": {
-                                      "fields": {
-
-                                      },
-                                      "sort": [
-                                          {
-                                              "field": "Mounted on"
-                                          }
-                                      ]
-                                  }
-                              }
-                          ],
-                          "transparent": false,
-                          "type": "table"
+                          "expr": "100 -\n(\n  avg(node_memory_MemAvailable_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"}) /\n  avg(node_memory_MemTotal_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\"})\n* 100\n)\n"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "Memory Usage",
+                  "type": "gauge"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 18
+                  },
+                  "id": 7,
+                  "panels": [
+
+                  ],
                   "title": "Disk",
-                  "titleSize": "h6",
                   "type": "row"
               },
               {
-                  "collapse": false,
-                  "collapsed": false,
-                  "panels": [
-                      {
-                          "aliasColors": {
-
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 0,
+                              "showPoints": "never"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "description": "Network received (bits/s)",
-                          "fill": 0,
-                          "fillGradient": 0,
-                          "gridPos": {
-
-                          },
-                          "id": 8,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "rate(node_network_receive_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device!=\"lo\"}[$__rate_interval]) * 8",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Network Received",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
+                          "min": 0
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/ read| written/"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "unit",
+                                      "value": "Bps"
+                                  }
                               ]
                           },
-                          "yaxes": [
-                              {
-                                  "format": "bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
+                          {
+                              "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/ io time/"
                               },
-                              {
-                                  "format": "bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
+                              "properties": [
+                                  {
+                                      "id": "unit",
+                                      "value": "percentunit"
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 19
+                  },
+                  "id": 8,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "rate(node_disk_read_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}} read"
                       },
                       {
-                          "aliasColors": {
-
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "bars": false,
-                          "dashLength": 10,
-                          "dashes": false,
-                          "datasource": "$datasource",
-                          "description": "Network transmitted (bits/s)",
-                          "fill": 0,
-                          "fillGradient": 0,
-                          "gridPos": {
-
+                          "expr": "rate(node_disk_written_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}} written"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
                           },
-                          "id": 9,
-                          "legend": {
-                              "alignAsTable": false,
-                              "avg": false,
-                              "current": false,
-                              "max": false,
-                              "min": false,
-                              "rightSide": false,
-                              "show": true,
-                              "sideWidth": null,
-                              "total": false,
-                              "values": false
-                          },
-                          "lines": true,
-                          "linewidth": 1,
-                          "links": [
-
-                          ],
-                          "nullPointMode": "null",
-                          "percentage": false,
-                          "pointradius": 5,
-                          "points": false,
-                          "renderer": "flot",
-                          "repeat": null,
-                          "seriesOverrides": [
-
-                          ],
-                          "spaceLength": 10,
-                          "span": 6,
-                          "stack": false,
-                          "steppedLine": false,
-                          "targets": [
-                              {
-                                  "expr": "rate(node_network_transmit_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device!=\"lo\"}[$__rate_interval]) * 8",
-                                  "format": "time_series",
-                                  "intervalFactor": 1,
-                                  "legendFormat": "{{device}}",
-                                  "refId": "A"
-                              }
-                          ],
-                          "thresholds": [
-
-                          ],
-                          "timeFrom": null,
-                          "timeShift": null,
-                          "title": "Network Transmitted",
-                          "tooltip": {
-                              "shared": true,
-                              "sort": 0,
-                              "value_type": "individual"
-                          },
-                          "type": "graph",
-                          "xaxis": {
-                              "buckets": null,
-                              "mode": "time",
-                              "name": null,
-                              "show": true,
-                              "values": [
-
-                              ]
-                          },
-                          "yaxes": [
-                              {
-                                  "format": "bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              },
-                              {
-                                  "format": "bps",
-                                  "label": null,
-                                  "logBase": 1,
-                                  "max": null,
-                                  "min": 0,
-                                  "show": true
-                              }
-                          ]
+                          "expr": "rate(node_disk_io_time_seconds_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device=~\"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)\"}[$__rate_interval])",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}} io time"
                       }
                   ],
-                  "repeat": null,
-                  "repeatIteration": null,
-                  "repeatRowId": null,
-                  "showTitle": true,
+                  "title": "Disk I/O",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "thresholds": {
+                              "steps": [
+                                  {
+                                      "color": "green"
+                                  },
+                                  {
+                                      "color": "yellow",
+                                      "value": 0.8
+                                  },
+                                  {
+                                      "color": "red",
+                                      "value": 0.9
+                                  }
+                              ]
+                          },
+                          "unit": "decbytes"
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Mounted on"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.width",
+                                      "value": 260
+                                  }
+                              ]
+                          },
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Size"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.width",
+                                      "value": 93
+                                  }
+                              ]
+                          },
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Used"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.width",
+                                      "value": 72
+                                  }
+                              ]
+                          },
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Available"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.width",
+                                      "value": 88
+                                  }
+                              ]
+                          },
+                          {
+                              "matcher": {
+                                  "id": "byName",
+                                  "options": "Used, %"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "unit",
+                                      "value": "percentunit"
+                                  },
+                                  {
+                                      "id": "custom.cellOptions",
+                                      "value": {
+                                          "type": "gauge"
+                                      }
+                                  },
+                                  {
+                                      "id": "max",
+                                      "value": 1
+                                  },
+                                  {
+                                      "id": "min",
+                                      "value": 0
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 19
+                  },
+                  "id": 9,
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "max by (mountpoint) (node_filesystem_size_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", fstype!=\"\", mountpoint!=\"\"})\n",
+                          "format": "table",
+                          "instant": true,
+                          "legendFormat": ""
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "max by (mountpoint) (node_filesystem_avail_bytes{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", fstype!=\"\", mountpoint!=\"\"})\n",
+                          "format": "table",
+                          "instant": true,
+                          "legendFormat": ""
+                      }
+                  ],
+                  "title": "Disk Space Usage",
+                  "transformations": [
+                      {
+                          "id": "groupBy",
+                          "options": {
+                              "fields": {
+                                  "Value #A": {
+                                      "aggregations": [
+                                          "lastNotNull"
+                                      ],
+                                      "operation": "aggregate"
+                                  },
+                                  "Value #B": {
+                                      "aggregations": [
+                                          "lastNotNull"
+                                      ],
+                                      "operation": "aggregate"
+                                  },
+                                  "mountpoint": {
+                                      "aggregations": [
+
+                                      ],
+                                      "operation": "groupby"
+                                  }
+                              }
+                          }
+                      },
+                      {
+                          "id": "merge"
+                      },
+                      {
+                          "id": "calculateField",
+                          "options": {
+                              "alias": "Used",
+                              "binary": {
+                                  "left": "Value #A (lastNotNull)",
+                                  "operator": "-",
+                                  "reducer": "sum",
+                                  "right": "Value #B (lastNotNull)"
+                              },
+                              "mode": "binary",
+                              "reduce": {
+                                  "reducer": "sum"
+                              }
+                          }
+                      },
+                      {
+                          "id": "calculateField",
+                          "options": {
+                              "alias": "Used, %",
+                              "binary": {
+                                  "left": "Used",
+                                  "operator": "/",
+                                  "reducer": "sum",
+                                  "right": "Value #A (lastNotNull)"
+                              },
+                              "mode": "binary",
+                              "reduce": {
+                                  "reducer": "sum"
+                              }
+                          }
+                      },
+                      {
+                          "id": "organize",
+                          "options": {
+                              "excludeByName": {
+
+                              },
+                              "indexByName": {
+
+                              },
+                              "renameByName": {
+                                  "Value #A (lastNotNull)": "Size",
+                                  "Value #B (lastNotNull)": "Available",
+                                  "mountpoint": "Mounted on"
+                              }
+                          }
+                      },
+                      {
+                          "id": "sortBy",
+                          "options": {
+                              "fields": {
+
+                              },
+                              "sort": [
+                                  {
+                                      "field": "Mounted on"
+                                  }
+                              ]
+                          }
+                      }
+                  ],
+                  "type": "table"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 26
+                  },
+                  "id": 10,
+                  "panels": [
+
+                  ],
                   "title": "Network",
-                  "titleSize": "h6",
                   "type": "row"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "description": "Network received (bits/s)",
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 0,
+                              "showPoints": "never"
+                          },
+                          "min": 0,
+                          "unit": "bps"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 27
+                  },
+                  "id": 11,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "rate(node_network_receive_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device!=\"lo\"}[$__rate_interval]) * 8",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}}"
+                      }
+                  ],
+                  "title": "Network Received",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "description": "Network transmitted (bits/s)",
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 0
+                          },
+                          "min": 0,
+                          "unit": "bps"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 27
+                  },
+                  "id": 12,
+                  "options": {
+                      "tooltip": {
+                          "mode": "multi"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "rate(node_network_transmit_bytes_total{job=\"node-exporter\", instance=\"$instance\", cluster=\"$cluster\", device!=\"lo\"}[$__rate_interval]) * 8",
+                          "intervalFactor": 1,
+                          "legendFormat": "{{device}}"
+                      }
+                  ],
+                  "title": "Network Transmitted",
+                  "type": "timeseries"
               }
           ],
-          "schemaVersion": 14,
-          "style": "dark",
+          "refresh": "30s",
+          "schemaVersion": 39,
           "tags": [
               "node-exporter-mixin"
           ],
           "templating": {
               "list": [
                   {
-                      "current": {
-                          "text": "default",
-                          "value": "default"
-                      },
-                      "hide": 0,
-                      "label": "Data Source",
                       "name": "datasource",
-                      "options": [
-
-                      ],
                       "query": "prometheus",
-                      "refresh": 1,
-                      "regex": "",
                       "type": "datasource"
                   },
                   {
-                      "allValue": null,
-                      "current": {
-
+                      "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
                       },
-                      "datasource": "$datasource",
                       "hide": 2,
-                      "includeAll": false,
                       "label": "Cluster",
-                      "multi": false,
                       "name": "cluster",
-                      "options": [
-
-                      ],
                       "query": "label_values(node_uname_info{job=\"node-exporter\", sysname!=\"Darwin\"}, cluster)",
                       "refresh": 2,
-                      "regex": "",
-                      "sort": 0,
-                      "tagValuesQuery": "",
-                      "tags": [
-
-                      ],
-                      "tagsQuery": "",
-                      "type": "query",
-                      "useTags": false
+                      "type": "query"
                   },
                   {
-                      "allValue": null,
-                      "current": {
-
+                      "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
                       },
-                      "datasource": "$datasource",
-                      "hide": 0,
-                      "includeAll": false,
                       "label": "Instance",
-                      "multi": false,
                       "name": "instance",
-                      "options": [
-
-                      ],
                       "query": "label_values(node_uname_info{job=\"node-exporter\", cluster=\"$cluster\", sysname!=\"Darwin\"}, instance)",
                       "refresh": 2,
-                      "regex": "",
-                      "sort": 0,
-                      "tagValuesQuery": "",
-                      "tags": [
-
-                      ],
-                      "tagsQuery": "",
-                      "type": "query",
-                      "useTags": false
+                      "type": "query"
                   }
               ]
           },
@@ -19344,35 +17516,9 @@ items:
               "from": "now-1h",
               "to": "now"
           },
-          "timepicker": {
-              "refresh_intervals": [
-                  "5s",
-                  "10s",
-                  "30s",
-                  "1m",
-                  "5m",
-                  "15m",
-                  "30m",
-                  "1h",
-                  "2h",
-                  "1d"
-              ],
-              "time_options": [
-                  "5m",
-                  "15m",
-                  "1h",
-                  "6h",
-                  "12h",
-                  "24h",
-                  "2d",
-                  "7d",
-                  "30d"
-              ]
-          },
           "timezone": "utc",
           "title": "Node Exporter / Nodes",
-          "uid": "7d57716318ee0dddbac5a7f451fb7753",
-          "version": 0
+          "uid": "7d57716318ee0dddbac5a7f451fb7753"
       }
   kind: ConfigMap
   metadata:
@@ -19438,7 +17584,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -19500,7 +17646,7 @@ items:
                   },
                   "id": 2,
                   "interval": "1m",
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -19550,7 +17696,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -19612,7 +17758,7 @@ items:
                   },
                   "id": 4,
                   "interval": "1m",
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -19763,7 +17909,7 @@ items:
                       "y": 0
                   },
                   "id": 1,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -19816,7 +17962,7 @@ items:
                       "y": 0
                   },
                   "id": 2,
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -19862,7 +18008,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -19908,7 +18054,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -19954,7 +18100,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -20000,7 +18146,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -20046,7 +18192,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -20092,7 +18238,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23137,7 +21283,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23188,7 +21334,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23239,7 +21385,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23290,7 +21436,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23341,7 +21487,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23392,7 +21538,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23467,7 +21613,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23518,7 +21664,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23569,7 +21715,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23620,7 +21766,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23671,7 +21817,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23792,7 +21938,7 @@ items:
                   "options": {
                       "colorMode": "none"
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23843,7 +21989,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23918,7 +22064,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -23993,7 +22139,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24068,7 +22214,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24119,7 +22265,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24170,7 +22316,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24221,7 +22367,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24272,7 +22418,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24397,7 +22543,7 @@ items:
                       "displayMode": "basic",
                       "showUnfilled": false
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24436,7 +22582,7 @@ items:
                       "displayMode": "basic",
                       "showUnfilled": false
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24475,7 +22621,7 @@ items:
                       "displayMode": "basic",
                       "showUnfilled": false
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24514,7 +22660,7 @@ items:
                       "displayMode": "basic",
                       "showUnfilled": false
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24565,7 +22711,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24616,7 +22762,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24667,7 +22813,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24718,7 +22864,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24769,7 +22915,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {
@@ -24820,7 +22966,7 @@ items:
                           "mode": "single"
                       }
                   },
-                  "pluginVersion": "v11.1.0",
+                  "pluginVersion": "v11.4.0",
                   "targets": [
                       {
                           "datasource": {

--- a/manifests/kubePrometheus-prometheusRule.yaml
+++ b/manifests/kubePrometheus-prometheusRule.yaml
@@ -53,7 +53,7 @@ spec:
     rules:
     - alert: NodeNetworkInterfaceFlapping
       annotations:
-        description: Network interface "{{ $labels.device }}" changing its up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}
+        description: The network interface "{{ $labels.device }}" at "{{ $labels.instance }}" changing its up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/general/nodenetworkinterfaceflapping
         summary: Network interface is often changing its status
       expr: |

--- a/manifests/kubePrometheus-prometheusRule.yaml
+++ b/manifests/kubePrometheus-prometheusRule.yaml
@@ -53,7 +53,7 @@ spec:
     rules:
     - alert: NodeNetworkInterfaceFlapping
       annotations:
-        description: The network interface "{{ $labels.device }}" at "{{ $labels.instance }}" changing its up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}
+        description: The network interface "{{ $labels.device }}" at "{{ $labels.instance }}" changing its up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}.
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/general/nodenetworkinterfaceflapping
         summary: Network interface is often changing its status
       expr: |

--- a/manifests/kubePrometheus-prometheusRule.yaml
+++ b/manifests/kubePrometheus-prometheusRule.yaml
@@ -53,7 +53,7 @@ spec:
     rules:
     - alert: NodeNetworkInterfaceFlapping
       annotations:
-        description: The network interface "{{ $labels.device }}" at "{{ $labels.instance }}" changing its up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}.
+        description: Network interface "{{ $labels.device }}" changing its up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/general/nodenetworkinterfaceflapping
         summary: Network interface is often changing its status
       expr: |

--- a/manifests/kubernetesControlPlane-prometheusRule.yaml
+++ b/manifests/kubernetesControlPlane-prometheusRule.yaml
@@ -565,11 +565,12 @@ spec:
         severity: critical
     - alert: KubeAggregatedAPIErrors
       annotations:
-        description: Kubernetes aggregated API {{ $labels.name }}/{{ $labels.namespace }} has reported errors. It has appeared unavailable {{ $value | humanize }} times averaged over the past 10m.
+        description: Kubernetes aggregated API {{ $labels.instance }}/{{ $labels.name }} has reported {{ $labels.reason }} errors on cluster {{ $labels.cluster }}.
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeaggregatedapierrors
         summary: Kubernetes aggregated API has reported errors.
       expr: |
-        sum by(name, namespace, cluster)(increase(aggregator_unavailable_apiservice_total{job="apiserver"}[10m])) > 4
+        sum by(cluster, instance, name, reason)(increase(aggregator_unavailable_apiservice_total{job="apiserver"}[1m])) > 0
+      for: 10m
       labels:
         severity: warning
     - alert: KubeAggregatedAPIDown
@@ -786,7 +787,7 @@ spec:
         sum by (cluster, verb, scope) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase1h{le="+Inf"})
       record: cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase1h
     - expr: |
-        sum by (cluster, verb, scope) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d{le="+Inf"} * 24 * 30)
+        sum by (cluster, verb, scope) (cluster_verb_scope_le:apiserver_request_sli_duration_seconds_bucket:increase30d{le="+Inf"})
       record: cluster_verb_scope:apiserver_request_sli_duration_seconds_count:increase30d
     - expr: |
         1 - (

--- a/manifests/nodeExporter-prometheusRule.yaml
+++ b/manifests/nodeExporter-prometheusRule.yaml
@@ -156,7 +156,7 @@ spec:
         severity: warning
     - alert: NodeHighNumberConntrackEntriesUsed
       annotations:
-        description: '{{ $value | humanizePercentage }} of conntrack entries are used.'
+        description: '{{`{{`}} $labels.instance {{`}}`}} {{ $value | humanizePercentage }} of conntrack entries are used.'
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodehighnumberconntrackentriesused
         summary: Number of conntrack are getting close to the limit.
       expr: |

--- a/manifests/nodeExporter-prometheusRule.yaml
+++ b/manifests/nodeExporter-prometheusRule.yaml
@@ -156,7 +156,7 @@ spec:
         severity: warning
     - alert: NodeHighNumberConntrackEntriesUsed
       annotations:
-        description: '{{`{{`}} $labels.instance {{`}}`}} {{ $value | humanizePercentage }} of conntrack entries are used.'
+        description: '{{ $labels.instance }} {{ $value | humanizePercentage }} of conntrack entries are used.'
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodehighnumberconntrackentriesused
         summary: Number of conntrack are getting close to the limit.
       expr: |

--- a/manifests/nodeExporter-prometheusRule.yaml
+++ b/manifests/nodeExporter-prometheusRule.yaml
@@ -254,7 +254,7 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/node/nodecpuhighusage
         summary: High CPU usage.
       expr: |
-        sum without(mode) (avg without (cpu) (rate(node_cpu_seconds_total{job="node-exporter", mode!="idle"}[2m]))) * 100 > 90
+        sum without(mode) (avg without (cpu) (rate(node_cpu_seconds_total{job="node-exporter", mode!~"idle|iowait"}[2m]))) * 100 > 90
       for: 15m
       labels:
         severity: info

--- a/manifests/setup/0alertmanagerConfigCustomResourceDefinition.yaml
+++ b/manifests/setup/0alertmanagerConfigCustomResourceDefinition.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.78.2
+    operator.prometheus.io/version: 0.79.2
   name: alertmanagerconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/manifests/setup/0alertmanagerCustomResourceDefinition.yaml
+++ b/manifests/setup/0alertmanagerCustomResourceDefinition.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.78.2
+    operator.prometheus.io/version: 0.79.2
   name: alertmanagers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -2213,7 +2213,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -2228,7 +2228,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -2275,7 +2275,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -2287,8 +2287,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2319,7 +2319,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -2334,7 +2334,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -2381,7 +2381,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -2393,8 +2393,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2421,7 +2421,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -2442,7 +2442,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2460,7 +2460,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -2525,7 +2525,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2627,7 +2627,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -2648,7 +2648,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2666,7 +2666,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -2731,7 +2731,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3070,7 +3070,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -3091,7 +3091,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3109,7 +3109,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -3174,7 +3174,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3724,7 +3724,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -3739,7 +3739,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -3786,7 +3786,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -3798,8 +3798,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3830,7 +3830,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -3845,7 +3845,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -3892,7 +3892,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -3904,8 +3904,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3932,7 +3932,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -3953,7 +3953,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3971,7 +3971,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -4036,7 +4036,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -4138,7 +4138,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -4159,7 +4159,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -4177,7 +4177,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -4242,7 +4242,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -4581,7 +4581,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -4602,7 +4602,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -4620,7 +4620,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -4685,7 +4685,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -4903,6 +4903,29 @@ spec:
                   If set to true all actions on the underlying managed objects are not
                   goint to be performed, except for delete actions.
                 type: boolean
+              persistentVolumeClaimRetentionPolicy:
+                description: |-
+                  The field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+                  The default behavior is all PVCs are retained.
+                  This is an alpha field from kubernetes 1.23 until 1.26 and a beta field from 1.26.
+                  It requires enabling the StatefulSetAutoDeletePVC feature gate.
+                properties:
+                  whenDeleted:
+                    description: |-
+                      WhenDeleted specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                      of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                      `Delete` policy causes those PVCs to be deleted.
+                    type: string
+                  whenScaled:
+                    description: |-
+                      WhenScaled specifies what happens to PVCs created from StatefulSet
+                      VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                      policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                      `Delete` policy causes the associated PVCs for any excess pods above
+                      the replica count to be deleted.
+                    type: string
+                type: object
               podMetadata:
                 description: |-
                   PodMetadata configures labels and annotations which are propagated to the Alertmanager pods.
@@ -5122,6 +5145,32 @@ spec:
                       Note that this field cannot be set when spec.os.name is windows.
                     format: int64
                     type: integer
+                  seLinuxChangePolicy:
+                    description: |-
+                      seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                      It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                      Valid values are "MountOption" and "Recursive".
+
+                      "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                      This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                      "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                      This requires all Pods that share the same volume to use the same SELinux label.
+                      It is not possible to share the same volume among privileged and unprivileged Pods.
+                      Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                      whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                      CSIDriver instance. Other volumes are always re-labelled recursively.
+                      "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                      If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                      If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                      and "Recursive" for all other volumes.
+
+                      This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                      All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: string
                   seLinuxOptions:
                     description: |-
                       The SELinux context to be applied to all containers.
@@ -5840,18 +5889,15 @@ spec:
                                     persistent volume is being resized.
                                   type: string
                                 status:
+                                  description: |-
+                                    Status is the status of the condition.
+                                    Can be True, False, Unknown.
+                                    More info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=state%20of%20pvc-,conditions.status,-(string)%2C%20required
                                   type: string
                                 type:
                                   description: |-
-                                    PersistentVolumeClaimConditionType defines the condition of PV claim.
-                                    Valid values are:
-                                      - "Resizing", "FileSystemResizePending"
-
-                                    If RecoverVolumeExpansionFailure feature gate is enabled, then following additional values can be expected:
-                                      - "ControllerResizeError", "NodeResizeError"
-
-                                    If VolumeAttributesClass feature gate is enabled, then following additional values can be expected:
-                                      - "ModifyVolumeError", "ModifyingVolume"
+                                    Type is the type of the condition.
+                                    More info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=set%20to%20%27ResizeStarted%27.-,PersistentVolumeClaimCondition,-contains%20details%20about
                                   type: string
                               required:
                               - status
@@ -6187,6 +6233,8 @@ spec:
                       description: |-
                         awsElasticBlockStore represents an AWS Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
+                        Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                        awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                         More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
@@ -6218,7 +6266,10 @@ spec:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                      description: |-
+                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                        are redirected to the disk.csi.azure.com CSI driver.
                       properties:
                         cachingMode:
                           description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -6250,7 +6301,10 @@ spec:
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                      description: |-
+                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                        are redirected to the file.csi.azure.com CSI driver.
                       properties:
                         readOnly:
                           description: |-
@@ -6268,7 +6322,9 @@ spec:
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                      description: |-
+                        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                        Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                       properties:
                         monitors:
                           description: |-
@@ -6319,6 +6375,8 @@ spec:
                     cinder:
                       description: |-
                         cinder represents a cinder volume attached and mounted on kubelets host machine.
+                        Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                        are redirected to the cinder.csi.openstack.org CSI driver.
                         More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
@@ -6425,7 +6483,7 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                      description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                       properties:
                         driver:
                           description: |-
@@ -6867,6 +6925,7 @@ spec:
                       description: |-
                         flexVolume represents a generic volume resource that is
                         provisioned/attached using an exec based plugin.
+                        Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                       properties:
                         driver:
                           description: driver is the name of the driver to use for this volume.
@@ -6910,7 +6969,9 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                      description: |-
+                        flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                        Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                       properties:
                         datasetName:
                           description: |-
@@ -6925,6 +6986,8 @@ spec:
                       description: |-
                         gcePersistentDisk represents a GCE Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
+                        Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                        gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                         More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
@@ -6960,7 +7023,7 @@ spec:
                     gitRepo:
                       description: |-
                         gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                        Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                         EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                         into the Pod's container.
                       properties:
@@ -6983,6 +7046,7 @@ spec:
                     glusterfs:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                        Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                         More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
@@ -7189,7 +7253,9 @@ spec:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                      description: |-
+                        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                        Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                       properties:
                         fsType:
                           description: |-
@@ -7204,7 +7270,11 @@ spec:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                      description: |-
+                        portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                        Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                        is on.
                       properties:
                         fsType:
                           description: |-
@@ -7539,7 +7609,9 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                      description: |-
+                        quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                        Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                       properties:
                         group:
                           description: |-
@@ -7577,6 +7649,7 @@ spec:
                     rbd:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                        Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                         More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
@@ -7649,7 +7722,9 @@ spec:
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                      description: |-
+                        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                       properties:
                         fsType:
                           default: xfs
@@ -7775,7 +7850,9 @@ spec:
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                      description: |-
+                        storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                       properties:
                         fsType:
                           description: |-
@@ -7820,7 +7897,10 @@ spec:
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                      description: |-
+                        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                        Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                        are redirected to the csi.vsphere.vmware.com CSI driver.
                       properties:
                         fsType:
                           description: |-
@@ -7916,7 +7996,12 @@ spec:
                     description: Defines the TLS parameters for HTTPS.
                     properties:
                       cert:
-                        description: Contains the TLS certificate for the server.
+                        description: |-
+                          Secret or ConfigMap containing the TLS certificate for the web server.
+
+                          Either `keySecret` or `keyFile` must be defined.
+
+                          It is mutually exclusive with `certFile`.
                         properties:
                           configMap:
                             description: ConfigMap containing data to use for the targets.
@@ -7965,19 +8050,28 @@ spec:
                         type: object
                       certFile:
                         description: |-
-                          Path to the TLS certificate file in the Prometheus container for the server.
-                          Mutually exclusive with `cert`.
+                          Path to the TLS certificate file in the container for the web server.
+
+                          Either `keySecret` or `keyFile` must be defined.
+
+                          It is mutually exclusive with `cert`.
                         type: string
                       cipherSuites:
                         description: |-
-                          List of supported cipher suites for TLS versions up to TLS 1.2. If empty,
-                          Go default cipher suites are used. Available cipher suites are documented
-                          in the go documentation: https://golang.org/pkg/crypto/tls/#pkg-constants
+                          List of supported cipher suites for TLS versions up to TLS 1.2.
+
+                          If not defined, the Go default cipher suites are used.
+                          Available cipher suites are documented in the Go documentation:
+                          https://golang.org/pkg/crypto/tls/#pkg-constants
                         items:
                           type: string
                         type: array
                       client_ca:
-                        description: Contains the CA certificate for client certificate authentication to the server.
+                        description: |-
+                          Secret or ConfigMap containing the CA certificate for client certificate
+                          authentication to the server.
+
+                          It is mutually exclusive with `clientCAFile`.
                         properties:
                           configMap:
                             description: ConfigMap containing data to use for the targets.
@@ -8026,30 +8120,43 @@ spec:
                         type: object
                       clientAuthType:
                         description: |-
-                          Server policy for client authentication. Maps to ClientAuth Policies.
+                          The server policy for client TLS authentication.
+
                           For more detail on clientAuth options:
                           https://golang.org/pkg/crypto/tls/#ClientAuthType
                         type: string
                       clientCAFile:
                         description: |-
-                          Path to the CA certificate file for client certificate authentication to the server.
-                          Mutually exclusive with `client_ca`.
+                          Path to the CA certificate file for client certificate authentication to
+                          the server.
+
+                          It is mutually exclusive with `client_ca`.
                         type: string
                       curvePreferences:
                         description: |-
                           Elliptic curves that will be used in an ECDHE handshake, in preference
-                          order. Available curves are documented in the go documentation:
+                          order.
+
+                          Available curves are documented in the Go documentation:
                           https://golang.org/pkg/crypto/tls/#CurveID
                         items:
                           type: string
                         type: array
                       keyFile:
                         description: |-
-                          Path to the TLS key file in the Prometheus container for the server.
-                          Mutually exclusive with `keySecret`.
+                          Path to the TLS private key file in the container for the web server.
+
+                          If defined, either `cert` or `certFile` must be defined.
+
+                          It is mutually exclusive with `keySecret`.
                         type: string
                       keySecret:
-                        description: Secret containing the TLS key for the server.
+                        description: |-
+                          Secret containing the TLS private key for the web server.
+
+                          Either `cert` or `certFile` must be defined.
+
+                          It is mutually exclusive with `keyFile`.
                         properties:
                           key:
                             description: The key of the secret to select from.  Must be a valid secret key.
@@ -8071,16 +8178,17 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       maxVersion:
-                        description: Maximum TLS version that is acceptable. Defaults to TLS13.
+                        description: Maximum TLS version that is acceptable.
                         type: string
                       minVersion:
-                        description: Minimum TLS version that is acceptable. Defaults to TLS12.
+                        description: Minimum TLS version that is acceptable.
                         type: string
                       preferServerCipherSuites:
                         description: |-
-                          Controls whether the server selects the
-                          client's most preferred cipher suite, or the server's most preferred
-                          cipher suite. If true then the server's preference, as expressed in
+                          Controls whether the server selects the client's most preferred cipher
+                          suite, or the server's most preferred cipher suite.
+
+                          If true then the server's preference, as expressed in
                           the order of elements in cipherSuites, is used.
                         type: boolean
                     type: object

--- a/manifests/setup/0podmonitorCustomResourceDefinition.yaml
+++ b/manifests/setup/0podmonitorCustomResourceDefinition.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.78.2
+    operator.prometheus.io/version: 0.79.2
   name: podmonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -74,6 +74,18 @@ spec:
 
                   It requires Prometheus >= v2.28.0.
                 pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
+                type: string
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
                 type: string
               jobLabel:
                 description: |-
@@ -1039,18 +1051,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the
@@ -1121,6 +1121,18 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              selectorMechanism:
+                description: |-
+                  Mechanism used to select the endpoints to scrape.
+                  By default, the selection process relies on relabel configurations to filter the discovered targets.
+                  Alternatively, you can opt in for role selectors, which may offer better efficiency in large clusters.
+                  Which strategy is best for your use case needs to be carefully evaluated.
+
+                  It requires Prometheus >= v2.17.0.
+                enum:
+                - RelabelConfig
+                - RoleSelector
+                type: string
               targetLimit:
                 description: |-
                   `targetLimit` defines a limit on the number of scraped targets that will

--- a/manifests/setup/0probeCustomResourceDefinition.yaml
+++ b/manifests/setup/0probeCustomResourceDefinition.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.78.2
+    operator.prometheus.io/version: 0.79.2
   name: probes.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -163,6 +163,18 @@ spec:
                 - key
                 type: object
                 x-kubernetes-map-type: atomic
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               interval:
                 description: |-
                   Interval at which targets are probed using the configured prober.
@@ -648,18 +660,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the

--- a/manifests/setup/0prometheusCustomResourceDefinition.yaml
+++ b/manifests/setup/0prometheusCustomResourceDefinition.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.78.2
+    operator.prometheus.io/version: 0.79.2
   name: prometheuses.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -1314,6 +1314,14 @@ spec:
                             Prometheus object.
                           minLength: 1
                           type: string
+                        noProxy:
+                          description: |-
+                            `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                            that should be excluded from proxying. IP and domain names can
+                            contain port numbers.
+
+                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                          type: string
                         pathPrefix:
                           description: Prefix for the HTTP path alerts are pushed to.
                           type: string
@@ -1323,6 +1331,48 @@ spec:
                           - type: string
                           description: Port on which the Alertmanager API is exposed.
                           x-kubernetes-int-or-string: true
+                        proxyConnectHeader:
+                          additionalProperties:
+                            items:
+                              description: SecretKeySelector selects a key of a Secret.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          description: |-
+                            ProxyConnectHeader optionally specifies headers to send to
+                            proxies during CONNECT requests.
+
+                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        proxyFromEnvironment:
+                          description: |-
+                            Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                            It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                          type: boolean
+                        proxyUrl:
+                          description: '`proxyURL` defines the HTTP proxy server to use.'
+                          pattern: ^http(s)?://.+$
+                          type: string
                         relabelings:
                           description: Relabel configuration applied to the discovered Alertmanagers.
                           items:
@@ -2228,7 +2278,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -2243,7 +2293,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -2290,7 +2340,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -2302,8 +2352,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2334,7 +2384,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -2349,7 +2399,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -2396,7 +2446,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -2408,8 +2458,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2436,7 +2486,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -2457,7 +2507,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2475,7 +2525,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -2540,7 +2590,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2642,7 +2692,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -2663,7 +2713,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2681,7 +2731,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -2746,7 +2796,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3085,7 +3135,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -3106,7 +3156,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3124,7 +3174,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -3189,7 +3239,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -4009,7 +4059,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -4024,7 +4074,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -4071,7 +4121,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -4083,8 +4133,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -4115,7 +4165,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -4130,7 +4180,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -4177,7 +4227,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -4189,8 +4239,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -4217,7 +4267,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -4238,7 +4288,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -4256,7 +4306,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -4321,7 +4371,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -4423,7 +4473,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -4444,7 +4494,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -4462,7 +4512,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -4527,7 +4577,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -4866,7 +4916,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -4887,7 +4937,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -4905,7 +4955,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -4970,7 +5020,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -7595,6 +7645,45 @@ spec:
                             permissions on the `Nodes` objects.
                           type: boolean
                       type: object
+                    authorization:
+                      description: |-
+                        Authorization section for the ScrapeClass.
+                        It will only apply if the scrape resource doesn't specify any Authorization.
+                      properties:
+                        credentials:
+                          description: Selects a key of a Secret in the namespace that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        credentialsFile:
+                          description: File to read a secret from, mutually exclusive with `credentials`.
+                          type: string
+                        type:
+                          description: |-
+                            Defines the authentication type. The value is case-insensitive.
+
+                            "Basic" is not a supported value.
+
+                            Default: "Bearer"
+                          type: string
+                      type: object
                     default:
                       description: |-
                         Default indicates that the scrape applies to all scrape objects that
@@ -8068,18 +8157,6 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeInterval:
                 default: 30s
                 description: |-
@@ -8211,6 +8288,32 @@ spec:
                       Note that this field cannot be set when spec.os.name is windows.
                     format: int64
                     type: integer
+                  seLinuxChangePolicy:
+                    description: |-
+                      seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                      It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                      Valid values are "MountOption" and "Recursive".
+
+                      "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                      This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                      "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                      This requires all Pods that share the same volume to use the same SELinux label.
+                      It is not possible to share the same volume among privileged and unprivileged Pods.
+                      Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                      whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                      CSIDriver instance. Other volumes are always re-labelled recursively.
+                      "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                      If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                      If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                      and "Recursive" for all other volumes.
+
+                      This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                      All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: string
                   seLinuxOptions:
                     description: |-
                       The SELinux context to be applied to all containers.
@@ -9062,18 +9165,15 @@ spec:
                                     persistent volume is being resized.
                                   type: string
                                 status:
+                                  description: |-
+                                    Status is the status of the condition.
+                                    Can be True, False, Unknown.
+                                    More info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=state%20of%20pvc-,conditions.status,-(string)%2C%20required
                                   type: string
                                 type:
                                   description: |-
-                                    PersistentVolumeClaimConditionType defines the condition of PV claim.
-                                    Valid values are:
-                                      - "Resizing", "FileSystemResizePending"
-
-                                    If RecoverVolumeExpansionFailure feature gate is enabled, then following additional values can be expected:
-                                      - "ControllerResizeError", "NodeResizeError"
-
-                                    If VolumeAttributesClass feature gate is enabled, then following additional values can be expected:
-                                      - "ModifyVolumeError", "ModifyingVolume"
+                                    Type is the type of the condition.
+                                    More info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=set%20to%20%27ResizeStarted%27.-,PersistentVolumeClaimCondition,-contains%20details%20about
                                   type: string
                               required:
                               - status
@@ -10137,6 +10237,8 @@ spec:
                       description: |-
                         awsElasticBlockStore represents an AWS Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
+                        Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                        awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                         More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
@@ -10168,7 +10270,10 @@ spec:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                      description: |-
+                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                        are redirected to the disk.csi.azure.com CSI driver.
                       properties:
                         cachingMode:
                           description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -10200,7 +10305,10 @@ spec:
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                      description: |-
+                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                        are redirected to the file.csi.azure.com CSI driver.
                       properties:
                         readOnly:
                           description: |-
@@ -10218,7 +10326,9 @@ spec:
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                      description: |-
+                        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                        Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                       properties:
                         monitors:
                           description: |-
@@ -10269,6 +10379,8 @@ spec:
                     cinder:
                       description: |-
                         cinder represents a cinder volume attached and mounted on kubelets host machine.
+                        Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                        are redirected to the cinder.csi.openstack.org CSI driver.
                         More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
@@ -10375,7 +10487,7 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                      description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                       properties:
                         driver:
                           description: |-
@@ -10817,6 +10929,7 @@ spec:
                       description: |-
                         flexVolume represents a generic volume resource that is
                         provisioned/attached using an exec based plugin.
+                        Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                       properties:
                         driver:
                           description: driver is the name of the driver to use for this volume.
@@ -10860,7 +10973,9 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                      description: |-
+                        flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                        Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                       properties:
                         datasetName:
                           description: |-
@@ -10875,6 +10990,8 @@ spec:
                       description: |-
                         gcePersistentDisk represents a GCE Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
+                        Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                        gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                         More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
@@ -10910,7 +11027,7 @@ spec:
                     gitRepo:
                       description: |-
                         gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                        Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                         EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                         into the Pod's container.
                       properties:
@@ -10933,6 +11050,7 @@ spec:
                     glusterfs:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                        Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                         More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
@@ -11139,7 +11257,9 @@ spec:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                      description: |-
+                        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                        Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                       properties:
                         fsType:
                           description: |-
@@ -11154,7 +11274,11 @@ spec:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                      description: |-
+                        portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                        Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                        is on.
                       properties:
                         fsType:
                           description: |-
@@ -11489,7 +11613,9 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                      description: |-
+                        quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                        Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                       properties:
                         group:
                           description: |-
@@ -11527,6 +11653,7 @@ spec:
                     rbd:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                        Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                         More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
@@ -11599,7 +11726,9 @@ spec:
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                      description: |-
+                        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                       properties:
                         fsType:
                           default: xfs
@@ -11725,7 +11854,9 @@ spec:
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                      description: |-
+                        storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                       properties:
                         fsType:
                           description: |-
@@ -11770,7 +11901,10 @@ spec:
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                      description: |-
+                        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                        Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                        are redirected to the csi.vsphere.vmware.com CSI driver.
                       properties:
                         fsType:
                           description: |-
@@ -11872,7 +12006,12 @@ spec:
                     description: Defines the TLS parameters for HTTPS.
                     properties:
                       cert:
-                        description: Contains the TLS certificate for the server.
+                        description: |-
+                          Secret or ConfigMap containing the TLS certificate for the web server.
+
+                          Either `keySecret` or `keyFile` must be defined.
+
+                          It is mutually exclusive with `certFile`.
                         properties:
                           configMap:
                             description: ConfigMap containing data to use for the targets.
@@ -11921,19 +12060,28 @@ spec:
                         type: object
                       certFile:
                         description: |-
-                          Path to the TLS certificate file in the Prometheus container for the server.
-                          Mutually exclusive with `cert`.
+                          Path to the TLS certificate file in the container for the web server.
+
+                          Either `keySecret` or `keyFile` must be defined.
+
+                          It is mutually exclusive with `cert`.
                         type: string
                       cipherSuites:
                         description: |-
-                          List of supported cipher suites for TLS versions up to TLS 1.2. If empty,
-                          Go default cipher suites are used. Available cipher suites are documented
-                          in the go documentation: https://golang.org/pkg/crypto/tls/#pkg-constants
+                          List of supported cipher suites for TLS versions up to TLS 1.2.
+
+                          If not defined, the Go default cipher suites are used.
+                          Available cipher suites are documented in the Go documentation:
+                          https://golang.org/pkg/crypto/tls/#pkg-constants
                         items:
                           type: string
                         type: array
                       client_ca:
-                        description: Contains the CA certificate for client certificate authentication to the server.
+                        description: |-
+                          Secret or ConfigMap containing the CA certificate for client certificate
+                          authentication to the server.
+
+                          It is mutually exclusive with `clientCAFile`.
                         properties:
                           configMap:
                             description: ConfigMap containing data to use for the targets.
@@ -11982,30 +12130,43 @@ spec:
                         type: object
                       clientAuthType:
                         description: |-
-                          Server policy for client authentication. Maps to ClientAuth Policies.
+                          The server policy for client TLS authentication.
+
                           For more detail on clientAuth options:
                           https://golang.org/pkg/crypto/tls/#ClientAuthType
                         type: string
                       clientCAFile:
                         description: |-
-                          Path to the CA certificate file for client certificate authentication to the server.
-                          Mutually exclusive with `client_ca`.
+                          Path to the CA certificate file for client certificate authentication to
+                          the server.
+
+                          It is mutually exclusive with `client_ca`.
                         type: string
                       curvePreferences:
                         description: |-
                           Elliptic curves that will be used in an ECDHE handshake, in preference
-                          order. Available curves are documented in the go documentation:
+                          order.
+
+                          Available curves are documented in the Go documentation:
                           https://golang.org/pkg/crypto/tls/#CurveID
                         items:
                           type: string
                         type: array
                       keyFile:
                         description: |-
-                          Path to the TLS key file in the Prometheus container for the server.
-                          Mutually exclusive with `keySecret`.
+                          Path to the TLS private key file in the container for the web server.
+
+                          If defined, either `cert` or `certFile` must be defined.
+
+                          It is mutually exclusive with `keySecret`.
                         type: string
                       keySecret:
-                        description: Secret containing the TLS key for the server.
+                        description: |-
+                          Secret containing the TLS private key for the web server.
+
+                          Either `cert` or `certFile` must be defined.
+
+                          It is mutually exclusive with `keyFile`.
                         properties:
                           key:
                             description: The key of the secret to select from.  Must be a valid secret key.
@@ -12027,16 +12188,17 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       maxVersion:
-                        description: Maximum TLS version that is acceptable. Defaults to TLS13.
+                        description: Maximum TLS version that is acceptable.
                         type: string
                       minVersion:
-                        description: Minimum TLS version that is acceptable. Defaults to TLS12.
+                        description: Minimum TLS version that is acceptable.
                         type: string
                       preferServerCipherSuites:
                         description: |-
-                          Controls whether the server selects the
-                          client's most preferred cipher suite, or the server's most preferred
-                          cipher suite. If true then the server's preference, as expressed in
+                          Controls whether the server selects the client's most preferred cipher
+                          suite, or the server's most preferred cipher suite.
+
+                          If true then the server's preference, as expressed in
                           the order of elements in cipherSuites, is used.
                         type: boolean
                     type: object

--- a/manifests/setup/0prometheusagentCustomResourceDefinition.yaml
+++ b/manifests/setup/0prometheusagentCustomResourceDefinition.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.78.2
+    operator.prometheus.io/version: 0.79.2
   name: prometheusagents.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -1585,7 +1585,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -1600,7 +1600,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -1647,7 +1647,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -1659,8 +1659,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1691,7 +1691,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -1706,7 +1706,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -1753,7 +1753,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -1765,8 +1765,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1793,7 +1793,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -1814,7 +1814,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1832,7 +1832,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -1897,7 +1897,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1999,7 +1999,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -2020,7 +2020,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2038,7 +2038,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -2103,7 +2103,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2442,7 +2442,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -2463,7 +2463,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2481,7 +2481,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -2546,7 +2546,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3324,7 +3324,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -3339,7 +3339,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -3386,7 +3386,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -3398,8 +3398,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3430,7 +3430,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -3445,7 +3445,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -3492,7 +3492,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -3504,8 +3504,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3532,7 +3532,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -3553,7 +3553,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3571,7 +3571,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -3636,7 +3636,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3738,7 +3738,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -3759,7 +3759,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3777,7 +3777,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -3842,7 +3842,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -4181,7 +4181,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -4202,7 +4202,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -4220,7 +4220,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -4285,7 +4285,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -6039,6 +6039,45 @@ spec:
                             permissions on the `Nodes` objects.
                           type: boolean
                       type: object
+                    authorization:
+                      description: |-
+                        Authorization section for the ScrapeClass.
+                        It will only apply if the scrape resource doesn't specify any Authorization.
+                      properties:
+                        credentials:
+                          description: Selects a key of a Secret in the namespace that contains the credentials for authentication.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        credentialsFile:
+                          description: File to read a secret from, mutually exclusive with `credentials`.
+                          type: string
+                        type:
+                          description: |-
+                            Defines the authentication type. The value is case-insensitive.
+
+                            "Basic" is not a supported value.
+
+                            Default: "Bearer"
+                          type: string
+                      type: object
                     default:
                       description: |-
                         Default indicates that the scrape applies to all scrape objects that
@@ -6512,18 +6551,6 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeInterval:
                 default: 30s
                 description: |-
@@ -6655,6 +6682,32 @@ spec:
                       Note that this field cannot be set when spec.os.name is windows.
                     format: int64
                     type: integer
+                  seLinuxChangePolicy:
+                    description: |-
+                      seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                      It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                      Valid values are "MountOption" and "Recursive".
+
+                      "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                      This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                      "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                      This requires all Pods that share the same volume to use the same SELinux label.
+                      It is not possible to share the same volume among privileged and unprivileged Pods.
+                      Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                      whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                      CSIDriver instance. Other volumes are always re-labelled recursively.
+                      "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                      If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                      If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                      and "Recursive" for all other volumes.
+
+                      This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                      All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: string
                   seLinuxOptions:
                     description: |-
                       The SELinux context to be applied to all containers.
@@ -7503,18 +7556,15 @@ spec:
                                     persistent volume is being resized.
                                   type: string
                                 status:
+                                  description: |-
+                                    Status is the status of the condition.
+                                    Can be True, False, Unknown.
+                                    More info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=state%20of%20pvc-,conditions.status,-(string)%2C%20required
                                   type: string
                                 type:
                                   description: |-
-                                    PersistentVolumeClaimConditionType defines the condition of PV claim.
-                                    Valid values are:
-                                      - "Resizing", "FileSystemResizePending"
-
-                                    If RecoverVolumeExpansionFailure feature gate is enabled, then following additional values can be expected:
-                                      - "ControllerResizeError", "NodeResizeError"
-
-                                    If VolumeAttributesClass feature gate is enabled, then following additional values can be expected:
-                                      - "ModifyVolumeError", "ModifyingVolume"
+                                    Type is the type of the condition.
+                                    More info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=set%20to%20%27ResizeStarted%27.-,PersistentVolumeClaimCondition,-contains%20details%20about
                                   type: string
                               required:
                               - status
@@ -8088,6 +8138,8 @@ spec:
                       description: |-
                         awsElasticBlockStore represents an AWS Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
+                        Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                        awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                         More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
@@ -8119,7 +8171,10 @@ spec:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                      description: |-
+                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                        are redirected to the disk.csi.azure.com CSI driver.
                       properties:
                         cachingMode:
                           description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -8151,7 +8206,10 @@ spec:
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                      description: |-
+                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                        are redirected to the file.csi.azure.com CSI driver.
                       properties:
                         readOnly:
                           description: |-
@@ -8169,7 +8227,9 @@ spec:
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                      description: |-
+                        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                        Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                       properties:
                         monitors:
                           description: |-
@@ -8220,6 +8280,8 @@ spec:
                     cinder:
                       description: |-
                         cinder represents a cinder volume attached and mounted on kubelets host machine.
+                        Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                        are redirected to the cinder.csi.openstack.org CSI driver.
                         More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
@@ -8326,7 +8388,7 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                      description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                       properties:
                         driver:
                           description: |-
@@ -8768,6 +8830,7 @@ spec:
                       description: |-
                         flexVolume represents a generic volume resource that is
                         provisioned/attached using an exec based plugin.
+                        Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                       properties:
                         driver:
                           description: driver is the name of the driver to use for this volume.
@@ -8811,7 +8874,9 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                      description: |-
+                        flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                        Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                       properties:
                         datasetName:
                           description: |-
@@ -8826,6 +8891,8 @@ spec:
                       description: |-
                         gcePersistentDisk represents a GCE Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
+                        Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                        gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                         More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
@@ -8861,7 +8928,7 @@ spec:
                     gitRepo:
                       description: |-
                         gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                        Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                         EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                         into the Pod's container.
                       properties:
@@ -8884,6 +8951,7 @@ spec:
                     glusterfs:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                        Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                         More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
@@ -9090,7 +9158,9 @@ spec:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                      description: |-
+                        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                        Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                       properties:
                         fsType:
                           description: |-
@@ -9105,7 +9175,11 @@ spec:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                      description: |-
+                        portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                        Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                        is on.
                       properties:
                         fsType:
                           description: |-
@@ -9440,7 +9514,9 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                      description: |-
+                        quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                        Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                       properties:
                         group:
                           description: |-
@@ -9478,6 +9554,7 @@ spec:
                     rbd:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                        Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                         More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
@@ -9550,7 +9627,9 @@ spec:
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                      description: |-
+                        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                       properties:
                         fsType:
                           default: xfs
@@ -9676,7 +9755,9 @@ spec:
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                      description: |-
+                        storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                       properties:
                         fsType:
                           description: |-
@@ -9721,7 +9802,10 @@ spec:
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                      description: |-
+                        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                        Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                        are redirected to the csi.vsphere.vmware.com CSI driver.
                       properties:
                         fsType:
                           description: |-
@@ -9823,7 +9907,12 @@ spec:
                     description: Defines the TLS parameters for HTTPS.
                     properties:
                       cert:
-                        description: Contains the TLS certificate for the server.
+                        description: |-
+                          Secret or ConfigMap containing the TLS certificate for the web server.
+
+                          Either `keySecret` or `keyFile` must be defined.
+
+                          It is mutually exclusive with `certFile`.
                         properties:
                           configMap:
                             description: ConfigMap containing data to use for the targets.
@@ -9872,19 +9961,28 @@ spec:
                         type: object
                       certFile:
                         description: |-
-                          Path to the TLS certificate file in the Prometheus container for the server.
-                          Mutually exclusive with `cert`.
+                          Path to the TLS certificate file in the container for the web server.
+
+                          Either `keySecret` or `keyFile` must be defined.
+
+                          It is mutually exclusive with `cert`.
                         type: string
                       cipherSuites:
                         description: |-
-                          List of supported cipher suites for TLS versions up to TLS 1.2. If empty,
-                          Go default cipher suites are used. Available cipher suites are documented
-                          in the go documentation: https://golang.org/pkg/crypto/tls/#pkg-constants
+                          List of supported cipher suites for TLS versions up to TLS 1.2.
+
+                          If not defined, the Go default cipher suites are used.
+                          Available cipher suites are documented in the Go documentation:
+                          https://golang.org/pkg/crypto/tls/#pkg-constants
                         items:
                           type: string
                         type: array
                       client_ca:
-                        description: Contains the CA certificate for client certificate authentication to the server.
+                        description: |-
+                          Secret or ConfigMap containing the CA certificate for client certificate
+                          authentication to the server.
+
+                          It is mutually exclusive with `clientCAFile`.
                         properties:
                           configMap:
                             description: ConfigMap containing data to use for the targets.
@@ -9933,30 +10031,43 @@ spec:
                         type: object
                       clientAuthType:
                         description: |-
-                          Server policy for client authentication. Maps to ClientAuth Policies.
+                          The server policy for client TLS authentication.
+
                           For more detail on clientAuth options:
                           https://golang.org/pkg/crypto/tls/#ClientAuthType
                         type: string
                       clientCAFile:
                         description: |-
-                          Path to the CA certificate file for client certificate authentication to the server.
-                          Mutually exclusive with `client_ca`.
+                          Path to the CA certificate file for client certificate authentication to
+                          the server.
+
+                          It is mutually exclusive with `client_ca`.
                         type: string
                       curvePreferences:
                         description: |-
                           Elliptic curves that will be used in an ECDHE handshake, in preference
-                          order. Available curves are documented in the go documentation:
+                          order.
+
+                          Available curves are documented in the Go documentation:
                           https://golang.org/pkg/crypto/tls/#CurveID
                         items:
                           type: string
                         type: array
                       keyFile:
                         description: |-
-                          Path to the TLS key file in the Prometheus container for the server.
-                          Mutually exclusive with `keySecret`.
+                          Path to the TLS private key file in the container for the web server.
+
+                          If defined, either `cert` or `certFile` must be defined.
+
+                          It is mutually exclusive with `keySecret`.
                         type: string
                       keySecret:
-                        description: Secret containing the TLS key for the server.
+                        description: |-
+                          Secret containing the TLS private key for the web server.
+
+                          Either `cert` or `certFile` must be defined.
+
+                          It is mutually exclusive with `keyFile`.
                         properties:
                           key:
                             description: The key of the secret to select from.  Must be a valid secret key.
@@ -9978,16 +10089,17 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       maxVersion:
-                        description: Maximum TLS version that is acceptable. Defaults to TLS13.
+                        description: Maximum TLS version that is acceptable.
                         type: string
                       minVersion:
-                        description: Minimum TLS version that is acceptable. Defaults to TLS12.
+                        description: Minimum TLS version that is acceptable.
                         type: string
                       preferServerCipherSuites:
                         description: |-
-                          Controls whether the server selects the
-                          client's most preferred cipher suite, or the server's most preferred
-                          cipher suite. If true then the server's preference, as expressed in
+                          Controls whether the server selects the client's most preferred cipher
+                          suite, or the server's most preferred cipher suite.
+
+                          If true then the server's preference, as expressed in
                           the order of elements in cipherSuites, is used.
                         type: boolean
                     type: object

--- a/manifests/setup/0prometheusruleCustomResourceDefinition.yaml
+++ b/manifests/setup/0prometheusruleCustomResourceDefinition.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.78.2
+    operator.prometheus.io/version: 0.79.2
   name: prometheusrules.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -55,6 +55,16 @@ spec:
                       description: Interval determines how often rules in the group are evaluated.
                       pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
                       type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        Labels to add or overwrite before storing the result for its rules.
+                        The labels defined at the rule level take precedence.
+
+                        It requires Prometheus >= 3.0.0.
+                        The field is ignored for Thanos Ruler.
+                      type: object
                     limit:
                       description: |-
                         Limit the number of alerts an alerting rule and series a recording

--- a/manifests/setup/0scrapeconfigCustomResourceDefinition.yaml
+++ b/manifests/setup/0scrapeconfigCustomResourceDefinition.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.78.2
+    operator.prometheus.io/version: 0.79.2
   name: scrapeconfigs.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -3782,6 +3782,18 @@ spec:
                   - server
                   type: object
                 type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               fileSDConfigs:
                 description: FileSDConfigs defines a list of file service discovery configurations.
                 items:
@@ -10466,18 +10478,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeInterval:
                 description: ScrapeInterval is the interval between consecutive scrapes.
                 pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$

--- a/manifests/setup/0servicemonitorCustomResourceDefinition.yaml
+++ b/manifests/setup/0servicemonitorCustomResourceDefinition.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.78.2
+    operator.prometheus.io/version: 0.79.2
   name: servicemonitors.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -954,6 +954,18 @@ spec:
                       type: boolean
                   type: object
                 type: array
+              fallbackScrapeProtocol:
+                description: |-
+                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
+
+                  It requires Prometheus >= v3.0.0.
+                enum:
+                - PrometheusProto
+                - OpenMetricsText0.0.1
+                - OpenMetricsText1.0.0
+                - PrometheusText0.0.4
+                - PrometheusText1.0.0
+                type: string
               jobLabel:
                 description: |-
                   `jobLabel` selects the label from the associated Kubernetes `Service`
@@ -1051,18 +1063,6 @@ spec:
                   Whether to scrape a classic histogram that is also exposed as a native histogram.
                   It requires Prometheus >= v2.45.0.
                 type: boolean
-              scrapeFallbackProtocol:
-                description: |-
-                  The protocol to use if a scrape returns blank, unparseable, or otherwise invalid Content-Type.
-
-                  It requires Prometheus >= v3.0.0.
-                enum:
-                - PrometheusProto
-                - OpenMetricsText0.0.1
-                - OpenMetricsText1.0.0
-                - PrometheusText0.0.4
-                - PrometheusText1.0.0
-                type: string
               scrapeProtocols:
                 description: |-
                   `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the
@@ -1133,6 +1133,18 @@ spec:
                     type: object
                 type: object
                 x-kubernetes-map-type: atomic
+              selectorMechanism:
+                description: |-
+                  Mechanism used to select the endpoints to scrape.
+                  By default, the selection process relies on relabel configurations to filter the discovered targets.
+                  Alternatively, you can opt in for role selectors, which may offer better efficiency in large clusters.
+                  Which strategy is best for your use case needs to be carefully evaluated.
+
+                  It requires Prometheus >= v2.17.0.
+                enum:
+                - RelabelConfig
+                - RoleSelector
+                type: string
               targetLabels:
                 description: |-
                   `targetLabels` defines the labels which are transferred from the

--- a/manifests/setup/0thanosrulerCustomResourceDefinition.yaml
+++ b/manifests/setup/0thanosrulerCustomResourceDefinition.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.5
-    operator.prometheus.io/version: 0.78.2
+    operator.prometheus.io/version: 0.79.2
   name: thanosrulers.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com
@@ -1314,7 +1314,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -1329,7 +1329,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -1376,7 +1376,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -1388,8 +1388,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1420,7 +1420,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -1435,7 +1435,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -1482,7 +1482,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -1494,8 +1494,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1522,7 +1522,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -1543,7 +1543,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1561,7 +1561,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -1626,7 +1626,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -1728,7 +1728,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -1749,7 +1749,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -1767,7 +1767,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -1832,7 +1832,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -2171,7 +2171,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -2192,7 +2192,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -2210,7 +2210,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -2275,7 +2275,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3014,7 +3014,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -3029,7 +3029,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -3076,7 +3076,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -3088,8 +3088,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3120,7 +3120,7 @@ spec:
                             More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                           properties:
                             exec:
-                              description: Exec specifies the action to take.
+                              description: Exec specifies a command to execute in the container.
                               properties:
                                 command:
                                   description: |-
@@ -3135,7 +3135,7 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                             httpGet:
-                              description: HTTPGet specifies the http request to perform.
+                              description: HTTPGet specifies an HTTP GET request to perform.
                               properties:
                                 host:
                                   description: |-
@@ -3182,7 +3182,7 @@ spec:
                               - port
                               type: object
                             sleep:
-                              description: Sleep represents the duration that the container should sleep before being terminated.
+                              description: Sleep represents a duration that the container should sleep.
                               properties:
                                 seconds:
                                   description: Seconds is the number of seconds to sleep.
@@ -3194,8 +3194,8 @@ spec:
                             tcpSocket:
                               description: |-
                                 Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
-                                for the backward compatibility. There are no validation of this field and
-                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                                for backward compatibility. There is no validation of this field and
+                                lifecycle hooks will fail at runtime when it is specified.
                               properties:
                                 host:
                                   description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3222,7 +3222,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -3243,7 +3243,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3261,7 +3261,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -3326,7 +3326,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3428,7 +3428,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -3449,7 +3449,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3467,7 +3467,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -3532,7 +3532,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -3871,7 +3871,7 @@ spec:
                         More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       properties:
                         exec:
-                          description: Exec specifies the action to take.
+                          description: Exec specifies a command to execute in the container.
                           properties:
                             command:
                               description: |-
@@ -3892,7 +3892,7 @@ spec:
                           format: int32
                           type: integer
                         grpc:
-                          description: GRPC specifies an action involving a GRPC port.
+                          description: GRPC specifies a GRPC HealthCheckRequest.
                           properties:
                             port:
                               description: Port number of the gRPC service. Number must be in the range 1 to 65535.
@@ -3910,7 +3910,7 @@ spec:
                           - port
                           type: object
                         httpGet:
-                          description: HTTPGet specifies the http request to perform.
+                          description: HTTPGet specifies an HTTP GET request to perform.
                           properties:
                             host:
                               description: |-
@@ -3975,7 +3975,7 @@ spec:
                           format: int32
                           type: integer
                         tcpSocket:
-                          description: TCPSocket specifies an action involving a TCP port.
+                          description: TCPSocket specifies a connection to a TCP port.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults to the pod IP.'
@@ -4601,6 +4601,32 @@ spec:
                       Note that this field cannot be set when spec.os.name is windows.
                     format: int64
                     type: integer
+                  seLinuxChangePolicy:
+                    description: |-
+                      seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                      It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                      Valid values are "MountOption" and "Recursive".
+
+                      "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                      This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                      "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                      This requires all Pods that share the same volume to use the same SELinux label.
+                      It is not possible to share the same volume among privileged and unprivileged Pods.
+                      Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                      whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                      CSIDriver instance. Other volumes are always re-labelled recursively.
+                      "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                      If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                      If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                      and "Recursive" for all other volumes.
+
+                      This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                      All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                      Note that this field cannot be set when spec.os.name is windows.
+                    type: string
                   seLinuxOptions:
                     description: |-
                       The SELinux context to be applied to all containers.
@@ -5310,18 +5336,15 @@ spec:
                                     persistent volume is being resized.
                                   type: string
                                 status:
+                                  description: |-
+                                    Status is the status of the condition.
+                                    Can be True, False, Unknown.
+                                    More info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=state%20of%20pvc-,conditions.status,-(string)%2C%20required
                                   type: string
                                 type:
                                   description: |-
-                                    PersistentVolumeClaimConditionType defines the condition of PV claim.
-                                    Valid values are:
-                                      - "Resizing", "FileSystemResizePending"
-
-                                    If RecoverVolumeExpansionFailure feature gate is enabled, then following additional values can be expected:
-                                      - "ControllerResizeError", "NodeResizeError"
-
-                                    If VolumeAttributesClass feature gate is enabled, then following additional values can be expected:
-                                      - "ModifyVolumeError", "ModifyingVolume"
+                                    Type is the type of the condition.
+                                    More info: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/persistent-volume-claim-v1/#:~:text=set%20to%20%27ResizeStarted%27.-,PersistentVolumeClaimCondition,-contains%20details%20about
                                   type: string
                               required:
                               - status
@@ -5695,6 +5718,8 @@ spec:
                       description: |-
                         awsElasticBlockStore represents an AWS Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
+                        Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                        awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
                         More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                       properties:
                         fsType:
@@ -5726,7 +5751,10 @@ spec:
                       - volumeID
                       type: object
                     azureDisk:
-                      description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                      description: |-
+                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                        are redirected to the disk.csi.azure.com CSI driver.
                       properties:
                         cachingMode:
                           description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
@@ -5758,7 +5786,10 @@ spec:
                       - diskURI
                       type: object
                     azureFile:
-                      description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                      description: |-
+                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                        are redirected to the file.csi.azure.com CSI driver.
                       properties:
                         readOnly:
                           description: |-
@@ -5776,7 +5807,9 @@ spec:
                       - shareName
                       type: object
                     cephfs:
-                      description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                      description: |-
+                        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                        Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
                       properties:
                         monitors:
                           description: |-
@@ -5827,6 +5860,8 @@ spec:
                     cinder:
                       description: |-
                         cinder represents a cinder volume attached and mounted on kubelets host machine.
+                        Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                        are redirected to the cinder.csi.openstack.org CSI driver.
                         More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                       properties:
                         fsType:
@@ -5933,7 +5968,7 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     csi:
-                      description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                      description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
                       properties:
                         driver:
                           description: |-
@@ -6375,6 +6410,7 @@ spec:
                       description: |-
                         flexVolume represents a generic volume resource that is
                         provisioned/attached using an exec based plugin.
+                        Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
                       properties:
                         driver:
                           description: driver is the name of the driver to use for this volume.
@@ -6418,7 +6454,9 @@ spec:
                       - driver
                       type: object
                     flocker:
-                      description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                      description: |-
+                        flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                        Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
                       properties:
                         datasetName:
                           description: |-
@@ -6433,6 +6471,8 @@ spec:
                       description: |-
                         gcePersistentDisk represents a GCE Disk resource that is attached to a
                         kubelet's host machine and then exposed to the pod.
+                        Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                        gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
                         More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                       properties:
                         fsType:
@@ -6468,7 +6508,7 @@ spec:
                     gitRepo:
                       description: |-
                         gitRepo represents a git repository at a particular revision.
-                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                        Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
                         EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
                         into the Pod's container.
                       properties:
@@ -6491,6 +6531,7 @@ spec:
                     glusterfs:
                       description: |-
                         glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                        Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
                         More info: https://examples.k8s.io/volumes/glusterfs/README.md
                       properties:
                         endpoints:
@@ -6697,7 +6738,9 @@ spec:
                       - claimName
                       type: object
                     photonPersistentDisk:
-                      description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                      description: |-
+                        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                        Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
                       properties:
                         fsType:
                           description: |-
@@ -6712,7 +6755,11 @@ spec:
                       - pdID
                       type: object
                     portworxVolume:
-                      description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                      description: |-
+                        portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                        Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                        is on.
                       properties:
                         fsType:
                           description: |-
@@ -7047,7 +7094,9 @@ spec:
                           x-kubernetes-list-type: atomic
                       type: object
                     quobyte:
-                      description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                      description: |-
+                        quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                        Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
                       properties:
                         group:
                           description: |-
@@ -7085,6 +7134,7 @@ spec:
                     rbd:
                       description: |-
                         rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                        Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
                         More info: https://examples.k8s.io/volumes/rbd/README.md
                       properties:
                         fsType:
@@ -7157,7 +7207,9 @@ spec:
                       - monitors
                       type: object
                     scaleIO:
-                      description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                      description: |-
+                        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
                       properties:
                         fsType:
                           default: xfs
@@ -7283,7 +7335,9 @@ spec:
                           type: string
                       type: object
                     storageos:
-                      description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                      description: |-
+                        storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
                       properties:
                         fsType:
                           description: |-
@@ -7328,7 +7382,10 @@ spec:
                           type: string
                       type: object
                     vsphereVolume:
-                      description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                      description: |-
+                        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                        Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                        are redirected to the csi.vsphere.vmware.com CSI driver.
                       properties:
                         fsType:
                           description: |-
@@ -7412,7 +7469,12 @@ spec:
                     description: Defines the TLS parameters for HTTPS.
                     properties:
                       cert:
-                        description: Contains the TLS certificate for the server.
+                        description: |-
+                          Secret or ConfigMap containing the TLS certificate for the web server.
+
+                          Either `keySecret` or `keyFile` must be defined.
+
+                          It is mutually exclusive with `certFile`.
                         properties:
                           configMap:
                             description: ConfigMap containing data to use for the targets.
@@ -7461,19 +7523,28 @@ spec:
                         type: object
                       certFile:
                         description: |-
-                          Path to the TLS certificate file in the Prometheus container for the server.
-                          Mutually exclusive with `cert`.
+                          Path to the TLS certificate file in the container for the web server.
+
+                          Either `keySecret` or `keyFile` must be defined.
+
+                          It is mutually exclusive with `cert`.
                         type: string
                       cipherSuites:
                         description: |-
-                          List of supported cipher suites for TLS versions up to TLS 1.2. If empty,
-                          Go default cipher suites are used. Available cipher suites are documented
-                          in the go documentation: https://golang.org/pkg/crypto/tls/#pkg-constants
+                          List of supported cipher suites for TLS versions up to TLS 1.2.
+
+                          If not defined, the Go default cipher suites are used.
+                          Available cipher suites are documented in the Go documentation:
+                          https://golang.org/pkg/crypto/tls/#pkg-constants
                         items:
                           type: string
                         type: array
                       client_ca:
-                        description: Contains the CA certificate for client certificate authentication to the server.
+                        description: |-
+                          Secret or ConfigMap containing the CA certificate for client certificate
+                          authentication to the server.
+
+                          It is mutually exclusive with `clientCAFile`.
                         properties:
                           configMap:
                             description: ConfigMap containing data to use for the targets.
@@ -7522,30 +7593,43 @@ spec:
                         type: object
                       clientAuthType:
                         description: |-
-                          Server policy for client authentication. Maps to ClientAuth Policies.
+                          The server policy for client TLS authentication.
+
                           For more detail on clientAuth options:
                           https://golang.org/pkg/crypto/tls/#ClientAuthType
                         type: string
                       clientCAFile:
                         description: |-
-                          Path to the CA certificate file for client certificate authentication to the server.
-                          Mutually exclusive with `client_ca`.
+                          Path to the CA certificate file for client certificate authentication to
+                          the server.
+
+                          It is mutually exclusive with `client_ca`.
                         type: string
                       curvePreferences:
                         description: |-
                           Elliptic curves that will be used in an ECDHE handshake, in preference
-                          order. Available curves are documented in the go documentation:
+                          order.
+
+                          Available curves are documented in the Go documentation:
                           https://golang.org/pkg/crypto/tls/#CurveID
                         items:
                           type: string
                         type: array
                       keyFile:
                         description: |-
-                          Path to the TLS key file in the Prometheus container for the server.
-                          Mutually exclusive with `keySecret`.
+                          Path to the TLS private key file in the container for the web server.
+
+                          If defined, either `cert` or `certFile` must be defined.
+
+                          It is mutually exclusive with `keySecret`.
                         type: string
                       keySecret:
-                        description: Secret containing the TLS key for the server.
+                        description: |-
+                          Secret containing the TLS private key for the web server.
+
+                          Either `cert` or `certFile` must be defined.
+
+                          It is mutually exclusive with `keyFile`.
                         properties:
                           key:
                             description: The key of the secret to select from.  Must be a valid secret key.
@@ -7567,16 +7651,17 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       maxVersion:
-                        description: Maximum TLS version that is acceptable. Defaults to TLS13.
+                        description: Maximum TLS version that is acceptable.
                         type: string
                       minVersion:
-                        description: Minimum TLS version that is acceptable. Defaults to TLS12.
+                        description: Minimum TLS version that is acceptable.
                         type: string
                       preferServerCipherSuites:
                         description: |-
-                          Controls whether the server selects the
-                          client's most preferred cipher suite, or the server's most preferred
-                          cipher suite. If true then the server's preference, as expressed in
+                          Controls whether the server selects the client's most preferred cipher
+                          suite, or the server's most preferred cipher suite.
+
+                          If true then the server's preference, as expressed in
                           the order of elements in cipherSuites, is used.
                         type: boolean
                     type: object


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description
The description in the prometheusrule of `NodeHighNumberConntrackEntriesUsed` and `node-network` lacks the instance label. Adding this label helps to know the specific alarm instance.





## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
