### PR TITLE
fix(manifests): exclude 'config-reloader' container from 'Alertmanage…

### DIFF
--- a/jsonnet/kube-prometheus/components/alertmanager.libsonnet
+++ b/jsonnet/kube-prometheus/components/alertmanager.libsonnet
@@ -66,7 +66,7 @@ local defaults = {
     _config: {
       alertmanagerName: '{{ $labels.namespace }}/{{ $labels.pod}}',
       alertmanagerClusterLabels: 'namespace,service',
-      alertmanagerSelector: 'job="alertmanager-' + defaults.name + '",namespace="' + defaults.namespace + '"',
+      alertmanagerSelector: 'job="alertmanager-' + defaults.name + '",container="alertmanager"' + ',namespace="' + defaults.namespace + '"',
       runbookURLPattern: 'https://runbooks.prometheus-operator.dev/runbooks/alertmanager/%s',
     },
   },

--- a/manifests/alertmanager-prometheusRule.yaml
+++ b/manifests/alertmanager-prometheusRule.yaml
@@ -23,7 +23,7 @@ spec:
       expr: |
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-        max_over_time(alertmanager_config_last_reload_successful{job="alertmanager-main",namespace="monitoring"}[5m]) == 0
+        max_over_time(alertmanager_config_last_reload_successful{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[5m]) == 0
       for: 10m
       labels:
         severity: critical
@@ -35,9 +35,9 @@ spec:
       expr: |
         # Without max_over_time, failed scrapes could create false negatives, see
         # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-          max_over_time(alertmanager_cluster_members{job="alertmanager-main",namespace="monitoring"}[5m])
+          max_over_time(alertmanager_cluster_members{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[5m])
         < on (namespace,service) group_left
-          count by (namespace,service) (max_over_time(alertmanager_cluster_members{job="alertmanager-main",namespace="monitoring"}[5m]))
+          count by (namespace,service) (max_over_time(alertmanager_cluster_members{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[5m]))
       for: 15m
       labels:
         severity: critical
@@ -48,9 +48,9 @@ spec:
         summary: An Alertmanager instance failed to send notifications.
       expr: |
         (
-          rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="monitoring"}[15m])
+          rate(alertmanager_notifications_failed_total{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[15m])
         /
-          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring"}[15m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[15m])
         )
         > 0.01
       for: 5m
@@ -63,9 +63,9 @@ spec:
         summary: All Alertmanager instances in a cluster failed to send notifications to a critical integration.
       expr: |
         min by (namespace,service, integration) (
-          rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="monitoring", integration=~`.*`}[15m])
+          rate(alertmanager_notifications_failed_total{job="alertmanager-main",container="alertmanager",namespace="monitoring", integration=~`.*`}[15m])
         /
-          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring", integration=~`.*`}[15m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",container="alertmanager",namespace="monitoring", integration=~`.*`}[15m])
         )
         > 0.01
       for: 5m
@@ -78,9 +78,9 @@ spec:
         summary: All Alertmanager instances in a cluster failed to send notifications to a non-critical integration.
       expr: |
         min by (namespace,service, integration) (
-          rate(alertmanager_notifications_failed_total{job="alertmanager-main",namespace="monitoring", integration!~`.*`}[15m])
+          rate(alertmanager_notifications_failed_total{job="alertmanager-main",container="alertmanager",namespace="monitoring", integration!~`.*`}[15m])
         /
-          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",namespace="monitoring", integration!~`.*`}[15m])
+          ignoring (reason) group_left rate(alertmanager_notifications_total{job="alertmanager-main",container="alertmanager",namespace="monitoring", integration!~`.*`}[15m])
         )
         > 0.01
       for: 5m
@@ -93,7 +93,7 @@ spec:
         summary: Alertmanager instances within the same cluster have different configurations.
       expr: |
         count by (namespace,service) (
-          count_values by (namespace,service) ("config_hash", alertmanager_config_hash{job="alertmanager-main",namespace="monitoring"})
+          count_values by (namespace,service) ("config_hash", alertmanager_config_hash{job="alertmanager-main",container="alertmanager",namespace="monitoring"})
         )
         != 1
       for: 20m
@@ -107,11 +107,11 @@ spec:
       expr: |
         (
           count by (namespace,service) (
-            avg_over_time(up{job="alertmanager-main",namespace="monitoring"}[5m]) < 0.5
+            avg_over_time(up{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[5m]) < 0.5
           )
         /
           count by (namespace,service) (
-            up{job="alertmanager-main",namespace="monitoring"}
+            up{job="alertmanager-main",container="alertmanager",namespace="monitoring"}
           )
         )
         >= 0.5
@@ -126,11 +126,11 @@ spec:
       expr: |
         (
           count by (namespace,service) (
-            changes(process_start_time_seconds{job="alertmanager-main",namespace="monitoring"}[10m]) > 4
+            changes(process_start_time_seconds{job="alertmanager-main",container="alertmanager",namespace="monitoring"}[10m]) > 4
           )
         /
           count by (namespace,service) (
-            up{job="alertmanager-main",namespace="monitoring"}
+            up{job="alertmanager-main",container="alertmanager",namespace="monitoring"}
           )
         )
         >= 0.5


### PR DESCRIPTION
…rClusterDown' alert

## Description

When Prometheus is not able to scrape the config-reloader but able to scrape Alertmanager itself, the alert would trigger a critical.

<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
exclude 'config-reloader' container from 'AlertmanagerClusterDown' alert
```
