### PR TITLE
Improve Kubernetes alert rules to reduce alert fatigue

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,13 @@ If you have any questions or feedback regarding kube-prometheus, join the [kube-
 ## License
 
 Apache License 2.0, see [LICENSE](https://github.com/prometheus-operator/kube-prometheus/blob/main/LICENSE).
+
+## Custom Alert Improvements
+
+Added custom Prometheus alert rules to reduce noisy Kubernetes alerts and improve observability.
+
+### Features
+- Excludes system namespaces from crash loop alerts
+- Detects high CPU usage
+- Reduces alert fatigue
+- Adds improved alert annotations

--- a/manifests/setup/custom-alerts.yaml
+++ b/manifests/setup/custom-alerts.yaml
@@ -1,0 +1,29 @@
+groups:
+- name: custom-kubernetes-alerts
+  rules:
+
+  - alert: CriticalPodCrashLooping
+    expr: |
+      max_over_time(
+        kube_pod_container_status_waiting_reason{
+          reason="CrashLoopBackOff",
+          namespace!~"kube-system|monitoring|default"
+        }[5m]
+      ) >= 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: Pod crash looping detected
+      description: Pod {{ $labels.pod }} in namespace {{ $labels.namespace }} is repeatedly crashing.
+
+  - alert: HighCPUUsage
+    expr: |
+      sum(rate(container_cpu_usage_seconds_total[5m])) by (pod)
+      > 0.8
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      summary: High CPU usage detected
+      description: Pod {{ $labels.pod }} has high CPU usage.


### PR DESCRIPTION
## Summary

This PR adds custom Prometheus alert rules to improve Kubernetes observability and reduce alert fatigue.

## Changes
- Added CrashLoopBackOff alert improvements
- Excluded system namespaces from alerts
- Added high CPU usage alert
- Improved alert annotations for readability

## Motivation
Default alert rules can generate noisy alerts from system namespaces and temporary deployment events. These changes help improve signal-to-noise ratio for operational monitoring.