### PR TITLE
chore: remove deprecated options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [CHANGE] Remove `alertmanagerName` and `thanosSelector` configuration options from `prometheus.libsonnet`. [#2755](https://github.com/prometheus-operator/kube-prometheus/pull/2755)
+
 ## release-0.16 / 2025-08-28
 
 * [ENHANCEMENT] Add common labels to blackbox-exporter ClusterRole. [#2667](https://github.com/prometheus-operator/kube-prometheus/pull/2667)


### PR DESCRIPTION
## Description

This commit removes configuration options which have been deprecated long time ago.


## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [x] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note

```
