### PR TITLE
Add component label to k8s-control-resources

### DIFF
--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -7,7 +7,7 @@ local defaults = {
   commonLabels:: {
     'app.kubernetes.io/name': 'kube-prometheus',
     'app.kubernetes.io/part-of': 'kube-prometheus',
-    'app.kubernetes.io/component': 'control-plane',
+    'app.kubernetes.io/component': 'kubernetes',
   },
   mixin:: {
     ruleLabels: {},

--- a/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
+++ b/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet
@@ -7,6 +7,7 @@ local defaults = {
   commonLabels:: {
     'app.kubernetes.io/name': 'kube-prometheus',
     'app.kubernetes.io/part-of': 'kube-prometheus',
+    'app.kubernetes.io/component': 'control-plane',
   },
   mixin:: {
     ruleLabels: {},

--- a/manifests/kubernetesControlPlane-prometheusRule.yaml
+++ b/manifests/kubernetesControlPlane-prometheusRule.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: kube-prometheus
     app.kubernetes.io/part-of: kube-prometheus
     prometheus: k8s

--- a/manifests/kubernetesControlPlane-prometheusRule.yaml
+++ b/manifests/kubernetesControlPlane-prometheusRule.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
+    app.kubernetes.io/component: control-plane
     app.kubernetes.io/name: kube-prometheus
     app.kubernetes.io/part-of: kube-prometheus
     prometheus: k8s

--- a/manifests/kubernetesControlPlane-serviceMonitorApiserver.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorApiserver.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
+    app.kubernetes.io/component: control-plane
     app.kubernetes.io/name: apiserver
     app.kubernetes.io/part-of: kube-prometheus
   name: kube-apiserver

--- a/manifests/kubernetesControlPlane-serviceMonitorApiserver.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorApiserver.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: apiserver
     app.kubernetes.io/part-of: kube-prometheus
   name: kube-apiserver

--- a/manifests/kubernetesControlPlane-serviceMonitorCoreDNS.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorCoreDNS.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
+    app.kubernetes.io/component: control-plane
     app.kubernetes.io/name: coredns
     app.kubernetes.io/part-of: kube-prometheus
   name: coredns

--- a/manifests/kubernetesControlPlane-serviceMonitorCoreDNS.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorCoreDNS.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: coredns
     app.kubernetes.io/part-of: kube-prometheus
   name: coredns

--- a/manifests/kubernetesControlPlane-serviceMonitorKubeControllerManager.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorKubeControllerManager.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
+    app.kubernetes.io/component: control-plane
     app.kubernetes.io/name: kube-controller-manager
     app.kubernetes.io/part-of: kube-prometheus
   name: kube-controller-manager

--- a/manifests/kubernetesControlPlane-serviceMonitorKubeControllerManager.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorKubeControllerManager.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: kube-controller-manager
     app.kubernetes.io/part-of: kube-prometheus
   name: kube-controller-manager

--- a/manifests/kubernetesControlPlane-serviceMonitorKubeScheduler.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorKubeScheduler.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: kube-scheduler
     app.kubernetes.io/part-of: kube-prometheus
   name: kube-scheduler

--- a/manifests/kubernetesControlPlane-serviceMonitorKubeScheduler.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorKubeScheduler.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
+    app.kubernetes.io/component: control-plane
     app.kubernetes.io/name: kube-scheduler
     app.kubernetes.io/part-of: kube-prometheus
   name: kube-scheduler

--- a/manifests/kubernetesControlPlane-serviceMonitorKubelet.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorKubelet.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    app.kubernetes.io/component: control-plane
+    app.kubernetes.io/component: kubernetes
     app.kubernetes.io/name: kubelet
     app.kubernetes.io/part-of: kube-prometheus
   name: kubelet

--- a/manifests/kubernetesControlPlane-serviceMonitorKubelet.yaml
+++ b/manifests/kubernetesControlPlane-serviceMonitorKubelet.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
+    app.kubernetes.io/component: control-plane
     app.kubernetes.io/name: kubelet
     app.kubernetes.io/part-of: kube-prometheus
   name: kubelet


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Add component label to k8s-control-resources. 

I would like to filter the resources in the generated manifests based on the `component` label and a bunch of them was missing this label. This PR together with [PR 2667](https://github.com/prometheus-operator/kube-prometheus/pull/2667) and [PR 2668](https://github.com/prometheus-operator/kube-prometheus/pull/2668) adds the missing labels.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Add component label to k8s-control-resources.
```
