### PR TITLE
feat: Add Perses addon as Grafana alternative for Kubernetes dashboards

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,3 +1,4 @@
 kind-version=v0.33.0
 kind-image-metrics-server=kindest/node:v1.37.0
+kind-image-perses=kindest/node:v1.37.0
 golang-version=1.26

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,14 +118,14 @@ jobs:
         run: |
           kubectl apply -f tests/e2e/kind/kubernetesControlPlane-kubeControllerManagerPrometheusDiscoveryService.yaml && \
           kubectl apply -f tests/e2e/kind/kubernetesControlPlane-kubeSchedulerPrometheusDiscoveryService.yaml
-      - name: Wait for cluster to finish bootstraping
+      - name: Wait for cluster to finish bootstrapping
         run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
       - name: Create kube-prometheus stack
         run: |
           kubectl create -f manifests/setup
           until kubectl get servicemonitors --all-namespaces ; do date; sleep 1; echo ""; done
           kubectl create -f manifests/
-      - name: Wait for kube-prometheus stack to finish bootstraping
+      - name: Wait for kube-prometheus stack to finish bootstrapping
         run: kubectl wait --for=condition=Ready pods --all -n monitoring --timeout=300s
       - name: Check resources in all namespaces
         if: always()
@@ -160,7 +160,7 @@ jobs:
           wait: 300s
           config: tests/e2e/kind/config.yml
           cluster_name: e2e
-      - name: Wait for cluster to finish bootstraping
+      - name: Wait for cluster to finish bootstrapping
         run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
       - name: Create kube-prometheus stack with metrics-server
         run: |
@@ -170,7 +170,7 @@ jobs:
           # Scale to 1 replica since the CI kind cluster is single-node and metrics-server
           # defaults to 2 replicas with hard pod anti-affinity.
           kubectl scale deployment metrics-server -n monitoring --replicas=1
-      - name: Wait for kube-prometheus stack to finish bootstraping
+      - name: Wait for kube-prometheus stack to finish bootstrapping
         run: kubectl wait --for=condition=Ready pods --all -n monitoring --timeout=300s
       - name: Check resources in all namespaces
         if: always()
@@ -189,6 +189,58 @@ jobs:
           export KUBECONFIG="${HOME}/.kube/config"
           make test-e2e-metrics-server
 
+  e2e-tests-perses:
+    name: E2E tests (perses)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Import environment variables from file
+        run: cat ".github/env" >> "$GITHUB_ENV"
+      - uses: actions/setup-go@v7
+        with:
+          go-version: ${{ env.golang-version }}
+      - name: Build perses manifests
+        run: make manifests-perses
+      - name: Start kind cluster
+        uses: helm/kind-action@v1.15.0
+        with:
+          version: ${{ env.kind-version }}
+          node_image: ${{ env.kind-image-perses }}
+          wait: 10s
+          config: tests/e2e/kind/config.yml
+          cluster_name: e2e
+      - name: Install kube-router for NetworkPolicy support
+        run: |
+          kubectl apply -f tests/e2e/kind/kube-router.yaml
+      - name: Wait for cluster to finish bootstrapping
+        run: kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=300s
+      - name: Create kube-prometheus stack with perses
+        run: |
+          kubectl create -f manifests/setup
+          kubectl wait --for condition=Established --all CustomResourceDefinition --timeout=300s
+          until kubectl get servicemonitors --all-namespaces ; do date; sleep 1; echo ""; done
+          kubectl create -f manifests/
+      - name: Wait for kube-prometheus stack to finish bootstrapping
+        run: kubectl wait --for=condition=Ready pods --all -n monitoring --timeout=300s
+      - name: Check resources in all namespaces
+        if: always()
+        run: |
+          kubectl get nodes -o wide
+          kubectl get services,endpoints,pods,prometheus,alertmanager,perses,persesdashboards.perses.dev --all-namespaces
+      - name: Describe non-ready pods
+        if: ${{ failure() }}
+        run: |
+          kubectl get pods -n monitoring --field-selector=status.phase!=Running -o name | xargs -r kubectl describe -n monitoring
+      - name: Check events in all namespaces
+        if: ${{ failure() }}
+        run: kubectl get events --all-namespaces --sort-by='.lastTimestamp'
+      - name: Run perses e2e tests
+        run: |
+          export KUBECONFIG="${HOME}/.kube/config"
+          make test-e2e-perses
+
   # Added to summarize the matrix and allow easy branch protection rules setup
   e2e-tests-result:
     name: End-to-End Test Results
@@ -196,11 +248,12 @@ jobs:
     needs:
       - e2e-tests
       - e2e-tests-metrics-server
+      - e2e-tests-perses
     runs-on: ubuntu-latest
     steps:
       - name: Mark the job as a success
-        if: needs.e2e-tests.result == 'success' && needs.e2e-tests-metrics-server.result == 'success'
+        if: needs.e2e-tests.result == 'success' && needs.e2e-tests-metrics-server.result == 'success' && needs.e2e-tests-perses.result == 'success'
         run: exit 0
       - name: Mark the job as a failure
-        if: needs.e2e-tests.result != 'success' || needs.e2e-tests-metrics-server.result != 'success'
+        if: needs.e2e-tests.result != 'success' || needs.e2e-tests-metrics-server.result != 'success' || needs.e2e-tests-perses.result != 'success'
         run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,12 @@ vendor/
 crdschemas/
 .mdoxcache
 
+# Generated locally by make manifests-metrics-server
+manifests/metrics-server-*
+
+# Generated locally by make manifests-perses
+manifests/perses-*
+manifests/setup/0perses*
+
 developer-workspace/gitpod/_output
 developer-workspace/codespaces/kind 

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,10 @@ test-e2e: ## Run end-to-end tests
 test-e2e-metrics-server: ## Run metrics-server end-to-end tests
 	RESOURCE_METRICS_API=metrics-server go test -mod=mod -timeout 55m -v ./tests/e2e -count=1 -run TestMetricsServerDeployment
 
+.PHONY: test-e2e-perses
+test-e2e-perses: ## Run perses addon end-to-end tests
+	PERSES_ADDON=true go test -mod=mod -timeout 55m -v ./tests/e2e -count=1 -run TestPersesAddon
+
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,9 @@ manifests: examples/kustomize.jsonnet $(GOJSONTOYAML_BIN) vendor ## Build manife
 manifests-metrics-server: examples/metrics-server.jsonnet $(GOJSONTOYAML_BIN) vendor ## Build manifests from examples/metrics-server.jsonnet
 	./build.sh $<
 
