### PR TITLE
fix(ci): ignore stackoverlow links in mdox validation

### DIFF
--- a/.mdox.validate.yaml
+++ b/.mdox.validate.yaml
@@ -17,3 +17,6 @@ validators:
   # Ignoring for now but we need remove the related content if it persists.
   - regex: 'https:\/\/www.weave.works.*'
     type: "ignore"
+  # StackOverflow returns 403 for automated requests.
+  - regex: 'https:\/\/stackoverflow.com.*'
+    type: "ignore"


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

This commit addresses the issue where StackOverflow blocks automated requests with 403 Forbidden responses to prevent scraping, causing mdox link validator to fail.

Added a regex pattern to ignore stackoverflow links in the mdox validation config.

Ref: https://github.com/prometheus-operator/kube-prometheus/actions/runs/19064248789/job/54450840605

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [x] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
Fix `make check-docs` command failing due to StackOverflow blocking automated link validation requests.
```
