### PR TITLE
alerts: fix duplicate series in InfoInhibitor alert

### DIFF
--- a/jsonnet/kube-prometheus/components/mixin/alerts/general.libsonnet
+++ b/jsonnet/kube-prometheus/components/mixin/alerts/general.libsonnet
@@ -46,7 +46,7 @@
                 This alert should be routed to a null receiver and configured to inhibit alerts with severity="info".
               |||,
             },
-            expr: 'count by (namespace) (ALERTS{severity = "info"} == 1) > 0 unless on (namespace) count by (namespace) (ALERTS{alertname != "InfoInhibitor", alertstate = "firing", severity =~ "warning|critical"} == 1) > 0',
+            expr: 'group by (namespace) (ALERTS{severity = "info"} == 1) unless on (namespace) group by (namespace) (ALERTS{alertname != "InfoInhibitor", alertstate = "firing", severity =~ "warning|critical"} == 1)',
             labels: {
               severity: 'none',
             },

--- a/manifests/kubePrometheus-prometheusRule.yaml
+++ b/manifests/kubePrometheus-prometheusRule.yaml
@@ -46,7 +46,7 @@ spec:
           This alert should be routed to a null receiver and configured to inhibit alerts with severity="info".
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/general/infoinhibitor
         summary: Info-level alert inhibition.
-      expr: count by (namespace) (ALERTS{severity = "info"} == 1) > 0 unless on (namespace) count by (namespace) (ALERTS{alertname != "InfoInhibitor", alertstate = "firing", severity =~ "warning|critical"} == 1) > 0
+      expr: group by (namespace) (ALERTS{severity = "info"} == 1) unless on (namespace) group by (namespace) (ALERTS{alertname != "InfoInhibitor", alertstate = "firing", severity =~ "warning|critical"} == 1)
       labels:
         severity: none
   - name: node-network


### PR DESCRIPTION
## Description

Fix the InfoInhibitor alert failing to evaluate with a "duplicate series" error in Prometheus.

When multiple info-level alerts fire in the same namespace, the current expression can produce multiple series with the same labelset after the `unless on(namespace)` operation, causing Prometheus to fail evaluation.

The fix uses `count by (namespace)` to aggregate alerts, ensuring each side of the `unless` operator produces exactly one series per namespace.

Fixes #2751

Related: prometheus-community/helm-charts#5873

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Fix InfoInhibitor alert failing with duplicate series error when multiple info-level alerts fire in the same namespace.
```