+manifests-perses: examples/perses.jsonnet $(GOJSONTOYAML_BIN) vendor ## Build manifests from examples/perses.jsonnet
+	./build.sh $<
+
 vendor: $(JB_BIN) jsonnetfile.json jsonnetfile.lock.json ## Install jsonnet dependencies
 	rm -rf vendor
 	$(JB_BIN) install

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Components included in this package:
 * [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)
 * [Grafana](https://grafana.com/)
 
+Optional addon:
+
+* [Perses](https://perses.dev/) — CNCF Sandbox alternative to Grafana (see [Using Perses instead of Grafana](docs/customizations/perses.md))
+
 This stack is meant for cluster monitoring, so it is pre-configured to collect metrics from all Kubernetes components. In addition to that it delivers a default set of dashboards and alerting rules. Many of the useful dashboards and alerts come from the [kubernetes-mixin project](https://github.com/kubernetes-monitoring/kubernetes-mixin), similar to this project it provides composable jsonnet as a library for users to customize to their needs.
 
 ## Prerequisites

--- a/docs/access-ui.md
+++ b/docs/access-ui.md
@@ -37,6 +37,16 @@ kubectl --namespace monitoring port-forward svc/grafana 3000
 Open Grafana on [localhost:3000](https://localhost:3000) in your browser.
 You can login with the username `admin` and password `admin`.
 
+## Perses (alternative to Grafana)
+
+If you have enabled the [Perses addon](customizations/perses.md) instead of Grafana:
+
+```shell
+kubectl --namespace monitoring port-forward svc/perses 8080
+```
+
+Open Perses on [localhost:8080](http://localhost:8080) in your browser. The bundled [community-mixins](https://github.com/perses/community-mixins) dashboards for the default kube-prometheus stack are loaded from `PersesDashboard` CRs, and a Prometheus datasource is auto-configured. See [dashboard coverage](customizations/perses.md#dashboard-coverage) for details.
+
 ## Alertmanager
 
 ```shell

--- a/docs/customizations/perses.md
+++ b/docs/customizations/perses.md
@@ -12,22 +12,22 @@ description: Replace Grafana with Perses for Kubernetes cluster dashboards using
 ---
 
 > [!NOTE]
-> Perses is currently integrated as an addon. Once dashboard parity with the Grafana dashboards shipped by kube-prometheus is fully validated, it will be promoted to a built-in toggle (similar to the `metrics-server` / `prometheus-adapter` switch).
+> Perses is currently integrated as an addon. Once the integration is mature, it may be promoted to a built-in toggle (similar to the `metrics-server` / `prometheus-adapter` switch).
 
-[Perses](https://perses.dev) is a CNCF Sandbox observability visualization platform. The `perses` addon replaces Grafana with Perses and deploys the same Kubernetes observability dashboards via the [perses-operator](https://github.com/perses/perses-operator) and [community-mixins](https://github.com/perses/community-mixins).
+[Perses](https://perses.dev) is a CNCF Sandbox observability visualization platform. The `perses` addon replaces Grafana with Perses and deploys Kubernetes observability dashboards from [community-mixins](https://github.com/perses/community-mixins) via the [perses-operator](https://github.com/perses/perses-operator).
 
 ## What the addon deploys
 
 | Resource | Kind | Description |
-|----------|------|-------------|
+| ---------- | ------ | ------------- |
 | perses-operator | Deployment, RBAC, ServiceAccount | Manages Perses CRs declaratively |
 | 4 CRDs | CustomResourceDefinition | `Perses`, `PersesDashboard`, `PersesDatasource`, `PersesGlobalDatasource` |
 | Perses instance | `Perses` CR | Runs the Perses server (port 8080) |
 | Prometheus datasource | `PersesGlobalDatasource` CR | Proxies queries to `prometheus-k8s` Service |
-| 18 dashboards | `PersesDashboard` CRs | API Server, Kubelet, Compute Resources, Networking, etc. |
+| Kubernetes dashboards | `PersesDashboard` CRs | Imported from community-mixins (see [Dashboard coverage](#dashboard-coverage)) |
 | ServiceMonitor | `ServiceMonitor` | Scrapes operator metrics |
 | PrometheusRule | `PrometheusRule` | Operator alerting rules |
-| NetworkPolicy patch | `NetworkPolicy` | Allows Perses to query Prometheus |
+| Prometheus NetworkPolicy | `NetworkPolicy` | Allows Perses pods to query Prometheus |
 
 ## Switching from Grafana to Perses
 
@@ -37,7 +37,7 @@ Generate manifests with Perses instead of Grafana:
 make manifests-perses
 ```
 
-This uses [`examples/perses.jsonnet`](../../examples/perses.jsonnet), which imports the Perses addon and disables Grafana automatically. Apply the generated manifests:
+This uses [`examples/perses.jsonnet`](../../examples/perses.jsonnet), which imports the Perses addon and sets `grafana: {}` to omit Grafana. Apply the generated manifests:
 
 ```shell
 # Apply CRDs and namespace first
@@ -57,7 +57,7 @@ kubectl apply -f manifests/
 kubectl --namespace monitoring port-forward svc/perses 8080
 ```
 
-Open Perses at [http://localhost:8080](http://localhost:8080). All 18 Kubernetes dashboards are pre-loaded via `PersesDashboard` CRs and the Prometheus datasource is auto-configured.
+Open Perses at [http://localhost:8080](http://localhost:8080). The operator creates a Service named after the `Perses` CR (`perses` by default). Dashboards and the Prometheus datasource are loaded from CRs.
 
 ### Using a custom jsonnet file
 
@@ -135,9 +135,36 @@ kubectl -n monitoring delete --ignore-not-found=true \
 }
 ```
 
+### Dashboard query selectors
+
+The Perses addon imports pre-generated dashboards from [community-mixins](https://github.com/perses/community-mixins), which use kubernetes-mixin default job labels. kube-prometheus overrides those selectors for Grafana via `kubernetesControlPlane`; the addon applies the same rewiring when importing dashboards:
+
+| community-mixins | kube-prometheus |
+|------------------|-----------------|
+| `job="cadvisor"` | `job="kubelet", metrics_path="/metrics/cadvisor"` |
+| `job="kube-apiserver"` | `job="apiserver"` |
+
+The addon also sets `prometheus.externalLabels.cluster` to `kube-prometheus` so the `cluster` dashboard variable resolves (required by kubernetes-mixin dashboards). Override either if your scrape labels differ:
+
+```jsonnet
+{
+  values+:: {
+    prometheus+: {
+      externalLabels+: {
+        cluster: 'my-cluster',
+      },
+    },
+    perses+: {
+      cadvisorJobSelector: 'job="kubelet", metrics_path="/metrics/cadvisor"',
+      kubeApiserverJobSelector: 'job="apiserver"',
+    },
+  },
+}
+```
+
 ### Change the Prometheus datasource URL
 
-By default the datasource proxies queries through the Perses server to `http://prometheus-k8s.<namespace>.svc.cluster.local:9090`. If your Prometheus Service has a different name:
+By default the datasource proxies queries through the Perses server to `http://prometheus-k8s.<namespace>.svc.cluster.local:9090` (see [`perses.libsonnet`](../../jsonnet/kube-prometheus/addons/perses.libsonnet)). Patch the generated component to use a different URL:
 
 ```jsonnet
 local kp =
@@ -204,28 +231,9 @@ local kp =
 
 ## Dashboard coverage
 
-The addon deploys the following dashboards from [perses/community-mixins](https://github.com/perses/community-mixins), which have functional parity with the Grafana dashboards shipped by kube-prometheus (kubernetes-mixin):
+Dashboards are imported from [community-mixins](https://github.com/perses/community-mixins) and rendered as `PersesDashboard` CRs. The authoritative list is in [`perses.libsonnet`](../../jsonnet/kube-prometheus/addons/perses.libsonnet); run `make manifests-perses` to regenerate manifests after addon or mixin updates.
 
-| Dashboard | Grafana equivalent |
-|-----------|-------------------|
-| API Server Overview | Kubernetes / API server |
-| Controller Manager Overview | Kubernetes / Controller Manager |
-| Kubelet Overview | Kubernetes / Kubelet |
-| Cluster Resources Overview | Kubernetes / Compute Resources / Cluster |
-| Node Resources Overview | Kubernetes / Compute Resources / Node |
-| Namespace Resources Overview | Kubernetes / Compute Resources / Namespace |
-| Pod Resources Overview | Kubernetes / Compute Resources / Pod |
-| Workload Resources Overview | Kubernetes / Compute Resources / Workload |
-| Multi-Cluster Resources Overview | Kubernetes / Compute Resources / Multi-Cluster |
-| Cluster Networking Overview | Kubernetes / Networking / Cluster |
-| Namespace Networking Overview | Kubernetes / Networking / Namespace |
-| Pod Networking Overview | Kubernetes / Networking / Pod |
-| Workload Networking Overview | Kubernetes / Networking / Workload |
-| Workload NS Networking Overview | Kubernetes / Networking / Workload (NS) |
-| Workload NS Resources Overview | Kubernetes / Compute Resources / Workload (NS) |
-| Persistent Volume Overview | Kubernetes / Persistent Volumes |
-| Proxy Overview | Kubernetes / Proxy |
-| Scheduler Overview | Kubernetes / Scheduler |
+For upstream dashboard definitions and changes, see [community-mixins/kubernetes dashboards](https://github.com/perses/community-mixins/tree/main/jsonnet/dashboards/operator/kubernetes).
 
 ## References
 

--- a/docs/customizations/perses.md
+++ b/docs/customizations/perses.md
@@ -1,0 +1,234 @@
+---
+weight: 320
+toc: true
+title: Using Perses instead of Grafana
+menu:
+    docs:
+        parent: kube
+lead: Replace Grafana with Perses for Kubernetes cluster dashboards
+images: []
+draft: false
+description: Replace Grafana with Perses for Kubernetes cluster dashboards using the Perses addon
+---
+
+> [!NOTE]
+> Perses is currently integrated as an addon. Once dashboard parity with the Grafana dashboards shipped by kube-prometheus is fully validated, it will be promoted to a built-in toggle (similar to the `metrics-server` / `prometheus-adapter` switch).
+
+[Perses](https://perses.dev) is a CNCF Sandbox observability visualization platform. The `perses` addon replaces Grafana with Perses and deploys the same Kubernetes observability dashboards via the [perses-operator](https://github.com/perses/perses-operator) and [community-mixins](https://github.com/perses/community-mixins).
+
+## What the addon deploys
+
+| Resource | Kind | Description |
+|----------|------|-------------|
+| perses-operator | Deployment, RBAC, ServiceAccount | Manages Perses CRs declaratively |
+| 4 CRDs | CustomResourceDefinition | `Perses`, `PersesDashboard`, `PersesDatasource`, `PersesGlobalDatasource` |
+| Perses instance | `Perses` CR | Runs the Perses server (port 8080) |
+| Prometheus datasource | `PersesGlobalDatasource` CR | Proxies queries to `prometheus-k8s` Service |
+| 18 dashboards | `PersesDashboard` CRs | API Server, Kubelet, Compute Resources, Networking, etc. |
+| ServiceMonitor | `ServiceMonitor` | Scrapes operator metrics |
+| PrometheusRule | `PrometheusRule` | Operator alerting rules |
+| NetworkPolicy patch | `NetworkPolicy` | Allows Perses to query Prometheus |
+
+## Switching from Grafana to Perses
+
+Generate manifests with Perses instead of Grafana:
+
+```shell
+make manifests-perses
+```
+
+This uses [`examples/perses.jsonnet`](../../examples/perses.jsonnet), which imports the Perses addon and disables Grafana automatically. Apply the generated manifests:
+
+```shell
+# Apply CRDs and namespace first
+kubectl apply --server-side -f manifests/setup
+kubectl wait \
+    --for condition=Established \
+    --all CustomResourceDefinition \
+    --namespace=monitoring
+
+# Apply the remaining manifests
+kubectl apply -f manifests/
+```
+
+### Access the Perses UI
+
+```shell
+kubectl --namespace monitoring port-forward svc/perses 8080
+```
+
+Open Perses at [http://localhost:8080](http://localhost:8080). All 18 Kubernetes dashboards are pre-loaded via `PersesDashboard` CRs and the Prometheus datasource is auto-configured.
+
+### Using a custom jsonnet file
+
+If you need to customize values beyond the defaults, create your own jsonnet file that imports the Perses addon. See [`examples/perses.jsonnet`](../../examples/perses.jsonnet) for reference:
+
+```jsonnet
+local kp =
+  (import 'kube-prometheus/main.libsonnet') +
+  (import 'kube-prometheus/addons/perses.libsonnet') +
+  {
+    values+:: {
+      common+: {
+        namespace: 'monitoring',
+      },
+    },
+    // Disable Grafana when using Perses.
+    grafana: {},
+  };
+```
+
+Then generate manifests with:
+
+```shell
+./build.sh my-perses.jsonnet
+```
+
+## Switching back to Grafana
+
+To revert to Grafana, regenerate manifests using the default target and reapply:
+
+```shell
+# Rebuild with Grafana (default)
+make manifests
+kubectl apply --server-side -f manifests/setup
+kubectl wait --for condition=Established --all CustomResourceDefinition --namespace=monitoring
+kubectl apply -f manifests/
+
+# Remove Perses-specific resources no longer in manifests
+kubectl -n monitoring delete --ignore-not-found=true \
+  perses perses \
+  persesglobaldatasources.perses.dev prometheus-datasource \
+  persesdashboards.perses.dev --all \
+  deployment perses-operator
+```
+
+## Customization
+
+### Override versions
+
+```jsonnet
+{
+  values+:: {
+    common+: {
+      versions+: {
+        perses: '0.54.0',
+        persesOperator: '0.5.0',
+      },
+    },
+  },
+}
+```
+
+### Override images (e.g. internal registry)
+
+```jsonnet
+{
+  values+:: {
+    common+: {
+      images+: {
+        perses: 'my-registry.example.com/perses:v0.54.0',
+        persesOperator: 'my-registry.example.com/perses-operator:v0.5.0',
+      },
+    },
+  },
+}
+```
+
+### Change the Prometheus datasource URL
+
+By default the datasource proxies queries through the Perses server to `http://prometheus-k8s.<namespace>.svc.cluster.local:9090`. If your Prometheus Service has a different name:
+
+```jsonnet
+local kp =
+  (import 'kube-prometheus/main.libsonnet') +
+  (import 'kube-prometheus/addons/perses.libsonnet') +
+  {
+    values+:: {
+      common+: { namespace: 'monitoring' },
+    },
+    perses+: {
+      prometheusGlobalDatasource+: {
+        spec+: {
+          config+: {
+            plugin+: {
+              spec+: {
+                proxy+: {
+                  spec+: {
+                    url: 'http://my-prometheus.monitoring.svc.cluster.local:9090',
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+```
+
+### Enable conversion webhooks
+
+By default, the operator's CRD conversion webhooks are disabled because they require [cert-manager](https://cert-manager.io/) to provision TLS certificates. If you need to serve both `v1alpha1` and `v1alpha2` API versions simultaneously (e.g., during a CRD version migration), you can enable them.
+
+**Prerequisites:**
+
+1. Install cert-manager:
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
+```
+
+2. Wait for cert-manager to be ready:
+
+```bash
+kubectl wait --for=condition=Available deployment --all -n cert-manager --timeout=120s
+```
+
+See the [cert-manager installation docs](https://cert-manager.io/docs/installation/) for alternative install methods (Helm, operator, etc.).
+
+**Enable webhooks in your Jsonnet:**
+
+```jsonnet
+local kp =
+  (import 'kube-prometheus/main.libsonnet') +
+  (import 'kube-prometheus/addons/perses.libsonnet') +
+  {
+    values+:: {
+      common+: { namespace: 'monitoring' },
+      perses+: { enableWebhooks: true },
+    },
+    grafana: {},
+  };
+```
+
+## Dashboard coverage
+
+The addon deploys the following dashboards from [perses/community-mixins](https://github.com/perses/community-mixins), which have functional parity with the Grafana dashboards shipped by kube-prometheus (kubernetes-mixin):
+
+| Dashboard | Grafana equivalent |
+|-----------|-------------------|
+| API Server Overview | Kubernetes / API server |
+| Controller Manager Overview | Kubernetes / Controller Manager |
+| Kubelet Overview | Kubernetes / Kubelet |
+| Cluster Resources Overview | Kubernetes / Compute Resources / Cluster |
+| Node Resources Overview | Kubernetes / Compute Resources / Node |
+| Namespace Resources Overview | Kubernetes / Compute Resources / Namespace |
+| Pod Resources Overview | Kubernetes / Compute Resources / Pod |
+| Workload Resources Overview | Kubernetes / Compute Resources / Workload |
+| Multi-Cluster Resources Overview | Kubernetes / Compute Resources / Multi-Cluster |
+| Cluster Networking Overview | Kubernetes / Networking / Cluster |
+| Namespace Networking Overview | Kubernetes / Networking / Namespace |
+| Pod Networking Overview | Kubernetes / Networking / Pod |
+| Workload Networking Overview | Kubernetes / Networking / Workload |
+| Workload NS Networking Overview | Kubernetes / Networking / Workload (NS) |
+| Workload NS Resources Overview | Kubernetes / Compute Resources / Workload (NS) |
+| Persistent Volume Overview | Kubernetes / Persistent Volumes |
+| Proxy Overview | Kubernetes / Proxy |
+| Scheduler Overview | Kubernetes / Scheduler |
+
+## References
+
+- [Perses project](https://perses.dev)
+- [perses-operator](https://github.com/perses/perses-operator)
+- [community-mixins](https://github.com/perses/community-mixins)

--- a/docs/customizations/perses.md
+++ b/docs/customizations/perses.md
@@ -18,16 +18,21 @@ description: Replace Grafana with Perses for Kubernetes cluster dashboards using
 
 ## What the addon deploys
 
-| Resource | Kind | Description |
-| ---------- | ------ | ------------- |
-| perses-operator | Deployment, RBAC, ServiceAccount | Manages Perses CRs declaratively |
-| 4 CRDs | CustomResourceDefinition | `Perses`, `PersesDashboard`, `PersesDatasource`, `PersesGlobalDatasource` |
-| Perses instance | `Perses` CR | Runs the Perses server (port 8080) |
-| Prometheus datasource | `PersesGlobalDatasource` CR | Proxies queries to `prometheus-k8s` Service |
-| Kubernetes dashboards | `PersesDashboard` CRs | Imported from community-mixins (see [Dashboard coverage](#dashboard-coverage)) |
-| ServiceMonitor | `ServiceMonitor` | Scrapes operator metrics |
-| PrometheusRule | `PrometheusRule` | Operator alerting rules |
-| Prometheus NetworkPolicy | `NetworkPolicy` | Allows Perses pods to query Prometheus |
+| Resource                 | Kind                             | Description                                                                    |
+|--------------------------|----------------------------------|--------------------------------------------------------------------------------|
+| perses-operator          | Deployment, RBAC, ServiceAccount | Manages Perses CRs declaratively                                               |
+| 4 CRDs                   | CustomResourceDefinition         | `Perses`, `PersesDashboard`, `PersesDatasource`, `PersesGlobalDatasource`      |
+| Perses instance          | `Perses` CR                      | Runs the Perses server (port 8080)                                             |
+| Prometheus datasource    | `PersesGlobalDatasource` CR      | Proxies queries to `prometheus-k8s` Service                                    |
+| Dashboards               | `PersesDashboard` CRs            | community-mixins (`kubernetes`, `prometheus`, `alertmanager`, `node-exporter`) |
+| ServiceMonitor           | `ServiceMonitor`                 | Scrapes operator metrics                                                       |
+| PrometheusRule           | `PrometheusRule`                 | Operator alerting rules                                                        |
+| Prometheus NetworkPolicy | `NetworkPolicy`                  | Allows Perses pods to query Prometheus                                         |
+
+> [!NOTE]
+> **Security:** Perses runs with authentication disabled by default, matching the bundled Grafana setup in kube-prometheus. Enable auth and secure cookies for production deployments.
+>
+> **Storage:** Dashboards and datasource configuration are stored in Kubernetes CRs. The Perses server uses ephemeral file storage for runtime state; pod restarts do not remove `PersesDashboard` or `PersesGlobalDatasource` objects.
 
 ## Switching from Grafana to Perses
 
@@ -35,7 +40,10 @@ Generate manifests with Perses instead of Grafana:
 
 ```shell
 make manifests-perses
+make test-e2e-perses
 ```
+
+CI runs `make test-e2e-perses` as part of the main workflow (see [`.github/workflows/ci.yaml`](../../.github/workflows/ci.yaml)).
 
 This uses [`examples/perses.jsonnet`](../../examples/perses.jsonnet), which imports the Perses addon and sets `grafana: {}` to omit Grafana. Apply the generated manifests:
 
@@ -51,6 +59,17 @@ kubectl wait \
 kubectl apply -f manifests/
 ```
 
+On an **existing** kube-prometheus cluster, `kubectl apply` does not remove resources that disappeared from the generated manifests. After applying the Perses manifests, delete Grafana explicitly (expect brief dashboard downtime while switching):
+
+```shell
+kubectl -n monitoring delete --ignore-not-found=true \
+  deployment grafana \
+  service grafana \
+  configmap/grafana-dashboards \
+  configmap/grafana-dashboard-definitions-0 \
+  secret/grafana-config
+```
+
 ### Access the Perses UI
 
 ```shell
@@ -61,28 +80,7 @@ Open Perses at [http://localhost:8080](http://localhost:8080). The operator crea
 
 ### Using a custom jsonnet file
 
-If you need to customize values beyond the defaults, create your own jsonnet file that imports the Perses addon. See [`examples/perses.jsonnet`](../../examples/perses.jsonnet) for reference:
-
-```jsonnet
-local kp =
-  (import 'kube-prometheus/main.libsonnet') +
-  (import 'kube-prometheus/addons/perses.libsonnet') +
-  {
-    values+:: {
-      common+: {
-        namespace: 'monitoring',
-      },
-    },
-    // Disable Grafana when using Perses.
-    grafana: {},
-  };
-```
-
-Then generate manifests with:
-
-```shell
-./build.sh my-perses.jsonnet
-```
+See [`examples/perses.jsonnet`](../../examples/perses.jsonnet). Generate with `./build.sh my-perses.jsonnet`.
 
 ## Switching back to Grafana
 
@@ -139,10 +137,10 @@ kubectl -n monitoring delete --ignore-not-found=true \
 
 The Perses addon imports pre-generated dashboards from [community-mixins](https://github.com/perses/community-mixins), which use kubernetes-mixin default job labels. kube-prometheus overrides those selectors for Grafana via `kubernetesControlPlane`; the addon applies the same rewiring when importing dashboards:
 
-| community-mixins | kube-prometheus |
-|------------------|-----------------|
-| `job="cadvisor"` | `job="kubelet", metrics_path="/metrics/cadvisor"` |
-| `job="kube-apiserver"` | `job="apiserver"` |
+| community-mixins       | kube-prometheus                                   |
+|------------------------|---------------------------------------------------|
+| `job="cadvisor"`       | `job="kubelet", metrics_path="/metrics/cadvisor"` |
+| `job="kube-apiserver"` | `job="apiserver"`                                 |
 
 The addon also sets `prometheus.externalLabels.cluster` to `kube-prometheus` so the `cluster` dashboard variable resolves (required by kubernetes-mixin dashboards). Override either if your scrape labels differ:
 
@@ -194,46 +192,42 @@ local kp =
   };
 ```
 
-### Enable conversion webhooks
-
-By default, the operator's CRD conversion webhooks are disabled because they require [cert-manager](https://cert-manager.io/) to provision TLS certificates. If you need to serve both `v1alpha1` and `v1alpha2` API versions simultaneously (e.g., during a CRD version migration), you can enable them.
-
-**Prerequisites:**
-
-1. Install cert-manager:
-
-```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
-```
-
-2. Wait for cert-manager to be ready:
-
-```bash
-kubectl wait --for=condition=Available deployment --all -n cert-manager --timeout=120s
-```
-
-See the [cert-manager installation docs](https://cert-manager.io/docs/installation/) for alternative install methods (Helm, operator, etc.).
-
-**Enable webhooks in your Jsonnet:**
-
-```jsonnet
-local kp =
-  (import 'kube-prometheus/main.libsonnet') +
-  (import 'kube-prometheus/addons/perses.libsonnet') +
-  {
-    values+:: {
-      common+: { namespace: 'monitoring' },
-      perses+: { enableWebhooks: true },
-    },
-    grafana: {},
-  };
-```
-
 ## Dashboard coverage
 
-Dashboards are imported from [community-mixins](https://github.com/perses/community-mixins) and rendered as `PersesDashboard` CRs. The authoritative list is in [`perses.libsonnet`](../../jsonnet/kube-prometheus/addons/perses.libsonnet); run `make manifests-perses` to regenerate manifests after addon or mixin updates.
+Dashboards are imported from [community-mixins](https://github.com/perses/community-mixins) via its [`dashboards.libsonnet`](https://github.com/perses/community-mixins/blob/main/jsonnet/dashboards.libsonnet) helper (namespace, datasource, and labels), then rewired for kube-prometheus scrape labels. By default the addon imports four community-mixins packages (`kubernetes`, `prometheus`, `alertmanager`, `node-exporter`), which renders **23** `PersesDashboard` CRs:
 
-For upstream dashboard definitions and changes, see [community-mixins/kubernetes dashboards](https://github.com/perses/community-mixins/tree/main/jsonnet/dashboards/operator/kubernetes).
+| Component           | Perses dashboards                                         | kube-prometheus component / addon               |
+|---------------------|-----------------------------------------------------------|-------------------------------------------------|
+| `kubernetes`        | 18 Kubernetes / control-plane and workload dashboards     | `kubernetesControlPlane`                        |
+| `prometheus`        | `prometheus-overview`, `prometheus-remote-write`          | `prometheus`                                    |
+| `alertmanager`      | `alertmanager-overview`                                   | `alertmanager`                                  |
+| `node-exporter`     | `node-exporter-nodes`, `node-exporter-cluster-use-method` | `nodeExporter`                                  |
+| `blackbox-exporter` | `blackbox-overview`                                       | `blackboxExporter`                              |
+| `perses`            | `perses-overview`                                         | Perses addon                                    |
+| `thanos`            | 6 Thanos component dashboards                             | Prometheus Thanos sidecar (when enabled)        |
+| `etcd`              | `etcd-overview`                                           | `static-etcd` addon or external etcd monitoring |
+
+These kube-prometheus components have **no Perses dashboard in community-mixins yet**: `kube-state-metrics`, `prometheus-operator`, `prometheus-adapter`, and `metrics-server`. Grafana also ships platform-specific node dashboards (e.g. Darwin/AIX) that community-mixins does not provide as Perses dashboards.
+
+Add optional packages via `dashboardComponents` (see below). Thanos and etcd dashboards can be enabled when those targets are scraped; panels may be empty until sidecar or etcd monitoring is configured.
+
+Authoritative configuration is in [`perses.libsonnet`](../../jsonnet/kube-prometheus/addons/perses.libsonnet). Run `make manifests-perses` after addon or mixin updates.
+
+### Trim dashboard imports
+
+Remove components you do not deploy:
+
+```jsonnet
+{
+  values+:: {
+    perses+: {
+      dashboardComponents: ['kubernetes', 'prometheus', 'alertmanager', 'node-exporter', 'blackbox-exporter', 'perses'],
+    },
+  },
+}
+```
+
+Available component names match [community-mixins `dashboards.libsonnet`](https://github.com/perses/community-mixins/blob/main/jsonnet/dashboards.libsonnet).
 
 ## References
 

--- a/examples/perses.jsonnet
+++ b/examples/perses.jsonnet
@@ -1,0 +1,41 @@
+local kp =
+  (import 'kube-prometheus/main.libsonnet') +
+  (import 'kube-prometheus/addons/perses.libsonnet') +
+  {
+    values+:: {
+      common+: {
+        namespace: 'monitoring',
+      },
+    },
+    // Disable Grafana when using Perses.
+    grafana: {},
+  };
+
+local manifests =
+  {
+    ['setup/' + resource]: kp[component][resource]
+    for component in std.objectFields(kp)
+    for resource in std.filter(
+      function(resource)
+        kp[component][resource].kind == 'CustomResourceDefinition' || kp[component][resource].kind == 'Namespace', std.objectFields(kp[component])
+    )
+  } +
+  {
+    [component + '-' + resource]: kp[component][resource]
+    for component in std.objectFields(kp)
+    for resource in std.filter(
+      function(resource)
+        kp[component][resource].kind != 'CustomResourceDefinition' && kp[component][resource].kind != 'Namespace', std.objectFields(kp[component])
+    )
+  };
+
+local kustomizationResourceFile(name) = './manifests/' + name + '.yaml';
+local kustomization = {
+  apiVersion: 'kustomize.config.k8s.io/v1beta1',
+  kind: 'Kustomization',
+  resources: std.map(kustomizationResourceFile, std.objectFields(manifests)),
+};
+
+manifests {
+  kustomization: kustomization,
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	github.com/Jeffail/gabs v1.4.0
 	github.com/prometheus/client_golang v1.24.1
+	k8s.io/api v0.37.0
 	k8s.io/apimachinery v0.37.0
 	k8s.io/client-go v0.37.0
 )
@@ -49,7 +50,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	k8s.io/api v0.37.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260721132016-d427ff9ee9ad // indirect
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd // indirect

--- a/jsonnet/kube-prometheus/addons/perses.libsonnet
+++ b/jsonnet/kube-prometheus/addons/perses.libsonnet
@@ -1,0 +1,214 @@
+{
+  values+:: {
+    common+: {
+      versions+: {
+        perses: error 'must provide version',
+        persesOperator: error 'must provide version',
+      } + (import '../versions.json'),
+      images+: {
+        perses: 'persesdev/perses:v' + $.values.common.versions.perses,
+        persesOperator: 'persesdev/perses-operator:v' + $.values.common.versions.persesOperator,
+      },
+    },
+    perses+: {
+      namespace: $.values.common.namespace,
+      version: $.values.common.versions.perses,
+      image: $.values.common.images.perses,
+      operatorVersion: $.values.common.versions.persesOperator,
+      operatorImage: $.values.common.images.persesOperator,
+    },
+  },
+
+  local defaults = {
+    local defaults = self,
+    name:: 'perses',
+    operatorName:: 'perses-operator',
+    namespace:: error 'must provide namespace',
+    version:: error 'must provide version',
+    image:: error 'must provide image',
+    operatorVersion:: error 'must provide operator version',
+    operatorImage:: error 'must provide operator image',
+    // Enable conversion webhooks (v1alpha1 <-> v1alpha2). Requires cert-manager.
+    enableWebhooks:: false,
+    commonLabels:: {
+      'app.kubernetes.io/name': defaults.name,
+      'app.kubernetes.io/version': defaults.version,
+      'app.kubernetes.io/part-of': 'kube-prometheus',
+    },
+  },
+
+  local persesOperatorLib = import 'github.com/perses/perses-operator/jsonnet/perses-operator.libsonnet',
+
+  local patchDashboard(dashboard, ns) = dashboard {
+    metadata+: { namespace: ns },
+  },
+
+  local perses = function(params) {
+    local p = self,
+    _config:: defaults + params,
+    local ns = p._config.namespace,
+
+    operator:: persesOperatorLib({
+      name: p._config.operatorName,
+      namespace: p._config.namespace,
+      version: p._config.operatorVersion,
+      image: p._config.operatorImage,
+    }),
+
+    '0persesCustomResourceDefinition': p.operator['0persesCustomResourceDefinition'],
+    '0persesdashboardsCustomResourceDefinition': p.operator['0persesdashboardsCustomResourceDefinition'],
+    '0persesdatasourcesCustomResourceDefinition': p.operator['0persesdatasourcesCustomResourceDefinition'],
+    '0persesglobaldatasourcesCustomResourceDefinition': p.operator['0persesglobaldatasourcesCustomResourceDefinition'],
+
+    operatorDeployment: p.operator.deployment {
+      spec+: {
+        template+: {
+          spec+: {
+            containers: [
+              c {
+                env+: if !p._config.enableWebhooks then [{ name: 'ENABLE_WEBHOOKS', value: 'false' }] else [],
+              }
+              for c in p.operator.deployment.spec.template.spec.containers
+            ],
+          },
+        },
+      },
+    },
+    operatorServiceAccount: p.operator.serviceAccount,
+    operatorRole: p.operator.role,
+    operatorRoleBinding: p.operator.roleBinding,
+    operatorLeaderElectionRole: p.operator.leaderElectionRole,
+    operatorLeaderElectionRoleBinding: p.operator.leaderElectionRoleBinding,
+    operatorPersesEditorRole: p.operator.persesEditorRole,
+    operatorPersesViewerRole: p.operator.persesViewerRole,
+    operatorPersesDashboardEditorRole: p.operator.persesDashboardEditorRole,
+    operatorPersesDashboardViewerRole: p.operator.persesDashboardViewerRole,
+    operatorPersesDatasourceEditorRole: p.operator.persesDatasourceEditorRole,
+    operatorPersesDatasourceViewerRole: p.operator.persesDatasourceViewerRole,
+    operatorPersesGlobalDatasourceEditorRole: p.operator.persesGlobalDatasourceEditorRole,
+    operatorPersesGlobalDatasourceViewerRole: p.operator.persesGlobalDatasourceViewerRole,
+    operatorServiceMonitor: p.operator.serviceMonitor,
+    operatorPrometheusRule: p.operator.prometheusRule,
+
+    persesInstance: {
+      apiVersion: 'perses.dev/v1alpha2',
+      kind: 'Perses',
+      metadata: {
+        name: p._config.name,
+        namespace: p._config.namespace,
+        labels: p._config.commonLabels,
+      },
+      spec: {
+        containerPort: 8080,
+        image: p._config.image,
+        config: {
+          security: {
+            readonly: false,
+            enable_auth: false,
+            cookie: {
+              secure: false,
+            },
+          },
+          database: {
+            file: {
+              folder: '/perses/data',
+              extension: 'json',
+            },
+          },
+        },
+      },
+    },
+
+    prometheusGlobalDatasource: {
+      apiVersion: 'perses.dev/v1alpha2',
+      kind: 'PersesGlobalDatasource',
+      metadata: {
+        name: 'prometheus-datasource',
+        labels: p._config.commonLabels,
+      },
+      spec: {
+        instanceSelector: {
+          matchLabels: {
+            'app.kubernetes.io/name': p._config.name,
+          },
+        },
+        config: {
+          display: {
+            name: 'Prometheus',
+          },
+          default: true,
+          plugin: {
+            kind: 'PrometheusDatasource',
+            spec: {
+              proxy: {
+                kind: 'HTTPProxy',
+                spec: {
+                  url: 'http://prometheus-k8s.%s.svc.cluster.local:9090' % p._config.namespace,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+
+    'dashboard-api-server-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/api-server-overview.json', ns),
+    'dashboard-controller-manager-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/controller-manager-overview.json', ns),
+    'dashboard-kubelet-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubelet-overview.json', ns),
+    'dashboard-kubernetes-cluster-networking-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-cluster-networking-overview.json', ns),
+    'dashboard-kubernetes-cluster-resources-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-cluster-resources-overview.json', ns),
+    'dashboard-kubernetes-multi-cluster-resources-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-multi-cluster-resources-overview.json', ns),
+    'dashboard-kubernetes-namespace-networking-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-namespace-networking-overview.json', ns),
+    'dashboard-kubernetes-namespace-resources-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-namespace-resources-overview.json', ns),
+    'dashboard-kubernetes-node-resources-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-node-resources-overview.json', ns),
+    'dashboard-kubernetes-persistent-volume-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-persistent-volume-overview.json', ns),
+    'dashboard-kubernetes-pod-networking-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-pod-networking-overview.json', ns),
+    'dashboard-kubernetes-pod-resources-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-pod-resources-overview.json', ns),
+    'dashboard-kubernetes-workload-networking-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-networking-overview.json', ns),
+    'dashboard-kubernetes-workload-ns-networking-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-ns-networking-overview.json', ns),
+    'dashboard-kubernetes-workload-ns-resources-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-ns-resources-overview.json', ns),
+    'dashboard-kubernetes-workload-resources-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-resources-overview.json', ns),
+    'dashboard-proxy-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/proxy-overview.json', ns),
+    'dashboard-scheduler-overview':
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/scheduler-overview.json', ns),
+  },
+
+  prometheus+: {
+    networkPolicy+: {
+      spec+: {
+        ingress+: [{
+          from: [{
+            podSelector: {
+              matchLabels: {
+                'app.kubernetes.io/name': 'perses',
+              },
+            },
+          }],
+          ports: [{
+            port: 9090,
+            protocol: 'TCP',
+          }],
+        }],
+      },
+    },
+  },
+
+  perses: perses($.values.perses),
+}

--- a/jsonnet/kube-prometheus/addons/perses.libsonnet
+++ b/jsonnet/kube-prometheus/addons/perses.libsonnet
@@ -17,6 +17,11 @@
       operatorVersion: $.values.common.versions.persesOperator,
       operatorImage: $.values.common.images.persesOperator,
     },
