### PR TITLE
docs: minikube requires containerd runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ kubectl delete --ignore-not-found=true -f manifests/ -f manifests/setup
 To try out this stack, start [minikube](https://github.com/kubernetes/minikube) with the following command:
 
 ```shell
-$ minikube delete && minikube start --container-runtime=containerd --kubernetes-version=v1.31.0 --memory=8g --bootstrapper=kubeadm --extra-config=kubelet.authentication-token-webhook=true --extra-config=kubelet.authorization-mode=Webhook --extra-config=scheduler.bind-address=0.0.0.0 --extra-config=controller-manager.bind-address=0.0.0.0
+$ minikube delete && minikube start --container-runtime=containerd --kubernetes-version=v1.32.3 --memory=6g --bootstrapper=kubeadm --extra-config=kubelet.authentication-token-webhook=true --extra-config=kubelet.authorization-mode=Webhook --extra-config=scheduler.bind-address=0.0.0.0 --extra-config=controller-manager.bind-address=0.0.0.0
 ```
 
 The kube-prometheus stack includes a resource metrics API server, so the metrics-server addon is not necessary. Ensure the metrics-server addon is disabled on minikube:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ kubectl delete --ignore-not-found=true -f manifests/ -f manifests/setup
 To try out this stack, start [minikube](https://github.com/kubernetes/minikube) with the following command:
 
 ```shell
-$ minikube delete && minikube start --kubernetes-version=v1.23.0 --memory=6g --bootstrapper=kubeadm --extra-config=kubelet.authentication-token-webhook=true --extra-config=kubelet.authorization-mode=Webhook --extra-config=scheduler.bind-address=0.0.0.0 --extra-config=controller-manager.bind-address=0.0.0.0
+$ minikube delete && minikube start --container-runtime=containerd --kubernetes-version=v1.31.0 --memory=8g --bootstrapper=kubeadm --extra-config=kubelet.authentication-token-webhook=true --extra-config=kubelet.authorization-mode=Webhook --extra-config=scheduler.bind-address=0.0.0.0 --extra-config=controller-manager.bind-address=0.0.0.0
 ```
 
 The kube-prometheus stack includes a resource metrics API server, so the metrics-server addon is not necessary. Ensure the metrics-server addon is disabled on minikube:


### PR DESCRIPTION
## Description

minikube still uses docker as default container runtime
kubelet is unable to populate k8s dashboards in that configuration
configuring minikube to use containerd solves the issue

https://github.com/prometheus-community/helm-charts/issues/3972#issuecomment-1823271696

https://github.com/prometheus-community/helm-charts/issues/3614#issuecomment-1966747857


## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

docs: update readme minikube section with containerd runtime
```release-note
minikube still uses docker as default container runtime
kubelet is unable to populate k8s dashboards in that configuration
configuring minikube to use containerd solves the issue

tested with below versions:
- k8s: 1.31,1.32
- minikube: 1.35.0
- kube-prometheus: {version present in kube-prometheus-stack:68.2.2}
- kube-prometheus-stack: 68.2.2
```
