### PR TITLE
Make `cluster` label visible in Node Exporter Dashboards

### DIFF
--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -14680,7 +14680,6 @@ items:
                           "type": "prometheus",
                           "uid": "${datasource}"
                       },
-                      "hide": 2,
                       "includeAll": false,
                       "name": "cluster",
                       "query": "label_values(node_time_seconds, cluster)",
@@ -15281,7 +15280,6 @@ items:
                           "type": "prometheus",
                           "uid": "${datasource}"
                       },
-                      "hide": 2,
                       "includeAll": false,
                       "name": "cluster",
                       "query": "label_values(node_time_seconds, cluster)",
@@ -16005,7 +16003,6 @@ items:
                           "type": "prometheus",
                           "uid": "${datasource}"
                       },
-                      "hide": 2,
                       "label": "Cluster",
                       "name": "cluster",
                       "query": "label_values(node_uname_info{job=\"node-exporter\", sysname!=\"Darwin\"}, cluster)",
@@ -16752,7 +16749,6 @@ items:
                           "type": "prometheus",
                           "uid": "${datasource}"
                       },
-                      "hide": 2,
                       "label": "Cluster",
                       "name": "cluster",
                       "query": "label_values(node_uname_info{job=\"node-exporter\", sysname=\"Darwin\"},  cluster)",
@@ -17491,7 +17487,6 @@ items:
                           "type": "prometheus",
                           "uid": "${datasource}"
                       },
-                      "hide": 2,
                       "label": "Cluster",
                       "name": "cluster",
                       "query": "label_values(node_uname_info{job=\"node-exporter\", sysname!=\"Darwin\"}, cluster)",


### PR DESCRIPTION
## Description

Remove the hide toggle in the `cluster´ label from all Node Exporter Dashboards.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Make cluster label visible on all node exporter dashboards
```