+    prometheus+: {
+      externalLabels+: {
+        cluster: 'kube-prometheus',
+      },
+    },
   },
 
   local defaults = {
@@ -30,6 +35,9 @@
     operatorImage:: error 'must provide operator image',
     // Enable conversion webhooks (v1alpha1 <-> v1alpha2). Requires cert-manager.
     enableWebhooks:: false,
+    // Rewire community-mixins job selectors to match kube-prometheus kubernetesControlPlane mixin.
+    cadvisorJobSelector:: 'job="kubelet", metrics_path="/metrics/cadvisor"',
+    kubeApiserverJobSelector:: 'job="apiserver"',
     commonLabels:: {
       'app.kubernetes.io/name': defaults.name,
       'app.kubernetes.io/version': defaults.version,
@@ -39,14 +47,64 @@
 
   local persesOperatorLib = import 'github.com/perses/perses-operator/jsonnet/perses-operator.libsonnet',
 
-  local patchDashboard(dashboard, ns) = dashboard {
-    metadata+: { namespace: ns },
-  },
-
   local perses = function(params) {
     local p = self,
     _config:: defaults + params,
     local ns = p._config.namespace,
+
+    local queryRewrites = [
+      { from: 'job="cadvisor"', to: p._config.cadvisorJobSelector },
+      { from: 'job="kube-apiserver"', to: p._config.kubeApiserverJobSelector },
+    ],
+
+    local rewireQuery(query) =
+      std.foldl(
+        function(q, rewrite) std.strReplace(q, rewrite.from, rewrite.to),
+        queryRewrites,
+        query,
+      ),
+
+    local patchDashboard(dashboard) = dashboard {
+      metadata+: { namespace: ns },
+      spec+: {
+        config+: {
+          panels: {
+            [panelKey]: dashboard.spec.config.panels[panelKey] {
+              spec+: if std.objectHas(dashboard.spec.config.panels[panelKey].spec, 'queries') then {
+                queries: [
+                  query {
+                    spec+: {
+                      plugin+: if std.objectHas(query.spec.plugin, 'spec') && std.objectHas(query.spec.plugin.spec, 'query') then {
+                        spec+: {
+                          query: rewireQuery(query.spec.plugin.spec.query),
+                        },
+                      } else {},
+                    },
+                  }
+                  for query in dashboard.spec.config.panels[panelKey].spec.queries
+                ],
+              } else {},
+            }
+            for panelKey in std.objectFields(dashboard.spec.config.panels)
+          },
+          variables: if std.objectHas(dashboard.spec.config, 'variables') then [
+            variable {
+              spec+: {
+                plugin+: if std.objectHas(variable.spec.plugin, 'spec') && std.objectHas(variable.spec.plugin.spec, 'matchers') then {
+                  spec+: {
+                    matchers: [
+                      rewireQuery(matcher)
+                      for matcher in variable.spec.plugin.spec.matchers
+                    ],
+                  },
+                } else {},
+              },
+            }
+            for variable in dashboard.spec.config.variables
+          ] else [],
+        },
+      },
+    },
 
     operator:: persesOperatorLib({
       name: p._config.operatorName,
@@ -153,41 +211,41 @@
     },
 
     'dashboard-api-server-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/api-server-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/api-server-overview.json'),
     'dashboard-controller-manager-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/controller-manager-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/controller-manager-overview.json'),
     'dashboard-kubelet-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubelet-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubelet-overview.json'),
     'dashboard-kubernetes-cluster-networking-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-cluster-networking-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-cluster-networking-overview.json'),
     'dashboard-kubernetes-cluster-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-cluster-resources-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-cluster-resources-overview.json'),
     'dashboard-kubernetes-multi-cluster-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-multi-cluster-resources-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-multi-cluster-resources-overview.json'),
     'dashboard-kubernetes-namespace-networking-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-namespace-networking-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-namespace-networking-overview.json'),
     'dashboard-kubernetes-namespace-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-namespace-resources-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-namespace-resources-overview.json'),
     'dashboard-kubernetes-node-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-node-resources-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-node-resources-overview.json'),
     'dashboard-kubernetes-persistent-volume-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-persistent-volume-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-persistent-volume-overview.json'),
     'dashboard-kubernetes-pod-networking-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-pod-networking-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-pod-networking-overview.json'),
     'dashboard-kubernetes-pod-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-pod-resources-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-pod-resources-overview.json'),
     'dashboard-kubernetes-workload-networking-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-networking-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-networking-overview.json'),
     'dashboard-kubernetes-workload-ns-networking-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-ns-networking-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-ns-networking-overview.json'),
     'dashboard-kubernetes-workload-ns-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-ns-resources-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-ns-resources-overview.json'),
     'dashboard-kubernetes-workload-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-resources-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-resources-overview.json'),
     'dashboard-proxy-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/proxy-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/proxy-overview.json'),
     'dashboard-scheduler-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/scheduler-overview.json', ns),
