### PR TITLE
feat: add config option for storage

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -233,6 +233,7 @@ function(params) {
         runAsNonRoot: true,
         fsGroup: 2000,
       },
+      [if std.objectHas(params, 'storage') then 'storage']: am._config.storage,
     },
   },
 }

--- a/jsonnet/kube-prometheus/components/prometheus.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus.libsonnet
@@ -363,6 +363,7 @@ function(params) {
         fsGroup: 2000,
       },
       [if std.objectHas(params, 'thanos') then 'thanos']: p._config.thanos,
+      [if std.objectHas(params, 'storage') then 'storage']: p._config.storage,
     },
   },
 


### PR DESCRIPTION
The commit introduces a configuration surface for specifying the storage
that should be attached to Prometheus and Alertmanager servers.

Signed-off-by: squat <lserven@gmail.com>
