### PR TITLE
prometheus-adapter: fix Windows compatibility in ClusterRoleBinding name

### DIFF
--- a/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
+++ b/jsonnet/kube-prometheus/components/prometheus-adapter.libsonnet
@@ -361,7 +361,7 @@ function(params) {
     apiVersion: 'rbac.authorization.k8s.io/v1',
     kind: 'ClusterRoleBinding',
     metadata: pa._metadata_no_ns {
-      name: 'resource-metrics:system:auth-delegator',
+      name: 'resource-metrics-system-auth-delegator',
     },
     roleRef: {
       apiGroup: 'rbac.authorization.k8s.io',

--- a/manifests/prometheusAdapter-clusterRoleBindingDelegator.yaml
+++ b/manifests/prometheusAdapter-clusterRoleBindingDelegator.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: kube-prometheus
     app.kubernetes.io/version: 0.12.0
-  name: resource-metrics:system:auth-delegator
+  name: resource-metrics-system-auth-delegator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Fixes: #2750 

## Description

Rename ClusterRoleBinding from `resource-metrics:system:auth-delegator` to `resource-metrics-system-auth-delegator` as colons are invalid filename characters on Windows, causing `kubectl diff -k` to fail.

## Type of change

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

```release-note
Fix Windows compatibility by renaming prometheus-adapter ClusterRoleBinding to use hyphens instead of colons.
```