### PR TITLE
test: verify Kubernetes jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,6 +121,10 @@ jobs:
           kubectl create -f manifests/setup
           until kubectl get servicemonitors --all-namespaces ; do date; sleep 1; echo ""; done
           kubectl create -f manifests/
+      - name: Wait for kube-prometheus stack to finish bootstraping
+        run: kubectl wait --for=condition=Ready pods --all -n monitoring --timeout=300s
+      - name: Check resources in all namespaces
+        run: kubectl get services,endpoints,pods,prometheus,alertmanager --all-namespaces
       - name: Run tests
         run: |
           export KUBECONFIG="${HOME}/.kube/config"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,10 @@ jobs:
       - name: Install kube-router for NetworkPolicy support
         run: |
           kubectl apply -f tests/e2e/kind/kube-router.yaml
+      - name: Install kube-scheduler and kube-controller-manager services
+        run: |
+          kubectl apply -f tests/e2e/kind/kubernetesControlPlane-kubeControllerManagerPrometheusDiscoveryService.yaml && \
+          kubectl apply -f tests/e2e/kind/kubernetesControlPlane-kubeSchedulerPrometheusDiscoveryService.yaml
       - name: Wait for cluster to finish bootstraping
         run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
       - name: Create kube-prometheus stack

--- a/tests/e2e/kind/config.yml
+++ b/tests/e2e/kind/config.yml
@@ -10,6 +10,14 @@ nodes:
         containerPath: /patches
 kubeadmConfigPatches:
   - |
+    kind: ClusterConfiguration
+    controllerManager:
+      extraArgs:
+        bind-address: "0.0.0.0"
+    scheduler:
+      extraArgs:
+        bind-address: "0.0.0.0"
+  - |
     kind: InitConfiguration
     patches:
       directory: /patches

--- a/tests/e2e/kind/kubernetesControlPlane-kubeControllerManagerPrometheusDiscoveryService.yaml
+++ b/tests/e2e/kind/kubernetesControlPlane-kubeControllerManagerPrometheusDiscoveryService.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-controller-manager
+  name: kube-controller-manager-prometheus-discovery
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+  - name: https-metrics
+    port: 10257
+    targetPort: 10257
+  selector:
+    component: kube-controller-manager

--- a/tests/e2e/kind/kubernetesControlPlane-kubeSchedulerPrometheusDiscoveryService.yaml
+++ b/tests/e2e/kind/kubernetesControlPlane-kubeSchedulerPrometheusDiscoveryService.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: kube-scheduler
+  name: kube-scheduler-prometheus-discovery
+  namespace: kube-system
+spec:
+  clusterIP: None
+  ports:
+  - name: https-metrics
+    port: 10259
+    targetPort: 10259
+  selector:
+    component: kube-scheduler

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -66,7 +66,7 @@ func pollCondition(timeout time.Duration, conditionFunc func() error) error {
 
 	var conditionErr error
 	if err := wait.PollImmediateUntilWithContext(ctx, 5*time.Second, func(context.Context) (bool, error) {
-		conditionErr := conditionFunc()
+		conditionErr = conditionFunc()
 		return conditionErr == nil, nil
 	}); err != nil {
 		return fmt.Errorf("%w: %w", err, conditionErr)
@@ -96,6 +96,16 @@ func TestQueryPrometheus(t *testing.T) {
 			job:     "apiserver",
 			expectN: 1,
 		}, {
+			// There are 4 kubelet endpoints.
+			job:     "kubelet",
+			expectN: 4,
+		}, {
+			job:     "kube-scheduler",
+			expectN: 1,
+		}, {
+			job:     "kube-controller-manager",
+			expectN: 1,
+		}, {
 			job:     "kube-state-metrics",
 			expectN: 1,
 		}, {
@@ -115,10 +125,12 @@ func TestQueryPrometheus(t *testing.T) {
 				if err != nil {
 					return err
 				}
+
 				if n < tc.expectN {
 					// Don't return an error as targets may only become visible after a while.
 					return fmt.Errorf("expected at least %d results for job=%q but got %d", tc.expectN, tc.job, n)
 				}
+
 				return nil
 			})
 			if err != nil {


### PR DESCRIPTION

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This commit ensures that Prometheus scrapes metrics from kubelet, kube-scheduler and kube-controller-manager. For the last 2 components, we need to bind the servers on "0.0.0.0" and create the corresponding Kubernetes services.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