+      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/scheduler-overview.json'),
   },
 
   prometheus+: {

--- a/jsonnet/kube-prometheus/addons/perses.libsonnet
+++ b/jsonnet/kube-prometheus/addons/perses.libsonnet
@@ -16,6 +16,7 @@
       image: $.values.common.images.perses,
       operatorVersion: $.values.common.versions.persesOperator,
       operatorImage: $.values.common.images.persesOperator,
+      kubeRbacProxyImage: $.values.common.images.kubeRbacProxy,
     },
     prometheus+: {
       externalLabels+: {
@@ -33,8 +34,26 @@
     image:: error 'must provide image',
     operatorVersion:: error 'must provide operator version',
     operatorImage:: error 'must provide operator image',
-    // Enable conversion webhooks (v1alpha1 <-> v1alpha2). Requires cert-manager.
-    enableWebhooks:: false,
+    kubeRbacProxyImage:: error 'must provide kubeRbacProxyImage',
+    kubeRbacProxy:: {
+      resources+: {
+        requests: { cpu: '10m', memory: '20Mi' },
+        limits: { cpu: '20m', memory: '40Mi' },
+      },
+    },
+    // community-mixins packages aligned with default kube-prometheus Grafana mixin dashboards.
+    dashboardComponents:: [
+      'kubernetes',
+      'prometheus',
+      'alertmanager',
+      'node-exporter',
+    ],
+    dashboardCommonLabels:: {
+      'app.kubernetes.io/component': 'dashboard',
+      'app.kubernetes.io/name': 'perses-dashboard',
+      'app.kubernetes.io/part-of': 'kube-prometheus',
+    },
+    globalDatasourceName:: 'prometheus-datasource',
     // Rewire community-mixins job selectors to match kube-prometheus kubernetesControlPlane mixin.
     cadvisorJobSelector:: 'job="kubelet", metrics_path="/metrics/cadvisor"',
     kubeApiserverJobSelector:: 'job="apiserver"',
@@ -46,15 +65,20 @@
   },
 
   local persesOperatorLib = import 'github.com/perses/perses-operator/jsonnet/perses-operator.libsonnet',
+  local communityMixinsDashboards = import 'github.com/perses/community-mixins/jsonnet/dashboards.libsonnet',
+  local krp = import '../components/kube-rbac-proxy.libsonnet',
 
-  local perses = function(params) {
-    local p = self,
-    _config:: defaults + params,
-    local ns = p._config.namespace,
+  local dashboardResources(config) = {
+    local importedDashboards = communityMixinsDashboards({
+      namespace: config.namespace,
+      commonLabels: config.dashboardCommonLabels,
+      datasource: config.globalDatasourceName,
+      components: config.dashboardComponents,
+    }).dashboards,
 
     local queryRewrites = [
-      { from: 'job="cadvisor"', to: p._config.cadvisorJobSelector },
-      { from: 'job="kube-apiserver"', to: p._config.kubeApiserverJobSelector },
+      { from: 'job="cadvisor"', to: config.cadvisorJobSelector },
+      { from: 'job="kube-apiserver"', to: config.kubeApiserverJobSelector },
     ],
 
     local rewireQuery(query) =
@@ -64,8 +88,7 @@
         query,
       ),
 
-    local patchDashboard(dashboard) = dashboard {
-      metadata+: { namespace: ns },
+    local rewireDashboard(dashboard) = dashboard {
       spec+: {
         config+: {
           panels: {
@@ -73,13 +96,13 @@
               spec+: if std.objectHas(dashboard.spec.config.panels[panelKey].spec, 'queries') then {
                 queries: [
                   query {
-                    spec+: {
-                      plugin+: if std.objectHas(query.spec.plugin, 'spec') && std.objectHas(query.spec.plugin.spec, 'query') then {
+                    spec+: if std.objectHas(query.spec.plugin, 'spec') && std.objectHas(query.spec.plugin.spec, 'query') then {
+                      plugin+: {
                         spec+: {
                           query: rewireQuery(query.spec.plugin.spec.query),
                         },
-                      } else {},
-                    },
+                      },
+                    } else {},
                   }
                   for query in dashboard.spec.config.panels[panelKey].spec.queries
                 ],
@@ -89,16 +112,16 @@
           },
           variables: if std.objectHas(dashboard.spec.config, 'variables') then [
             variable {
-              spec+: {
-                plugin+: if std.objectHas(variable.spec.plugin, 'spec') && std.objectHas(variable.spec.plugin.spec, 'matchers') then {
+              spec+: if std.objectHas(variable.spec.plugin, 'spec') && std.objectHas(variable.spec.plugin.spec, 'matchers') then {
+                plugin+: {
                   spec+: {
                     matchers: [
                       rewireQuery(matcher)
                       for matcher in variable.spec.plugin.spec.matchers
                     ],
                   },
-                } else {},
-              },
+                },
+              } else {},
             }
             for variable in dashboard.spec.config.variables
           ] else [],
@@ -106,11 +129,37 @@
       },
     },
 
+    resources: std.foldl(
+      function(acc, dashboard) acc {
+        ['dashboard-' + dashboard.metadata.name]: rewireDashboard(dashboard),
+      },
+      importedDashboards,
+      {},
+    ),
+  }.resources,
+
+  local perses = function(params) {
+    local p = self,
+    _config:: defaults + params,
+
     operator:: persesOperatorLib({
       name: p._config.operatorName,
       namespace: p._config.namespace,
       version: p._config.operatorVersion,
       image: p._config.operatorImage,
+    }),
+
+    local operatorSelectorLabels = p.operator.deployment.spec.selector.matchLabels,
+    local operatorLabels = p.operator.deployment.metadata.labels,
+
+    local kubeRbacProxy = krp(p._config.kubeRbacProxy {
+      name: 'kube-rbac-proxy',
+      upstream: 'http://127.0.0.1:8082/',
+      secureListenAddress: ':8443',
+      ports: [
+        { name: 'https', containerPort: 8443 },
+      ],
+      image: p._config.kubeRbacProxyImage,
     }),
 
     '0persesCustomResourceDefinition': p.operator['0persesCustomResourceDefinition'],
@@ -122,18 +171,81 @@
       spec+: {
         template+: {
           spec+: {
+            automountServiceAccountToken: true,
             containers: [
               c {
-                env+: if !p._config.enableWebhooks then [{ name: 'ENABLE_WEBHOOKS', value: 'false' }] else [],
+                args+: if c.name == 'manager' then ['--metrics-bind-address=127.0.0.1:8082'] else [],
+                env+: [{ name: 'ENABLE_WEBHOOKS', value: 'false' }],
               }
               for c in p.operator.deployment.spec.template.spec.containers
-            ],
+            ] + [kubeRbacProxy],
           },
         },
       },
     },
+    operatorService: {
+      apiVersion: 'v1',
+      kind: 'Service',
+      metadata: {
+        name: p._config.operatorName,
+        namespace: p._config.namespace,
+        labels: operatorLabels,
+      },
+      spec: {
+        clusterIP: 'None',
+        ports: [{
+          name: 'https',
+          port: 8443,
+          targetPort: 'https',
+        }],
+        selector: operatorSelectorLabels,
+      },
+    },
     operatorServiceAccount: p.operator.serviceAccount,
-    operatorRole: p.operator.role,
+    operatorRole: p.operator.role {
+      rules+: [
+        {
+          apiGroups: ['authentication.k8s.io'],
+          resources: ['tokenreviews'],
+          verbs: ['create'],
+        },
+        {
+          apiGroups: ['authorization.k8s.io'],
+          resources: ['subjectaccessreviews'],
+          verbs: ['create'],
+        },
+      ],
+    },
+    operatorMetricsReaderClusterRole: (import 'github.com/perses/perses-operator/jsonnet/generated/auth_proxy_client_clusterrole.json') {
+      metadata+: {
+        name: p._config.operatorName + '-metrics-reader',
+        labels: operatorLabels {
+          'app.kubernetes.io/component': 'kube-rbac-proxy',
+          'app.kubernetes.io/instance': 'metrics-reader',
+        },
+      },
+    },
+    operatorMetricsReaderClusterRoleBinding: {
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRoleBinding',
+      metadata: {
+        name: p._config.operatorName + '-metrics-reader',
+        labels: operatorLabels {
+          'app.kubernetes.io/component': 'kube-rbac-proxy',
+          'app.kubernetes.io/instance': 'metrics-reader-binding',
+        },
+      },
+      roleRef: {
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: p._config.operatorName + '-metrics-reader',
+      },
+      subjects: [{
+        kind: 'ServiceAccount',
+        name: 'prometheus-k8s',
+        namespace: p._config.namespace,
+      }],
+    },
     operatorRoleBinding: p.operator.roleBinding,
     operatorLeaderElectionRole: p.operator.leaderElectionRole,
     operatorLeaderElectionRoleBinding: p.operator.leaderElectionRoleBinding,
@@ -145,7 +257,49 @@
     operatorPersesDatasourceViewerRole: p.operator.persesDatasourceViewerRole,
     operatorPersesGlobalDatasourceEditorRole: p.operator.persesGlobalDatasourceEditorRole,
     operatorPersesGlobalDatasourceViewerRole: p.operator.persesGlobalDatasourceViewerRole,
-    operatorServiceMonitor: p.operator.serviceMonitor,
+    operatorServiceMonitor: p.operator.serviceMonitor {
+      spec+: {
+        jobLabel: 'app.kubernetes.io/name',
+        endpoints: [{
+          bearerTokenFile: '/var/run/secrets/kubernetes.io/serviceaccount/token',
+          path: '/metrics',
+          port: 'https',
+          scheme: 'https',
+          tlsConfig: {
+            insecureSkipVerify: true,
+          },
+        }],
+      },
+    },
+    operatorNetworkPolicy: {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'NetworkPolicy',
+      metadata: {
+        name: p._config.operatorName,
+        namespace: p._config.namespace,
+        labels: operatorLabels,
+      },
+      spec: {
+        podSelector: {
+          matchLabels: operatorSelectorLabels,
+        },
+        policyTypes: ['Egress', 'Ingress'],
+        egress: [{}],
+        ingress: [{
+          from: [{
+            podSelector: {
+              matchLabels: {
+                'app.kubernetes.io/name': 'prometheus',
+              },
+            },
+          }],
+          ports: [{
+            port: 'https',
+            protocol: 'TCP',
+          }],
+        }],
+      },
+    },
     operatorPrometheusRule: p.operator.prometheusRule,
 
     persesInstance: {
@@ -181,7 +335,7 @@
       apiVersion: 'perses.dev/v1alpha2',
       kind: 'PersesGlobalDatasource',
       metadata: {
-        name: 'prometheus-datasource',
+        name: p._config.globalDatasourceName,
         labels: p._config.commonLabels,
       },
       spec: {
@@ -209,43 +363,6 @@
         },
       },
     },
-
-    'dashboard-api-server-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/api-server-overview.json'),
-    'dashboard-controller-manager-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/controller-manager-overview.json'),
-    'dashboard-kubelet-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubelet-overview.json'),
-    'dashboard-kubernetes-cluster-networking-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-cluster-networking-overview.json'),
-    'dashboard-kubernetes-cluster-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-cluster-resources-overview.json'),
-    'dashboard-kubernetes-multi-cluster-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-multi-cluster-resources-overview.json'),
-    'dashboard-kubernetes-namespace-networking-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-namespace-networking-overview.json'),
-    'dashboard-kubernetes-namespace-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-namespace-resources-overview.json'),
-    'dashboard-kubernetes-node-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-node-resources-overview.json'),
-    'dashboard-kubernetes-persistent-volume-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-persistent-volume-overview.json'),
-    'dashboard-kubernetes-pod-networking-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-pod-networking-overview.json'),
-    'dashboard-kubernetes-pod-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-pod-resources-overview.json'),
-    'dashboard-kubernetes-workload-networking-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-networking-overview.json'),
-    'dashboard-kubernetes-workload-ns-networking-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-ns-networking-overview.json'),
-    'dashboard-kubernetes-workload-ns-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-ns-resources-overview.json'),
-    'dashboard-kubernetes-workload-resources-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-resources-overview.json'),
-    'dashboard-proxy-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/proxy-overview.json'),
-    'dashboard-scheduler-overview':
-      patchDashboard(import 'github.com/perses/community-mixins/jsonnet/dashboards/operator/kubernetes/scheduler-overview.json'),
   },
 
   prometheus+: {
@@ -268,5 +385,5 @@
     },
   },
 
