### PR TITLE
fix(k8s.rules.pod_owner): Use native casing of workload_type for downstream vector matching

### DIFF
--- a/manifests/kubernetesControlPlane-prometheusRule.yaml
+++ b/manifests/kubernetesControlPlane-prometheusRule.yaml
@@ -1467,37 +1467,37 @@ spec:
             label_join(
               group by (cluster, namespace, job_name, pod) (
                 label_join(
-                  kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"Job\"}
-                , \"job_name\", \"\", \"owner_name\")
+                  kube_pod_owner{job="kube-state-metrics", owner_kind="Job"}
+                , "job_name", "", "owner_name")
               )
               * on (cluster, namespace, job_name) group_left(owner_kind, owner_name)
               group by (cluster, namespace, job_name, owner_kind, owner_name) (
-                kube_job_owner{job=\"kube-state-metrics\", owner_kind!=\"Pod\", owner_kind!=\"\"}
+                kube_job_owner{job="kube-state-metrics", owner_kind!="Pod", owner_kind!=""}
               )
-            , \"workload\", \"\", \"owner_name\")
-          , \"workload_type\", \"\", \"owner_kind\")
+            , "workload", "", "owner_name")
+          , "workload_type", "", "owner_kind")
         
           OR
         
           label_replace(
             label_replace(
               label_replace(
-                kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"ReplicaSet\"}
-                , \"replicaset\", \"$1\", \"owner_name\", \"(.+)\"
+                kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet"}
+                , "replicaset", "$1", "owner_name", "(.+)"
               )
               * on(cluster, namespace, replicaset) group_left(owner_kind, owner_name)
               group by (cluster, namespace, replicaset, owner_kind, owner_name) (
-                kube_replicaset_owner{job=\"kube-state-metrics\", owner_kind!=\"Deployment\", owner_kind!=\"\"}
+                kube_replicaset_owner{job="kube-state-metrics", owner_kind!="Deployment", owner_kind!=""}
               )
-            , \"workload\", \"$1\", \"owner_name\", \"(.+)\")
+            , "workload", "$1", "owner_name", "(.+)")
             OR
             label_replace(
               group by (cluster, namespace, pod, owner_name, owner_kind) (
-                kube_pod_owner{job=\"kube-state-metrics\", owner_kind!=\"ReplicaSet\", owner_kind!=\"DaemonSet\", owner_kind!=\"StatefulSet\", owner_kind!=\"Job\", owner_kind!=\"Node\", owner_kind!=\"\"}
+                kube_pod_owner{job="kube-state-metrics", owner_kind!="ReplicaSet", owner_kind!="DaemonSet", owner_kind!="StatefulSet", owner_kind!="Job", owner_kind!="Node", owner_kind!=""}
               )
-              , \"workload\", \"$1\", \"owner_name\", \"(.+)\"
+              , "workload", "$1", "owner_name", "(.+)"
             )
-          , \"workload_type\", \"$1\", \"owner_kind\", \"(.+)\")
+          , "workload_type", "$1", "owner_kind", "(.+)")
         )
       record: namespace_workload_pod:kube_pod_owner:relabel
   - name: kube-scheduler.rules

--- a/manifests/kubernetesControlPlane-prometheusRule.yaml
+++ b/manifests/kubernetesControlPlane-prometheusRule.yaml
@@ -1388,7 +1388,7 @@ spec:
           )
         )
       labels:
-        workload_type: replicaset
+        workload_type: ReplicaSet
       record: namespace_workload_pod:kube_pod_owner:relabel
     - expr: |
         max by (cluster, namespace, workload, pod) (
@@ -1405,7 +1405,7 @@ spec:
           )
         )
       labels:
-        workload_type: deployment
+        workload_type: Deployment
       record: namespace_workload_pod:kube_pod_owner:relabel
     - expr: |
         max by (cluster, namespace, workload, pod) (
@@ -1415,7 +1415,7 @@ spec:
           )
         )
       labels:
-        workload_type: daemonset
+        workload_type: DaemonSet
       record: namespace_workload_pod:kube_pod_owner:relabel
     - expr: |
         max by (cluster, namespace, workload, pod) (
@@ -1424,7 +1424,7 @@ spec:
           "workload", "$1", "owner_name", "(.*)")
         )
       labels:
-        workload_type: statefulset
+        workload_type: StatefulSet
       record: namespace_workload_pod:kube_pod_owner:relabel
     - expr: |
         group by (cluster, namespace, workload, pod) (
@@ -1441,7 +1441,7 @@ spec:
           , "workload", "", "owner_name")
         )
       labels:
-        workload_type: job
+        workload_type: Job
       record: namespace_workload_pod:kube_pod_owner:relabel
     - expr: |
         max by (cluster, namespace, workload, pod) (
@@ -1450,7 +1450,7 @@ spec:
           "workload", "$1", "pod", "(.+)")
         )
       labels:
