### PR TITLE
Update grafana-mixin to latest main

### DIFF
--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -28,8 +28,8 @@
           "subdir": "grafana-mixin"
         }
       },
-      "version": "1120f9e255760a3c104b57871fcb91801e934382",
-      "sum": "MkjR7zCgq6MUZgjDzop574tFKoTX2OBr7DTwm1K+Ofs="
+      "version": "ebe2f442bdc2c35b8183e2004338c210aa93abde",
+      "sum": "S8mRTRH4w62kMCa2je3iCtvscYrwQmkyJ7Y/aM14KbE="
     },
     {
       "source": {

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -3158,7 +3158,6 @@ items:
               }
           ],
           "schemaVersion": 30,
-          "style": "dark",
           "tags": [
 
           ],

--- a/manifests/grafana-prometheusRule.yaml
+++ b/manifests/grafana-prometheusRule.yaml
@@ -19,8 +19,8 @@ spec:
         message: '{{ $labels.namespace }}/{{ $labels.job }}/{{ $labels.handler }} is experiencing {{ $value | humanize }}% errors'
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/grafana/grafanarequestsfailing
       expr: |
-        100 * namespace_job_handler_statuscode:grafana_http_request_duration_seconds_count:rate5m{handler!~"/api/datasources/proxy/:id.*|/api/ds/query|/api/tsdb/query", status_code=~"5.."}
-        / ignoring (status_code)
+        100 * sum without (status_code) (namespace_job_handler_statuscode:grafana_http_request_duration_seconds_count:rate5m{handler!~"/api/datasources/proxy/:id.*|/api/ds/query|/api/tsdb/query", status_code=~"5.."})
+        /
         sum without (status_code) (namespace_job_handler_statuscode:grafana_http_request_duration_seconds_count:rate5m{handler!~"/api/datasources/proxy/:id.*|/api/ds/query|/api/tsdb/query"})
         > 50
       for: 5m


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This updates the grafana-mixin to the latest main. The changes are minimal, but the main reason to update is to include https://github.com/grafana/grafana/pull/63382 which fixes an bug that can cause the `GrafanaRequestsFailing` alert to fail to evaluate. This PR would supersede https://github.com/prometheus-operator/kube-prometheus/pull/2592.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
- Update grafana-mixin to latest. Fixes evaluation errors for the GrafanaRequestsFailing alert.
```