-  perses: perses($.values.perses),
+  perses: perses($.values.perses) + dashboardResources(defaults + $.values.perses),
 }

--- a/jsonnet/kube-prometheus/jsonnetfile.json
+++ b/jsonnet/kube-prometheus/jsonnetfile.json
@@ -117,6 +117,26 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/perses/perses-operator.git",
+          "subdir": "jsonnet"
+        }
+      },
+      "version": "main",
+      "name": "perses-operator"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/perses/community-mixins.git",
+          "subdir": "jsonnet"
+        }
+      },
+      "version": "main",
+      "name": "community-mixins"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/thanos-io/thanos",
           "subdir": "mixin"
         }

--- a/jsonnet/kube-prometheus/platforms/platforms.libsonnet
+++ b/jsonnet/kube-prometheus/platforms/platforms.libsonnet
@@ -30,6 +30,7 @@ local platformPatch(p) = if p != null && std.objectHas(platforms, p) then platfo
     metricsServer: {},
     prometheusOperator: {},
     pyrra: {},
+    perses: {},
   } + platformPatch($.values.common.platform),
 
   alertmanager+: p.alertmanager,
@@ -44,4 +45,5 @@ local platformPatch(p) = if p != null && std.objectHas(platforms, p) then platfo
   kubernetesControlPlane+: p.kubernetesControlPlane,
   kubePrometheus+: p.kubePrometheus,
   pyrra+: p.pyrra,
