### PR TITLE
ci: Update versions workflow to capture error

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -34,11 +34,22 @@ jobs:
           git diff
           # Get the links to the changelogs of the updated versions and make them
           # available to the reviewers
-          {
-            echo "new_changelogs<<EOF"
-            scripts/get-new-changelogs.sh
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
+          # 1) Start the multiline output, unconditionally
+          echo "new_changelogs<<EOF" >> "$GITHUB_OUTPUT"
+    
+          # 2) Run the changelog script, capture its exit code,
+          #    and append its stdout to the output.
+          scripts/get-new-changelogs.sh >> "$GITHUB_OUTPUT"
+          script_rc=$?
+    
+          # 3) Close the delimiter so Actions can parse the value.
+          echo "EOF" >> "$GITHUB_OUTPUT"
+    
+          # 4) If the script failed, re-exit with its code to fail the job.
+          if [ $script_rc -ne 0 ]; then
+            echo "::error::get-new-changelogs.sh failed with exit code $script_rc"
+            exit $script_rc
+          fi
         if: matrix.branch == 'main'
       - name: Update jsonnet dependencies
         run: |


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

This will hopefully fix the issue with automated version updates in CI. I have a successful run here https://github.com/prometheus-operator/kube-prometheus/pull/2693


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
