### PR TITLE
Add labels to aws-node Service and ServiceMonitor

### DIFF
--- a/jsonnet/kube-prometheus/addons/aws-vpc-cni.libsonnet
+++ b/jsonnet/kube-prometheus/addons/aws-vpc-cni.libsonnet
@@ -17,7 +17,11 @@
       metadata: {
         name: 'aws-node',
         namespace: 'kube-system',
-        labels: { 'app.kubernetes.io/name': 'aws-node' },
+        labels: {
+          'app.kubernetes.io/name': 'aws-node',
+          'app.kubernetes.io/component': 'prometheus',
+          'app.kubernetes.io/part-of': 'kube-prometheus',
+        },
       },
       spec: {
         ports: [
@@ -40,6 +44,8 @@
         namespace: $.values.kubernetesControlPlane.namespace,
         labels: {
           'app.kubernetes.io/name': 'aws-node',
+          'app.kubernetes.io/component': 'prometheus',
+          'app.kubernetes.io/part-of': 'kube-prometheus',
         },
       },
       spec: {


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This makes these resources labeled the same as the prometheusRuleAwsVpcCni PrometheusRule further down in the same file.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add labels to aws-node Service and ServiceMonitor
```
