### PR TITLE
examples: "changing-default-rules" doesn't remove all kubernetesControlPlane prometheusRules.

### DIFF
--- a/examples/changing-default-rules.libsonnet
+++ b/examples/changing-default-rules.libsonnet
@@ -1,6 +1,6 @@
 local filter = {
   kubernetesControlPlane+: {
-    prometheusRule+:: {
+    prometheusRule+: {
       spec+: {
         groups: std.map(
           function(group)
@@ -22,7 +22,7 @@ local filter = {
 };
 local update = {
   kubernetesControlPlane+: {
-    prometheusRule+:: {
+    prometheusRule+: {
       spec+: {
         groups: std.map(
           function(group)


### PR DESCRIPTION
The `prometheusRule+::` was overriding the visibility, causing no output.

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

`examples/changing-default-rules.libsonnet` uses `prometheusRule+::`, but this changes the visibility of the field used to actually expose the created `PrometheusRule` objects. See:

https://github.com/prometheus-operator/kube-prometheus/blob/3c832a104d6e71b268a3023373eebebf01a5f52e/jsonnet/kube-prometheus/components/k8s-control-plane.libsonnet#L52-L64

Using `prometheusRule+:` instead works as expected.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
- Correct `changing-default-rules.libsonnet` example's override of `kubernetesControlPlane.prometheusRule`'s visibility.
```
