### PR TITLE
main.libsonnet: Align kubePrometheus constructor with other components

### DIFF
--- a/jsonnet/kube-prometheus/main.libsonnet
+++ b/jsonnet/kube-prometheus/main.libsonnet
@@ -128,6 +128,10 @@ local utils = import './lib/utils.libsonnet';
       namespace: $.values.common.namespace,
       mixin+: { ruleLabels: $.values.common.ruleLabels },
     },
+    kubePrometheus: {
+      namespace: $.values.common.namespace,
+      mixin+: { ruleLabels: $.values.common.ruleLabels },
+    },
   },
 
   alertmanager: alertmanager($.values.alertmanager),
@@ -139,12 +143,7 @@ local utils = import './lib/utils.libsonnet';
   prometheusAdapter: prometheusAdapter($.values.prometheusAdapter),
   prometheusOperator: prometheusOperator($.values.prometheusOperator),
   kubernetesControlPlane: kubernetesControlPlane($.values.kubernetesControlPlane),
-  kubePrometheus: customMixin(
-    {
-      namespace: $.values.common.namespace,
-      mixin+: { ruleLabels: $.values.common.ruleLabels },
-    }
-  ) + {
+  kubePrometheus: customMixin($.values.kubePrometheus) + {
     namespace: {
       apiVersion: 'v1',
       kind: 'Namespace',


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

All components are constructed by passing `$.values[component]` as a parameter to the function responsible for initializing it; e.g. the `prometheus` component is constructed with

```jsonnet
prometheus($.values.prometheus)
```

But the `kubePrometheus` component wasn't following that pattern, making it hard to pass some configuration options in a standard way.

For instance, before this commit, setting

```jsonnet
{
  values+:: {
    kubePrometheus+: {
      mixin+: {
        _config+:: {
          hostNetworkInterfaceSelector: 'device!~"(lxc|veth).+"',
        },
      },
    },
  },
}
```

would have had no effect.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [x] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Allow `kubePrometheus` component to be customized through `$.values.kubePrometheus`
```
