### PR TITLE
Fix pyyaml unable to parse "- =" in AlertmanagerConfig CRD

### DIFF
--- a/manifests/setup/0alertmanagerConfigCustomResourceDefinition.yaml
+++ b/manifests/setup/0alertmanagerConfigCustomResourceDefinition.yaml
@@ -77,7 +77,7 @@ spec:
                               Valid values: "=" (equality), "!=" (inequality), "=~" (regex match), "!~" (regex non-match).
                             enum:
                             - '!='
-                            - =
+                            - '='
                             - =~
                             - '!~'
                             type: string
@@ -116,7 +116,7 @@ spec:
                               Valid values: "=" (equality), "!=" (inequality), "=~" (regex match), "!~" (regex non-match).
                             enum:
                             - '!='
-                            - =
+                            - '='
                             - =~
                             - '!~'
                             type: string
@@ -10930,7 +10930,7 @@ spec:
                             Valid values: "=" (equality), "!=" (inequality), "=~" (regex match), "!~" (regex non-match).
                           enum:
                           - '!='
-                          - =
+                          - '='
                           - =~
                           - '!~'
                           type: string


### PR DESCRIPTION
Fix pyyaml unable to parse "- =" in AlertmanagerConfig CRD

## Description

I am using ansible to load and transform the kube-prometheus manifests. Ansible uses pyyaml to parse YAML structures with the from_yaml ansible filter. I am able to parse all the kube-prometheus manifests that I need, except for 0alertmanagerConfigCustomResourceDefinition.yaml. Parsing that file results in an error in every place the equal sign character (=) appears alone in a list (thus "- ="). You can see more details here:

https://github.com/ansible/ansible/issues/86333#issuecomment-3656242442

The ansible developers brought to my attention this page: https://yaml.org/type/value.html
which seem to indicate that the '=' character is special to YAML. This prompted me to create this pull request. By enclosing the equality char in quotes we make it 100% certain that this is in fact just a simple string.

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

Fix pyyaml unable to parse "- =" in AlertmanagerConfig CRD

