### PR TITLE
Fix manifests generation for GH actions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,5 +19,4 @@ jsonnet -J vendor -m manifests "${1-example.jsonnet}" | xargs -I{} sh -c 'cat {}
 
 # Make sure to remove json files
 find manifests -type f ! -name '*.yaml' -delete
-rm -f kustomization
-
+mv manifests/kustomization.yaml .

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -105,8 +105,7 @@ jsonnet -J vendor -m manifests "${1-example.jsonnet}" | xargs -I{} sh -c 'cat {}
 
 # Make sure to remove json files
 find manifests -type f ! -name '*.yaml' -delete
-rm -f kustomization
-
+mv manifests/kustomization.yaml .
 ```
 
 > Note you need `jsonnet` (`go install github.com/google/go-jsonnet/cmd/jsonnet@latest`) and `gojsontoyaml` (`go install github.com/brancz/gojsontoyaml@latest`) installed to run `build.sh`. If you just want json output, not yaml, then you can skip the pipe and everything afterwards.

--- a/examples/kustomize.jsonnet
+++ b/examples/kustomize.jsonnet
@@ -33,5 +33,5 @@ local kustomization = {
 };
 
 manifests {
-  '../kustomization': kustomization,
+  kustomization: kustomization,
 }


### PR DESCRIPTION
When running inside GitHub actions, the script fails with `openat ../kustomization: path escapes from parent`. It looks like the container runtime is hardened to prevent path traversal attacks. The simplest solution is to avoid using a relative path.

