### PR TITLE
chore: Add instance label to the prometheusrule description

### DIFF
--- a/jsonnet/kube-prometheus/components/mixin/alerts/node.libsonnet
+++ b/jsonnet/kube-prometheus/components/mixin/alerts/node.libsonnet
@@ -8,7 +8,7 @@
             alert: 'NodeNetworkInterfaceFlapping',
             annotations: {
               summary: 'Network interface is often changing its status',
-              description: 'Network interface "{{ $labels.device }}" changing its up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}',
+              description: 'The network interface "{{ $labels.device }}" at "{{ $labels.instance }}" changing its up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}',
             },
             expr: |||
               changes(node_network_up{%(nodeExporterSelector)s,%(hostNetworkInterfaceSelector)s}[2m]) > 2

--- a/manifests/kubePrometheus-prometheusRule.yaml
+++ b/manifests/kubePrometheus-prometheusRule.yaml
@@ -53,7 +53,7 @@ spec:
     rules:
     - alert: NodeNetworkInterfaceFlapping
       annotations:
-        description: Network interface "{{ $labels.device }}" changing its up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}
+        description: The network interface "{{ $labels.device }}" at "{{ $labels.instance }}" changing its up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/general/nodenetworkinterfaceflapping
         summary: Network interface is often changing its status
       expr: |


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

The description in the prometheusrule of `NodeNetworkInterfaceFlapping` not have instance label. Add instance label help to know the alert instance.



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
