### PR TITLE
Toggle `showMultiCluster` for Node Exporter Mixin Configurations

### DIFF
--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -53,6 +53,7 @@ local defaults = {
       fsSpaceFillingUpCriticalThreshold: 10,
       diskDeviceSelector: 'device=~"(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|md.+|dasd.+)"',
       runbookURLPattern: 'https://runbooks.prometheus-operator.dev/runbooks/node/%s',
+      showMultiCluster: true,
     },
   },
 };

--- a/manifests/grafana-dashboardDefinitions.yaml
+++ b/manifests/grafana-dashboardDefinitions.yaml
@@ -14680,7 +14680,7 @@ items:
                           "type": "prometheus",
                           "uid": "${datasource}"
                       },
-                      "hide": 2,
+                      "hide": 0,
                       "includeAll": false,
                       "name": "cluster",
                       "query": "label_values(node_time_seconds, cluster)",
@@ -14714,6 +14714,594 @@ items:
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 11.4.0
     name: grafana-dashboard-node-cluster-rsrc-use
+    namespace: monitoring
+- apiVersion: v1
+  data:
+    node-multicluster-rsrc-use.json: |-
+      {
+          "graphTooltip": 1,
+          "panels": [
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 0
+                  },
+                  "id": 1,
+                  "panels": [
+
+                  ],
+                  "title": "CPU",
+                  "type": "row"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 1
+                  },
+                  "id": 2,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sum(\n  ((\n    instance:node_cpu_utilisation:rate5m{job=\"node-exporter\"}\n    *\n    instance:node_num_cpu:sum{job=\"node-exporter\"}\n  ) != 0)\n  / scalar(sum(instance:node_num_cpu:sum{job=\"node-exporter\"}))\n) by (cluster)\n",
+                          "legendFormat": "{{%(clusterLabel)s}}"
+                      }
+                  ],
+                  "title": "CPU Utilisation",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 1
+                  },
+                  "id": 3,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sum((\n    instance:node_load1_per_cpu:ratio{job=\"node-exporter\"}\n    / scalar(count(instance:node_load1_per_cpu:ratio{job=\"node-exporter\"}))\n) != 0) by (cluster)\n",
+                          "legendFormat": "{{%(clusterLabel)s}}"
+                      }
+                  ],
+                  "title": "CPU Saturation (Load1 per CPU)",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 8
+                  },
+                  "id": 4,
+                  "panels": [
+
+                  ],
+                  "title": "Memory",
+                  "type": "row"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 9
+                  },
+                  "id": 5,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sum((\n    instance:node_memory_utilisation:ratio{job=\"node-exporter\"}\n    / scalar(count(instance:node_memory_utilisation:ratio{job=\"node-exporter\"}))\n) != 0) by (cluster)\n",
+                          "legendFormat": "{{%(clusterLabel)s}}"
+                      }
+                  ],
+                  "title": "Memory Utilisation",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "rds"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 9
+                  },
+                  "id": 6,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sum((\n    instance:node_vmstat_pgmajfault:rate5m{job=\"node-exporter\"}\n) != 0) by (cluster)\n",
+                          "legendFormat": "{{%(clusterLabel)s}}"
+                      }
+                  ],
+                  "title": "Memory Saturation (Major Page Faults)",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 16
+                  },
+                  "id": 7,
+                  "panels": [
+
+                  ],
+                  "title": "Network",
+                  "type": "row"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "Bps"
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/Transmit/"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.transform",
+                                      "value": "negative-Y"
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 17
+                  },
+                  "id": 8,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sum((\n    instance:node_network_receive_bytes_excluding_lo:rate5m{job=\"node-exporter\"}\n) != 0) by (cluster)\n",
+                          "legendFormat": "{{%(clusterLabel)s}} Receive"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sum((\n    instance:node_network_transmit_bytes_excluding_lo:rate5m{job=\"node-exporter\"}\n) != 0) by (cluster)\n",
+                          "legendFormat": "{{%(clusterLabel)s}} Transmit"
+                      }
+                  ],
+                  "title": "Network Utilisation (Bytes Receive/Transmit)",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "Bps"
+                      },
+                      "overrides": [
+                          {
+                              "matcher": {
+                                  "id": "byRegexp",
+                                  "options": "/Transmit/"
+                              },
+                              "properties": [
+                                  {
+                                      "id": "custom.transform",
+                                      "value": "negative-Y"
+                                  }
+                              ]
+                          }
+                      ]
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 17
+                  },
+                  "id": 9,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sum((\n    instance:node_network_receive_drop_excluding_lo:rate5m{job=\"node-exporter\"}\n) != 0) by (cluster)\n",
+                          "legendFormat": "{{%(clusterLabel)s}} Receive"
+                      },
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sum((\n    instance:node_network_transmit_drop_excluding_lo:rate5m{job=\"node-exporter\"}\n) != 0) by (cluster)\n",
+                          "legendFormat": "{{%(clusterLabel)s}} Transmit"
+                      }
+                  ],
+                  "title": "Network Saturation (Drops Receive/Transmit)",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 24
+                  },
+                  "id": 10,
+                  "panels": [
+
+                  ],
+                  "title": "Disk IO",
+                  "type": "row"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 0,
+                      "y": 25
+                  },
+                  "id": 11,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sum((\n    instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\"}\n    / scalar(count(instance_device:node_disk_io_time_seconds:rate5m{job=\"node-exporter\"}))\n) != 0) by (cluster, device)\n",
+                          "legendFormat": "{{%(clusterLabel)s}} {{device}}"
+                      }
+                  ],
+                  "title": "Disk IO Utilisation",
+                  "type": "timeseries"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 12,
+                      "x": 12,
+                      "y": 25
+                  },
+                  "id": 12,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sum((\n  instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\"}\n  / scalar(count(instance_device:node_disk_io_time_weighted_seconds:rate5m{job=\"node-exporter\"}))\n) != 0) by (cluster, device)\n",
+                          "legendFormat": "{{%(clusterLabel)s}} {{device}}"
+                      }
+                  ],
+                  "title": "Disk IO Saturation",
+                  "type": "timeseries"
+              },
+              {
+                  "collapsed": false,
+                  "gridPos": {
+                      "h": 1,
+                      "w": 24,
+                      "x": 0,
+                      "y": 34
+                  },
+                  "id": 13,
+                  "panels": [
+
+                  ],
+                  "title": "Disk Space",
+                  "type": "row"
+              },
+              {
+                  "datasource": {
+                      "type": "prometheus",
+                      "uid": "${datasource}"
+                  },
+                  "fieldConfig": {
+                      "defaults": {
+                          "custom": {
+                              "fillOpacity": 100,
+                              "showPoints": "never",
+                              "stacking": {
+                                  "mode": "normal"
+                              }
+                          },
+                          "unit": "percentunit"
+                      }
+                  },
+                  "gridPos": {
+                      "h": 7,
+                      "w": 24,
+                      "x": 0,
+                      "y": 35
+                  },
+                  "id": 14,
+                  "options": {
+                      "legend": {
+                          "showLegend": false
+                      },
+                      "tooltip": {
+                          "mode": "multi",
+                          "sort": "desc"
+                      }
+                  },
+                  "pluginVersion": "v11.4.0",
+                  "targets": [
+                      {
+                          "datasource": {
+                              "type": "prometheus",
+                              "uid": "$datasource"
+                          },
+                          "expr": "sum (\n  sum without (device) (\n    max without (fstype, mountpoint, instance, pod) ((\n      node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\", mountpoint!=\"\"} - node_filesystem_avail_bytes{job=\"node-exporter\", fstype!=\"\", mountpoint!=\"\"}\n    ) != 0)\n  )\n  / scalar(sum(max without (fstype, mountpoint) (node_filesystem_size_bytes{job=\"node-exporter\", fstype!=\"\", mountpoint!=\"\"})))\n) by (cluster)\n",
+                          "legendFormat": "{{%(clusterLabel)s}}"
+                      }
+                  ],
+                  "title": "Disk Space Utilisation",
+                  "type": "timeseries"
+              }
+          ],
+          "refresh": "30s",
+          "schemaVersion": 39,
+          "tags": [
+              "node-exporter-mixin"
+          ],
+          "templating": {
+              "list": [
+                  {
+                      "name": "datasource",
+                      "query": "prometheus",
+                      "type": "datasource"
+                  },
+                  {
+                      "datasource": {
+                          "type": "prometheus",
+                          "uid": "${datasource}"
+                      },
+                      "refresh": 2,
+                      "sort": 1
+                  }
+              ]
+          },
+          "time": {
+              "from": "now-1h",
+              "to": "now"
+          },
+          "timezone": "utc",
+          "title": "Node Exporter / USE Method / Multi-cluster",
+          "uid": "8079490bd591ae67c254fd9062437b2d"
+      }
+  kind: ConfigMap
+  metadata:
+    labels:
+      app.kubernetes.io/component: grafana
+      app.kubernetes.io/name: grafana
+      app.kubernetes.io/part-of: kube-prometheus
+      app.kubernetes.io/version: 11.4.0
+    name: grafana-dashboard-node-multicluster-rsrc-use
     namespace: monitoring
 - apiVersion: v1
   data:
@@ -15281,7 +15869,7 @@ items:
                           "type": "prometheus",
                           "uid": "${datasource}"
                       },
-                      "hide": 2,
+                      "hide": 0,
                       "includeAll": false,
                       "name": "cluster",
                       "query": "label_values(node_time_seconds, cluster)",
@@ -16005,7 +16593,7 @@ items:
                           "type": "prometheus",
                           "uid": "${datasource}"
                       },
-                      "hide": 2,
+                      "hide": 0,
                       "label": "Cluster",
                       "name": "cluster",
                       "query": "label_values(node_uname_info{job=\"node-exporter\", sysname!=\"Darwin\"}, cluster)",
@@ -16752,7 +17340,7 @@ items:
                           "type": "prometheus",
                           "uid": "${datasource}"
                       },
-                      "hide": 2,
+                      "hide": 0,
                       "label": "Cluster",
                       "name": "cluster",
                       "query": "label_values(node_uname_info{job=\"node-exporter\", sysname=\"Darwin\"},  cluster)",
@@ -17491,7 +18079,7 @@ items:
                           "type": "prometheus",
                           "uid": "${datasource}"
                       },
-                      "hide": 2,
+                      "hide": 0,
                       "label": "Cluster",
                       "name": "cluster",
                       "query": "label_values(node_uname_info{job=\"node-exporter\", sysname!=\"Darwin\"}, cluster)",


### PR DESCRIPTION
## Description

Enabled  `showMultiCluster` on Node Exporter dashboards.

## Type of change

- [X] `ENHANCEMENT` (non-breaking change which improves existing functionality)

## Changelog entry


```release-note
Enabled  `showMultiCluster` on Node Exporter dashboards.
```
