### PR TITLE
fix(monitoring-alerting): use max by() in KubeQuota rules to avoid many-to-many errors

### DIFF
--- a/manifests/kubernetesControlPlane-prometheusRule.yaml
+++ b/manifests/kubernetesControlPlane-prometheusRule.yaml
@@ -383,12 +383,12 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotaalmostfull
         summary: Namespace quota is going to be full.
       expr: |
-        max without (instance, job, type) (
+        max by (cluster, namespace, resource, resourcequota) (
           kube_resourcequota{job="kube-state-metrics", type="used"}
         )
         / on (cluster, namespace, resource, resourcequota) group_left()
         (
-          max without (instance, job, type) (
+          max by (cluster, namespace, resource, resourcequota) (
             kube_resourcequota{job="kube-state-metrics", type="hard"}
           ) > 0
         )
@@ -402,12 +402,12 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotafullyused
         summary: Namespace quota is fully used.
       expr: |
-        max without (instance, job, type) (
+        max by (cluster, namespace, resource, resourcequota) (
           kube_resourcequota{job="kube-state-metrics", type="used"}
         )
         / on (cluster, namespace, resource, resourcequota) group_left()
         (
-          max without (instance, job, type) (
+          max by (cluster, namespace, resource, resourcequota) (
             kube_resourcequota{job="kube-state-metrics", type="hard"}
           ) > 0
         )
@@ -421,12 +421,12 @@ spec:
         runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotaexceeded
         summary: Namespace quota has exceeded the limits.
       expr: |
-        max without (instance, job, type) (
+        max by (cluster, namespace, resource, resourcequota) (
           kube_resourcequota{job="kube-state-metrics", type="used"}
         )
         / on (cluster, namespace, resource, resourcequota) group_left()
         (
-          max without (instance, job, type) (
+          max by (cluster, namespace, resource, resourcequota) (
             kube_resourcequota{job="kube-state-metrics", type="hard"}
           ) > 0
         ) > 1


### PR DESCRIPTION



<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

During kube-state-metrics rolling restarts (e.g. node reboots), two pods temporarily scrape the same metrics. The upstream rules use max without(instance, job, type) which preserves pod/container/endpoint/service labels — these differ between the two pods, producing duplicate series on the join's right-hand side. Prometheus then rejects the query with "many-to-many matching not allowed".

## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [ ] `FEATURE` (non-breaking change which adds functionality)
- [x] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
use max by() in KubeQuota rules to avoid many-to-many errors
```
