### PR TITLE
Alertmanager: Select AlertmanagerConfig CRs within its own namespace by default

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -234,6 +234,7 @@ function(params) {
         fsGroup: 2000,
       },
       [if std.objectHas(params, 'storage') then 'storage']: am._config.storage,
+      alertmanagerConfigSelector: {},
     },
   },
 }

--- a/manifests/alertmanager-alertmanager.yaml
+++ b/manifests/alertmanager-alertmanager.yaml
@@ -10,6 +10,7 @@ metadata:
   name: main
   namespace: monitoring
 spec:
+  alertmanagerConfigSelector: {}
   image: quay.io/prometheus/alertmanager:v0.28.1
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This PR modifies the Alertmanager CR to automatically select AlertmanagerConfig CRs within its own namespace by default.

Currently, Alertmanager `spec.alertmanagerConfigSelector` is unspecified by default, which means no AlertmanagerConfigs are selected by default.

On the other hand, Prometheus `.spec.serviceMonitorSelector` is `{}` by default, meaning it automatically selects ServiceMonitor CRs within its own namespace by default.

Users are confused by this discrepancy in default configurations between Prometheus CRs and Alertmanager CRs.

## Type of change

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Alertmanager : Select AlertmanagerConfig CRs in its own namespace by default
```
