### PR TITLE
Fix port allocation for node-exporter

### DIFF
--- a/jsonnet/kube-prometheus/components/node-exporter.libsonnet
+++ b/jsonnet/kube-prometheus/components/node-exporter.libsonnet
@@ -26,6 +26,7 @@ local defaults = {
   // thus [a-z0-9] regex below
   ignoredNetworkDevices:: '^(veth.*|[a-f0-9]{15})$',
   port:: 9100,
+  internal_port:: 9101,
   commonLabels:: {
     'app.kubernetes.io/name': defaults.name,
     'app.kubernetes.io/version': defaults.version,
@@ -210,7 +211,7 @@ function(params) {
       name: ne._config.name,
       image: ne._config.image,
       args: [
-        '--web.listen-address=' + std.join(':', [ne._config.listenAddress, std.toString(ne._config.port)]),
+        '--web.listen-address=' + std.join(':', [ne._config.listenAddress, std.toString(ne._config.internal_port)]),
         '--path.sysfs=/host/sys',
         '--path.rootfs=/host/root',
         '--path.udev.data=/host/root/run/udev/data',
@@ -236,7 +237,7 @@ function(params) {
     local kubeRbacProxy = krp(ne._config.kubeRbacProxy {
       name: 'kube-rbac-proxy',
       //image: krpImage,
-      upstream: 'http://127.0.0.1:' + ne._config.port + '/',
+      upstream: 'http://127.0.0.1:' + ne._config.internal_port + '/',
       secureListenAddress: '[$(IP)]:' + ne._config.port,
       // Keep `hostPort` here, rather than in the node-exporter container
       // because Kubernetes mandates that if you define a `hostPort` then

--- a/manifests/nodeExporter-daemonset.yaml
+++ b/manifests/nodeExporter-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
       automountServiceAccountToken: true
       containers:
       - args:
-        - --web.listen-address=127.0.0.1:9100
+        - --web.listen-address=127.0.0.1:9101
         - --path.sysfs=/host/sys
         - --path.rootfs=/host/root
         - --path.udev.data=/host/root/run/udev/data
@@ -66,7 +66,7 @@ spec:
       - args:
         - --secure-listen-address=[$(IP)]:9100
         - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-        - --upstream=http://127.0.0.1:9100/
+        - --upstream=http://127.0.0.1:9101/
         env:
         - name: IP
           valueFrom:


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

The daemonset for the node exporter is statically invalid. It assigns port 9100 both to the node-exporter container and to the kube-rbac-proxy container.

This results in the following behavior at runtime:

  1. kube-rbac-proxy and node-exporter race for port 9100.
  2. If kube-rbac-proxy wins, the system functions normally. However, kube-rbac-proxy is disfunctional and does NOT actually check authorization.
  3. If kube-rbac-proxy wins, it fails to locate its upstream and crashes. The race restarts.

This change is somewhat risky as we've been (so far) rolling out node-exporter with no kube-rbac-proxy, and would now unmasks any bugs in the kube-rbac-proxy integration.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Activate kube-rbac-proxy for node-exporter.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
