### PR TITLE
GrafanaRequestsFailing: fix many-to-one matching must be explicit error

### DIFF
--- a/manifests/grafana-prometheusRule.yaml
+++ b/manifests/grafana-prometheusRule.yaml
@@ -17,11 +17,9 @@ spec:
     - alert: GrafanaRequestsFailing
       annotations:
         message: '{{ $labels.namespace }}/{{ $labels.job }}/{{ $labels.handler }} is experiencing {{ $value | humanize }}% errors'
-        runbook_url: https://runbooks.prometheus-operator.dev/runbooks/grafana/grafanarequestsfailing
       expr: |
-        100 * namespace_job_handler_statuscode:grafana_http_request_duration_seconds_count:rate5m{handler!~"/api/datasources/proxy/:id.*|/api/ds/query|/api/tsdb/query", status_code=~"5.."}
-        / ignoring (status_code)
-        sum without (status_code) (namespace_job_handler_statuscode:grafana_http_request_duration_seconds_count:rate5m{handler!~"/api/datasources/proxy/:id.*|/api/ds/query|/api/tsdb/query"})
+        100 * sum without (status_code) (namespace_job_handler_statuscode:grafana_http_request_duration_seconds_count:rate5m{handler!~"/api/datasources/proxy/:id.*|/api/ds/query|/api/tsdb/query", status_code=~"5.."})
+        / sum without (status_code) (namespace_job_handler_statuscode:grafana_http_request_duration_seconds_count:rate5m{handler!~"/api/datasources/proxy/:id.*|/api/ds/query|/api/tsdb/query"})
         > 50
       for: 5m
       labels:


### PR DESCRIPTION
Hey folks 👋🏻 

I got paged because this alert started failing to evaluate with the `many-to-one matching must be explicit (group_left/group_right)` error.

The left-hand side keeps the "status_code" label in the time series, which can lead to one single handler having multiple time series. When divided by the right-hand expression, it won't contain the status_code, leading to a many-to-one error.

I solved this by removing the `status_code` from the left-hand side. If I'm not mistaken, that also means we can get rid of `ignoring`. It could have been addressed with `group_left`, but the proposed expression seemed easier to follow. The expression should retain the "trigger on a per-route basis" intent.

I think this has always been incorrect, but I'm I'm surprised no one has experienced it.

I also noticed the runbook does not exist, so I removed it to avoid confusion