-        workload_type: barepod
+        workload_type: BarePod
       record: namespace_workload_pod:kube_pod_owner:relabel
     - expr: |
         max by (cluster, namespace, workload, pod) (
@@ -1459,9 +1459,46 @@ spec:
           "workload", "$1", "pod", "(.+)")
         )
       labels:
-        workload_type: staticpod
+        workload_type: StaticPod
       record: namespace_workload_pod:kube_pod_owner:relabel
-    - expr: "group by (cluster, namespace, workload, workload_type, pod) (\n  label_join(\n    label_join(\n      group by (cluster, namespace, job_name, pod) (\n        label_join(\n          kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"Job\"}\n        , \"job_name\", \"\", \"owner_name\")\n      )\n      * on (cluster, namespace, job_name) group_left(owner_kind, owner_name)\n      group by (cluster, namespace, job_name, owner_kind, owner_name) (\n        kube_job_owner{job=\"kube-state-metrics\", owner_kind!=\"Pod\", owner_kind!=\"\"}\n      )\n    , \"workload\", \"\", \"owner_name\")\n  , \"workload_type\", \"\", \"owner_kind\")\n  \n  OR\n\n  label_replace(\n    label_replace(\n      label_replace(\n        kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"ReplicaSet\"}\n        , \"replicaset\", \"$1\", \"owner_name\", \"(.+)\"\n      )\n      * on(cluster, namespace, replicaset) group_left(owner_kind, owner_name)\n      group by (cluster, namespace, replicaset, owner_kind, owner_name) (\n        kube_replicaset_owner{job=\"kube-state-metrics\", owner_kind!=\"Deployment\", owner_kind!=\"\"}\n      )\n    , \"workload\", \"$1\", \"owner_name\", \"(.+)\")\n    OR\n    label_replace(\n      group by (cluster, namespace, pod, owner_name, owner_kind) (\n        kube_pod_owner{job=\"kube-state-metrics\", owner_kind!=\"ReplicaSet\", owner_kind!=\"DaemonSet\", owner_kind!=\"StatefulSet\", owner_kind!=\"Job\", owner_kind!=\"Node\", owner_kind!=\"\"}\n      )\n      , \"workload\", \"$1\", \"owner_name\", \"(.+)\"\n    )\n  , \"workload_type\", \"$1\", \"owner_kind\", \"(.+)\")\n)\n"
+    - expr: |
+        group by (cluster, namespace, workload, workload_type, pod) (
+          label_join(
+            label_join(
+              group by (cluster, namespace, job_name, pod) (
+                label_join(
+                  kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"Job\"}
+                , \"job_name\", \"\", \"owner_name\")
+              )
+              * on (cluster, namespace, job_name) group_left(owner_kind, owner_name)
+              group by (cluster, namespace, job_name, owner_kind, owner_name) (
+                kube_job_owner{job=\"kube-state-metrics\", owner_kind!=\"Pod\", owner_kind!=\"\"}
+              )
+            , \"workload\", \"\", \"owner_name\")
+          , \"workload_type\", \"\", \"owner_kind\")
+        
+          OR
+        
+          label_replace(
+            label_replace(
+              label_replace(
+                kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"ReplicaSet\"}
+                , \"replicaset\", \"$1\", \"owner_name\", \"(.+)\"
+              )
+              * on(cluster, namespace, replicaset) group_left(owner_kind, owner_name)
+              group by (cluster, namespace, replicaset, owner_kind, owner_name) (
+                kube_replicaset_owner{job=\"kube-state-metrics\", owner_kind!=\"Deployment\", owner_kind!=\"\"}
+              )
+            , \"workload\", \"$1\", \"owner_name\", \"(.+)\")
+            OR
+            label_replace(
+              group by (cluster, namespace, pod, owner_name, owner_kind) (
+                kube_pod_owner{job=\"kube-state-metrics\", owner_kind!=\"ReplicaSet\", owner_kind!=\"DaemonSet\", owner_kind!=\"StatefulSet\", owner_kind!=\"Job\", owner_kind!=\"Node\", owner_kind!=\"\"}
+              )
+              , \"workload\", \"$1\", \"owner_name\", \"(.+)\"
+            )
+          , \"workload_type\", \"$1\", \"owner_kind\", \"(.+)\")
+        )
       record: namespace_workload_pod:kube_pod_owner:relabel
   - name: kube-scheduler.rules
     rules:


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

This PR fixes a bug where the `namespace_workload_pod:kube_pod_owner:relabel` metric returns inconsistent data for the `workload_type` label.

<img width="1402" height="954" alt="image" src="https://github.com/user-attachments/assets/45073a3e-d281-444d-8d89-93e4be94372d" />

This is particularly painful when a downstream user wants to use this metric to do vector matching with other metrics that have a `workload_type` or `owner_kind` type label.

Some more rationale... the raw KSM metrics seem to prefer singular camel cased values for this label. Seeing as this is a relabeling of KSM metrics, we should probably abide by the upstream preference for consistency.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fixed the `workload_type` label on the `namespace_workload_pod:kube_pod_owner:relabel` metric to be consistent internally and with upstream metrics.
```