+  perses+: p.perses,
 }

--- a/jsonnet/kube-prometheus/versions.json
+++ b/jsonnet/kube-prometheus/versions.json
@@ -10,5 +10,7 @@
   "prometheusOperator": "0.93.1",
   "kubeRbacProxy": "0.22.1",
   "configmapReload": "0.15.0",
-  "pyrra": "0.10.1"
+  "pyrra": "0.10.1",
+  "perses": "0.54.0",
+  "persesOperator": "0.5.0"
 }

--- a/jsonnetfile.lock.json
+++ b/jsonnetfile.lock.json
@@ -144,6 +144,28 @@
     {
       "source": {
         "git": {
+          "remote": "https://github.com/perses/community-mixins.git",
+          "subdir": "jsonnet"
+        }
+      },
+      "version": "fdc816750458cc6112667214291073994f46afb8",
+      "sum": "pLnaafS4/jflwia9kZH8d83+8vb0iwgcfJ1C8cPLdkQ=",
+      "name": "community-mixins"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/perses/perses-operator.git",
+          "subdir": "jsonnet"
+        }
+      },
+      "version": "28b82ced25c856799594bea0c733bede85bca18a",
+      "sum": "WgnrJN1Nriyb2k2VzL8YtPwQjIuxKleZbyV9NBQQdUM=",
+      "name": "perses-operator"
+    },
+    {
+      "source": {
+        "git": {
           "remote": "https://github.com/prometheus-operator/prometheus-operator.git",
           "subdir": "jsonnet/mixin"
         }

--- a/scripts/generate-versions.sh
+++ b/scripts/generate-versions.sh
@@ -72,6 +72,8 @@ cat <<-EOF
   "prometheusOperator": "$(get_version "prometheus-operator/prometheus-operator")",
   "kubeRbacProxy": "$(get_version "brancz/kube-rbac-proxy")",
   "configmapReload": "$(get_version "jimmidyson/configmap-reload")",
-  "pyrra": "$(get_version "pyrra-dev/pyrra")"
+  "pyrra": "$(get_version "pyrra-dev/pyrra")",
+  "perses": "$(get_version "perses/perses")",
+  "persesOperator": "$(get_version "perses/perses-operator")"
 }
 EOF

--- a/tests/e2e/perses_test.go
+++ b/tests/e2e/perses_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -29,6 +31,9 @@ import (
 const (
 	persesNamespace           = "monitoring"
 	minPersesDashboardObjects = 23
+	persesAvailableCondition  = "Available"
+	persesDegradedCondition   = "Degraded"
+	operatorManagerContainer  = "manager"
 )
 
 func TestPersesAddon(t *testing.T) {
@@ -37,6 +42,34 @@ func TestPersesAddon(t *testing.T) {
 	}
 
 	kClient := promClient.kubeClient
+
+	t.Run("grafana is not deployed", func(t *testing.T) {
+		_, err := kClient.AppsV1().Deployments(persesNamespace).Get(context.Background(), "grafana", metav1.GetOptions{})
+		if err == nil {
+			t.Fatal("grafana deployment should not exist when using perses")
+		}
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("unexpected error checking grafana deployment: %v", err)
+		}
+
+		_, err = kClient.CoreV1().Services(persesNamespace).Get(context.Background(), "grafana", metav1.GetOptions{})
+		if err == nil {
+			t.Fatal("grafana service should not exist when using perses")
+		}
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("unexpected error checking grafana service: %v", err)
+		}
+
+		pods, err := kClient.CoreV1().Pods(persesNamespace).List(context.Background(), metav1.ListOptions{
+			LabelSelector: "app.kubernetes.io/name=grafana",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(pods.Items) > 0 {
+			t.Fatalf("expected no grafana pods, got %d", len(pods.Items))
+		}
+	})
 
 	t.Run("operator deployment is ready", func(t *testing.T) {
 		err := pollCondition(5*time.Minute, func() error {
@@ -59,16 +92,33 @@ func TestPersesAddon(t *testing.T) {
 			return persesInstanceReady(kClient)
 		})
 		if err != nil {
-			t.Fatal(err)
+			t.Fatal(formatPersesOperatorDebug(kClient, err))
+		}
+	})
+
+	t.Run("perses CR status is available and not degraded", func(t *testing.T) {
+		err := pollCondition(5*time.Minute, func() error {
+			conditions, err := getPersesCRConditions(kClient)
+			if err != nil {
+				return err
+			}
+			return assertReconciledConditions(conditions, "Perses/perses")
+		})
+		if err != nil {
+			t.Fatal(formatPersesOperatorDebug(kClient, err))
 		}
 	})
 
 	t.Run("perses service responds", func(t *testing.T) {
 		err := pollCondition(5*time.Minute, func() error {
+			if err := persesServiceEndpointsReady(kClient); err != nil {
+				return err
+			}
+
 			_, err := kClient.CoreV1().RESTClient().Get().
 				Namespace(persesNamespace).
 				Resource("services").
-				Name("perses").
+				Name("perses:http").
 				SubResource("proxy").
 				Suffix("/api/v1/health").
 				DoRaw(context.Background())
@@ -81,12 +131,18 @@ func TestPersesAddon(t *testing.T) {
 
 	t.Run("dashboards and datasource CRs exist", func(t *testing.T) {
 		err := pollCondition(5*time.Minute, func() error {
-			dashboards, err := listPersesDashboards(kClient)
+			dashboards, err := listPersesDashboardsWithStatus(kClient)
 			if err != nil {
 				return err
 			}
-			if dashboards < minPersesDashboardObjects {
-				return fmt.Errorf("expected at least %d PersesDashboard objects, got %d", minPersesDashboardObjects, dashboards)
+			if len(dashboards) < minPersesDashboardObjects {
+				return fmt.Errorf("expected at least %d PersesDashboard objects, got %d", minPersesDashboardObjects, len(dashboards))
+			}
+
+			for _, dashboard := range dashboards {
+				if err := assertReconciledConditions(dashboard.Conditions, "PersesDashboard/"+dashboard.Name); err != nil {
+					return err
+				}
 			}
 
 			_, err = kClient.CoreV1().RESTClient().Get().
@@ -95,7 +151,7 @@ func TestPersesAddon(t *testing.T) {
 			return err
 		})
 		if err != nil {
-			t.Fatal(err)
+			t.Fatal(formatPersesOperatorDebug(kClient, err))
 		}
 	})
 
@@ -135,20 +191,141 @@ func persesInstanceReady(kClient kubernetes.Interface) error {
 	return nil
 }
 
-func listPersesDashboards(kClient kubernetes.Interface) (int, error) {
+func persesServiceEndpointsReady(kClient kubernetes.Interface) error {
+	endpoints, err := kClient.CoreV1().Endpoints(persesNamespace).Get(context.Background(), "perses", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, subset := range endpoints.Subsets {
+		if len(subset.Addresses) > 0 {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("perses service has no ready endpoints")
+}
+
+func listPersesDashboardsWithStatus(kClient kubernetes.Interface) ([]persesDashboardItem, error) {
 	raw, err := kClient.CoreV1().RESTClient().Get().
 		AbsPath("/apis/perses.dev/v1alpha2/namespaces", persesNamespace, "persesdashboards").
 		DoRaw(context.Background())
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	var list struct {
-		Items []json.RawMessage `json:"items"`
+		Items []struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Status struct {
+				Conditions []metav1.Condition `json:"conditions"`
+			} `json:"status"`
+		} `json:"items"`
 	}
 	if err := json.Unmarshal(raw, &list); err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	return len(list.Items), nil
+	dashboards := make([]persesDashboardItem, 0, len(list.Items))
+	for _, item := range list.Items {
+		dashboards = append(dashboards, persesDashboardItem{
+			Name:       item.Metadata.Name,
+			Conditions: item.Status.Conditions,
+		})
+	}
+
+	return dashboards, nil
+}
+
+type persesDashboardItem struct {
+	Name       string
+	Conditions []metav1.Condition
+}
+
+func getPersesCRConditions(kClient kubernetes.Interface) ([]metav1.Condition, error) {
+	raw, err := kClient.CoreV1().RESTClient().Get().
+		AbsPath("/apis/perses.dev/v1alpha2/namespaces", persesNamespace, "perses", "perses").
+		DoRaw(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	var perses struct {
+		Status struct {
+			Conditions []metav1.Condition `json:"conditions"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(raw, &perses); err != nil {
+		return nil, err
+	}
+
+	return perses.Status.Conditions, nil
+}
+
+func getCondition(conditions []metav1.Condition, conditionType string) (metav1.Condition, bool) {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition, true
+		}
+	}
+	return metav1.Condition{}, false
+}
+
+func assertReconciledConditions(conditions []metav1.Condition, resourceName string) error {
+	available, ok := getCondition(conditions, persesAvailableCondition)
+	if !ok || available.Status != metav1.ConditionTrue {
+		detail := "condition not set"
+		if ok {
+			detail = fmt.Sprintf("reason=%s message=%s", available.Reason, available.Message)
+		}
+		return fmt.Errorf("%s: Available!=True (%s)", resourceName, detail)
+	}
+
+	degraded, ok := getCondition(conditions, persesDegradedCondition)
+	if !ok {
+		return fmt.Errorf("%s: Degraded condition not set", resourceName)
+	}
+	if degraded.Status == metav1.ConditionTrue {
+		return fmt.Errorf("%s: Degraded=True reason=%s message=%s", resourceName, degraded.Reason, degraded.Message)
+	}
+	if degraded.Status != metav1.ConditionFalse {
+		return fmt.Errorf("%s: Degraded=%s reason=%s message=%s", resourceName, degraded.Status, degraded.Reason, degraded.Message)
+	}
+
+	return nil
+}
+
+func getOperatorManagerLogs(kClient kubernetes.Interface, tailLines int64) (string, error) {
+	pods, err := kClient.CoreV1().Pods(persesNamespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=perses-operator",
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("perses-operator pod not found")
+	}
+
+	tail := tailLines
+	req := kClient.CoreV1().Pods(persesNamespace).GetLogs(pods.Items[0].Name, &corev1.PodLogOptions{
+		Container: operatorManagerContainer,
+		TailLines: &tail,
+	})
+	logBytes, err := req.DoRaw(context.Background())
+	if err != nil {
+		return "", err
+	}
+
+	return string(logBytes), nil
+}
+
+func formatPersesOperatorDebug(kClient kubernetes.Interface, err error) error {
+	logs, logErr := getOperatorManagerLogs(kClient, 200)
+	if logErr != nil {
+		return fmt.Errorf("%w\n\nfailed to fetch perses-operator logs: %v", err, logErr)
+	}
+
+	return fmt.Errorf("%w\n\nrecent perses-operator manager logs:\n%s", err, logs)
 }

--- a/tests/e2e/perses_test.go
+++ b/tests/e2e/perses_test.go
@@ -1,0 +1,154 @@
+// Copyright 2026 The prometheus-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	persesNamespace           = "monitoring"
+	minPersesDashboardObjects = 23
+)
+
+func TestPersesAddon(t *testing.T) {
+	if os.Getenv("PERSES_ADDON") != "true" {
+		t.Skip("PERSES_ADDON != true, skipping perses addon tests")
+	}
+
+	kClient := promClient.kubeClient
+
+	t.Run("operator deployment is ready", func(t *testing.T) {
+		err := pollCondition(5*time.Minute, func() error {
+			deploy, err := kClient.AppsV1().Deployments(persesNamespace).Get(context.Background(), "perses-operator", metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if deploy.Status.ReadyReplicas != *deploy.Spec.Replicas {
+				return fmt.Errorf("expecting %d ready replicas, got %d", *deploy.Spec.Replicas, deploy.Status.ReadyReplicas)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("perses instance is ready", func(t *testing.T) {
+		err := pollCondition(5*time.Minute, func() error {
+			return persesInstanceReady(kClient)
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("perses service responds", func(t *testing.T) {
+		err := pollCondition(5*time.Minute, func() error {
+			_, err := kClient.CoreV1().RESTClient().Get().
+				Namespace(persesNamespace).
+				Resource("services").
+				Name("perses").
+				SubResource("proxy").
+				Suffix("/api/v1/health").
+				DoRaw(context.Background())
+			return err
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("dashboards and datasource CRs exist", func(t *testing.T) {
+		err := pollCondition(5*time.Minute, func() error {
+			dashboards, err := listPersesDashboards(kClient)
+			if err != nil {
+				return err
+			}
+			if dashboards < minPersesDashboardObjects {
+				return fmt.Errorf("expected at least %d PersesDashboard objects, got %d", minPersesDashboardObjects, dashboards)
+			}
+
+			_, err = kClient.CoreV1().RESTClient().Get().
+				AbsPath("/apis/perses.dev/v1alpha2/persesglobaldatasources/prometheus-datasource").
+				DoRaw(context.Background())
+			return err
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("operator scraped by prometheus", func(t *testing.T) {
+		err := pollCondition(5*time.Minute, func() error {
+			n, err := promClient.query(`up{job="perses-operator"} == 1`)
+			if err != nil {
+				return err
+			}
+			if n < 1 {
+				return fmt.Errorf("expected at least 1 up target for job=perses-operator, got %d", n)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func persesInstanceReady(kClient kubernetes.Interface) error {
+	statefulSet, err := kClient.AppsV1().StatefulSets(persesNamespace).Get(context.Background(), "perses", metav1.GetOptions{})
+	if err == nil {
+		if statefulSet.Status.ReadyReplicas < 1 {
+			return fmt.Errorf("expecting at least 1 ready perses replica, got %d", statefulSet.Status.ReadyReplicas)
+		}
+		return nil
+	}
+
+	deploy, err := kClient.AppsV1().Deployments(persesNamespace).Get(context.Background(), "perses", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("perses workload not found: %w", err)
+	}
+	if deploy.Status.ReadyReplicas != *deploy.Spec.Replicas {
+		return fmt.Errorf("expecting %d ready perses replicas, got %d", *deploy.Spec.Replicas, deploy.Status.ReadyReplicas)
+	}
+	return nil
+}
+
+func listPersesDashboards(kClient kubernetes.Interface) (int, error) {
+	raw, err := kClient.CoreV1().RESTClient().Get().
+		AbsPath("/apis/perses.dev/v1alpha2/namespaces", persesNamespace, "persesdashboards").
+		DoRaw(context.Background())
+	if err != nil {
+		return 0, err
+	}
+
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return 0, err
+	}
+
+	return len(list.Items), nil
+}


### PR DESCRIPTION
<!--
WARNING: Not using this template will result in a longer review process and your change won't be visible in CHANGELOG.
-->

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._

* Adds a perses jsonnet addon so kube-prometheus users can deploy Perses instead of Grafana with the same Kubernetes observability dashboards. I wanted to addon  now till we review the dashboard parity between Grafana and Perses. And we can make it into toggle to switch between Grafana and Perses similar toggle done for Metrics Server vs Prometheus Adapter

* Imports perses-operator and community-mixins; deploys operator, Perses instance, Prometheus datasource, and 18 PersesDashboard CRs
Adds examples/perses.jsonnet and make manifests-perses for manifest generation

* Add documentation for switching to Perses (migration is not included)

### Manual Testing Steps

**Update vendor dependencies**

```
make vendor
```

**Generate YAML manifests**

```
make manifests-perses
```

**Running in cluster

```
# Create a kind cluster
kind create cluster --name kp-perses-test

# Apply setup manifests first (CRDs, namespace, operator)
kubectl apply --server-side -f manifests/setup/

# Wait for CRDs to be established
kubectl wait --for condition=Established --all CustomResourceDefinition --timeout=60s

# Apply remaining manifests
kubectl apply -f manifests/

# Check the operator is running
kubectl -n monitoring get pods -l app.kubernetes.io/name=perses-operator

# Check the Perses instance is created
kubectl -n monitoring get perses

# Check the GlobalDatasource
kubectl get persesglobaldatasources

# Check dashboards
kubectl -n monitoring get persesdashboards

# Port-forward to Perses UI
kubectl -n monitoring port-forward svc/perses 8080:8080
```

From Tested dashboards (not all dashboards tested since there is no enough data in local cluster)

<img width="1506" height="835" alt="Screenshot 2026-08-20 at 1 10 15 PM" src="https://github.com/user-attachments/assets/b9c38412-4e34-450e-98a6-65166cc202a6" />

<img width="1503" height="816" alt="Screenshot 2026-08-20 at 1 11 10 PM" src="https://github.com/user-attachments/assets/914cf78e-af49-4e50-8871-fab7f3e9aede" />



## Type of change

_What type of changes does your code introduce to the kube-prometheus? Put an `x` in the box that apply._

- [ ] `CHANGE` (fix or feature that would cause existing functionality to not work as expected)
- [x] `FEATURE` (non-breaking change which adds functionality)
- [ ] `BUGFIX` (non-breaking change which fixes an issue)
- [ ] `ENHANCEMENT` (non-breaking change which improves existing functionality)
- [ ] `NONE` (if none of the other choices apply. Example, tooling, build system, CI, docs, etc.)

## Changelog entry

_Please put a one-line changelog entry below. Later this will be copied to the changelog file._

<!-- 
Your release note should be written in clear and straightforward sentences. Most often, users aren't familiar with
the technical details of your PR, so consider what they need to know when you write your release note.

Some brief examples of release notes:
- Add metadataConfig field to the Prometheus CRD for configuring how remote-write sends metadata information.
- Generate correct scraping configuration for Probes with empty or unset module parameter.
-->

```release-note
feat: Add Perses addon as Grafana alternative for Kubernetes dashboards
```
