### PR TITLE
main.libsonnet: Get grafanaDashboards mixin from all components

### DIFF
--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -69,12 +69,12 @@ local utils = import './lib/utils.libsonnet';
       version: $.values.common.versions.grafana,
       image: $.values.common.images.grafana,
       prometheusName: $.values.prometheus.name,
-      // TODO(paulfantom) This should be done by iterating over all objects and looking for object.mixin.grafanaDashboards
-      dashboards: $.nodeExporter.mixin.grafanaDashboards +
-                  $.prometheus.mixin.grafanaDashboards +
-                  $.kubernetesControlPlane.mixin.grafanaDashboards +
-                  $.alertmanager.mixin.grafanaDashboards +
-                  $.grafana.mixin.grafanaDashboards,
+      dashboards: {
+        [name]: $[component].mixin.grafanaDashboards[name]
+        for component in std.objectFields($)
+        if std.objectHasAll(std.get($[component], 'mixin', {}), 'grafanaDashboards')
+        for name in std.objectFields($[component].mixin.grafanaDashboards)
+      },
       mixin+: { ruleLabels: $.values.common.ruleLabels },
     },
     kubeStateMetrics: {


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

Instead of hard-coding the list of components to get `mixin.grafanaDashboards` from, iterate over all components that define that mixin.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

This simply addresses a longstanding TODO, and should not change any functionality. It just make that part of the code a bit more flexible in case more components start providing Grafana dashboards through `mixin.grafanaDashboards`.

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Loop through each component to look for Grafana dashboards defined in `mixin.grafanaDashboards.
```
